### PR TITLE
fix(ci): update publish script to ignore existing versions

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -6,10 +6,12 @@ on:
 jobs:
   publish-charts:
     runs-on: ubuntu-latest
+    if: github.repository == 'aws/eks-node-monitoring-agent'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - name: "Checkout"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
-          ref: 'main'
+          fetch-depth: 0
       - name: "Setup Helm"
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # 4.3.0
       - name: "Publish Charts"

--- a/hack/publish-charts.sh
+++ b/hack/publish-charts.sh
@@ -7,7 +7,24 @@ VERSION=$(git describe --tags --always)
 STAGING_DIR=${1:-${GIT_REPO_ROOT}}
 CHART_URL=${2:-https://aws.github.io/eks-node-monitoring-agent}
 
+git fetch --all
+git config user.email eks-bot@users.noreply.github.com
+git config user.name eks-bot
+
 helm package ${GIT_REPO_ROOT}/charts/* --destination ${STAGING_DIR} --dependency-update
+
+for bundle in ${STAGING_DIR}/*.tgz; do
+    if git cat-file -e origin/gh-pages:${bundle}; then
+        echo "⏩ Release already exists for ${bundle}"
+        rm -f ${bundle}
+    fi
+done
+
+if ! ls ${STAGING_DIR}/*.tgz; then
+    echo "⏩ No changes to be staged"
+    exit 0
+fi
+
 git checkout gh-pages
 mv ${STAGING_DIR}/*.tgz .
 helm repo index . --url ${CHART_URL}


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

* update publish script to ignore existing versions and exit early if nothing needs to be updated
* set the commit author as `eks-bot` and fetch all the branches before attempting to checkout `gh-pages`

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
