### PR TITLE
fix(ci): checkout repo for chart publish

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -7,6 +7,9 @@ jobs:
   publish-charts:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          ref: 'main'
       - name: "Setup Helm"
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # 4.3.0
       - name: "Publish Charts"


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

the action for publishing charts was forgetting to checkout the repository

https://github.com/aws/eks-node-monitoring-agent/actions/runs/15032908812/job/42249232151#step:3:6

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
