### PR TITLE
fix: add missing p5en.48xlarge to the nodeSelectorTerms for the dcgmA…

### DIFF
--- a/charts/eks-node-monitoring-agent/Chart.yaml
+++ b/charts/eks-node-monitoring-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: eks-node-monitoring-agent
-version: 1.3.0
+version: 1.3.1
 appVersion: 1.3.0
 description: A Helm chart for eks-node-montoring-agent
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -98,7 +98,7 @@ dcgmAgent:
             # Only schedule on NVIDIA GPU nodes
           - key: node.kubernetes.io/instance-type
             operator: In
-            values: [g3.16xlarge, g3.4xlarge, g3.8xlarge, g3s.xlarge, g4dn.12xlarge, g4dn.16xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.metal, g4dn.xlarge, g5.12xlarge, g5.16xlarge, g5.24xlarge, g5.2xlarge, g5.48xlarge, g5.4xlarge, g5.8xlarge, g5.xlarge, g6.12xlarge, g6.16xlarge, g6.24xlarge, g6.2xlarge, g6.48xlarge, g6.4xlarge, g6.8xlarge, g6.xlarge, g6e.12xlarge, g6e.16xlarge, g6e.24xlarge, g6e.2xlarge, g6e.48xlarge, g6e.4xlarge, g6e.8xlarge, g6e.xlarge, gr6.4xlarge, gr6.8xlarge, p2.16xlarge, p2.8xlarge, p2.xlarge, p3.16xlarge, p3.2xlarge, p3.8xlarge, p4d.24xlarge, p5.48xlarge, p5e.48xlarge]
+            values: [g3.16xlarge, g3.4xlarge, g3.8xlarge, g3s.xlarge, g4dn.12xlarge, g4dn.16xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.metal, g4dn.xlarge, g5.12xlarge, g5.16xlarge, g5.24xlarge, g5.2xlarge, g5.48xlarge, g5.4xlarge, g5.8xlarge, g5.xlarge, g6.12xlarge, g6.16xlarge, g6.24xlarge, g6.2xlarge, g6.48xlarge, g6.4xlarge, g6.8xlarge, g6.xlarge, g6e.12xlarge, g6e.16xlarge, g6e.24xlarge, g6e.2xlarge, g6e.48xlarge, g6e.4xlarge, g6e.8xlarge, g6e.xlarge, gr6.4xlarge, gr6.8xlarge, p2.16xlarge, p2.8xlarge, p2.xlarge, p3.16xlarge, p3.2xlarge, p3.8xlarge, p4d.24xlarge, p5.48xlarge, p5e.48xlarge, p5en.48xlarge]
             # Don't schedule on special compute types
           - key: eks.amazonaws.com/compute-type
             operator: NotIn


### PR DESCRIPTION

**Issue #, if available**:

**Description of changes**:

The list of instance-types on which the DCGM Server should run was missing the p5en.48xlarge type, meaning the DCGM server could not be started on these nodes.
I'm unsure how to properly release a helm chart and have only updated the version in Chart.yaml.

**Testing Done**:

I changed the entire `affinity` value in my environment and it worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.