### PR TITLE
fix: imagePullSecrets correct position in the template

### DIFF
--- a/charts/eks-node-monitoring-agent/templates/daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/daemonset.yaml
@@ -31,6 +31,10 @@ spec:
       serviceAccountName: {{ template "eks-node-monitoring-agent.serviceAccountName" . }}
       hostNetwork: true
       hostPID: true
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ template "eks-node-monitoring-agent.image" . }}
@@ -52,10 +56,6 @@ spec:
             httpGet:
               path: /healthz
               port: 8002
-          {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
           {{- with .Values.nodeAgent.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
**Description of changes**:

Correct position for imagePullSecrets in the daemonset template.

**Testing Done**: yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
