### PR TITLE
ci: add helm chart publisher

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -1,0 +1,13 @@
+name: "[CI] Publish Charts"
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Setup Helm"
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # 4.3.0
+      - name: "Publish Charts"
+        run: hack/publish-charts.sh

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -10,6 +10,15 @@ This chart installs the [`eks-node-monitoring-agent`](https://github.com/aws/eks
 ## Installing the Chart
 
 ```shell
+# using the github chart repository
+helm repo add eks-node-monitoring-agent https://aws.github.io/eks-node-monitoring-agent
+helm install eks-node-monitoring-agent eks-node-monitoring-agent/eks-node-monitoring-agent --namespace kube-system
+```
+
+**OR**
+
+```shell
+# using the chart sources
 git clone https://github.com/aws/eks-node-monitoring-agent.git
 cd eks-node-monitoring-agent
 helm install eks-node-monitoring-agent ./charts/eks-node-monitoring-agent --namespace kube-system

--- a/hack/publish-charts.sh
+++ b/hack/publish-charts.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
+VERSION=$(git describe --tags --always)
+
+STAGING_DIR=${1:-${GIT_REPO_ROOT}}
+CHART_URL=${2:-https://aws.github.io/eks-node-monitoring-agent}
+
+helm package ${GIT_REPO_ROOT}/charts/* --destination ${STAGING_DIR} --dependency-update
+git checkout gh-pages
+mv ${STAGING_DIR}/*.tgz .
+helm repo index . --url ${CHART_URL}
+git add index.yaml *.tgz
+git commit -m "Publish charts ${VERSION}"
+git push origin gh-pages
+echo "✅ Published charts"


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

This PR adds a workflow to publish helm charts once a new commit is pushed to `main`

**Testing Done**:

Pushed initial chart version to github pages - https://github.com/aws/eks-node-monitoring-agent/tree/gh-pages

```bash
helm repo add eks-node-monitoring-agent https://aws.github.io/eks-node-monitoring-agent
helm search repo eks-node --versions
NAME                                                    CHART VERSION	APP VERSION	DESCRIPTION
eks-node-monitoring-agent/eks-node-monitoring-a...      1.2.0        	1.2.0      	A Helm chart for eks-node-montoring-agent
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
