### PR TITLE
Toggle daemonset support

### DIFF
--- a/charts/eks-node-monitoring-agent/templates/daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nodeAgent.enabled }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -69,3 +70,4 @@ spec:
         - name: host-root
           hostPath:
             path: /
+{{- end }}

--- a/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dcgmAgent.enabled }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -46,3 +47,4 @@ spec:
             hostPort: 5555
           securityContext:
             privileged: true
+{{- end }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -18,6 +18,8 @@ serviceAccount:
   annotations: {}
 
 nodeAgent:
+  # Specifies whether the node agent should be installed
+  enabled: true
   image:
     # -- Image tag for the eks-node-monitoring-agent
     tag: v1.4.0-eksbuild.2
@@ -76,6 +78,8 @@ nodeAgent:
     - operator: Exists
 
 dcgmAgent:
+  # Specifies whether the dcgm agent should be installed
+  enabled: true
   image:
     # -- Image tag for the dcgm-exporter
     tag: 4.1.1-4.0.4-ubuntu22.04


### PR DESCRIPTION
**[Issue 20,](https://github.com/aws/eks-node-monitoring-agent/issues/20)**

**Description of changes**:
This Pr toggles the deployment of daemonset, I believe we only need the dcgm toggle but I also added nodeAgent toggle just in case it's needed for whatever reason, both of them are enabled by default for backward compatibility.
**Testing Done**:

