### PR TITLE
feat: add environment config for monitoring agent container

### DIFF
--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -41,6 +41,7 @@ The following table lists the configurable parameters for this chart and their d
 | nameOverride | string | `"eks-node-monitoring-agent"` | A name override for the chart |
 | nodeAgent.additionalArgs | list | `[]` | List of addittional container arguments for the eks-node-monitoring-agent |
 | nodeAgent.affinity | object | see [`values.yaml`](./values.yaml) | Map of pod affinities for the eks-node-monitoring-agent |
+| nodeAgent.env | object | `{}` | Container environment for the eks-node-monitoring-agent |
 | nodeAgent.image.account | string | `"602401143452"` | ECR repository account number for the eks-node-monitoring-agent |
 | nodeAgent.image.domain | string | `"amazonaws.com"` | ECR repository domain for the eks-node-monitoring-agent |
 | nodeAgent.image.endpoint | string | `"ecr"` | ECR repository endpoint for the eks-node-monitoring-agent |

--- a/charts/eks-node-monitoring-agent/templates/daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/daemonset.yaml
@@ -48,6 +48,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- range $key, $value := .Values.nodeAgent.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -57,6 +57,8 @@ nodeAgent:
               values:
                 - amd64
                 - arm64
+  # -- Container environment for the eks-node-monitoring-agent
+  env: {}
   # -- Container resources for the eks-node-monitoring-agent
   resources:
     requests:


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

Add environment variable options to monitoring agent helm chart values.

**Testing Done**:

```yaml
helm template eks-node-monitoring-agent ./charts/eks-node-monitoring-agent --namespace kube-system --debug --set nodeAgent.env.foo=bar

...
      serviceAccountName: eks-node-monitoring-agent
      hostNetwork: true
      hostPID: true
      containers:
        - name: eks-node-monitoring-agent
          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/eks-node-monitoring-agent:v1.2.0-eksbuild.1
          imagePullPolicy: IfNotPresent
          args:
            - --probe-address=:8002
            - --metrics-address=:8003
          env:
            - name: HOST_ROOT
              value: /host
            - name: MY_NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
            - name: foo
              value: "bar"
          livenessProbe:
            httpGet:
              path: /healthz
              port: 8002
          resources:
            limits:
              cpu: 250m
              memory: 100Mi
            requests:
              cpu: 10m
              memory: 30Mi
          securityContext:
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
