### PR TITLE
fix(ci): handle staging directory path

### DIFF
--- a/hack/publish-charts.sh
+++ b/hack/publish-charts.sh
@@ -26,7 +26,11 @@ if ! ls ${STAGING_DIR}/*.tgz; then
 fi
 
 git checkout gh-pages
-mv ${STAGING_DIR}/*.tgz .
+
+if [ "$(realpath ${STAGING_DIR})" != "$(realpath .)" ]; then
+    mv ${STAGING_DIR}/*.tgz .
+fi
+
 helm repo index . --url ${CHART_URL}
 git add index.yaml *.tgz
 git commit -m "Publish charts ${VERSION}"


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

handle the error for moving files when the staging directory resolves to the current directory: 
```
mv: '/home/runner/work/eks-node-monitoring-agent/eks-node-monitoring-agent/eks-node-monitoring-agent-1.3.0.tgz' and './eks-node-monitoring-agent-1.3.0.tgz' are the same file
```

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
