### PR TITLE
feat: add podLabels handling to the DaemonSets

### DIFF
--- a/charts/eks-node-monitoring-agent/templates/daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/daemonset.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
         {{- include "eks-node-monitoring-agent.labels" . | nindent 8 }}
+        {{- with .Values.nodeAgent.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.nodeAgent.affinity }}
       affinity: {{- toYaml . | nindent 8 }}

--- a/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         k8s-app: dcgm-server
         version: v1
+        {{- with .Values.dcgmAgent.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.dcgmAgent.affinity }}
       affinity: {{- toYaml . | nindent 8 }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -74,6 +74,8 @@ nodeAgent:
   # -- Deployment tolerations for the eks-node-monitoring-agent
   tolerations:
     - operator: Exists
+  # -- Pod labels applied to the eks-node-monitoring-agent
+  podLabels: {}
 
 dcgmAgent:
   image:
@@ -120,6 +122,8 @@ dcgmAgent:
   resources: {}
   # -- Deployment tolerations for the dcgm
   tolerations: []
+  # -- Pod labels applied to the dcgm exporter
+  podLabels: {}
 
 # -- Update strategy for all daemon sets
 updateStrategy:


### PR DESCRIPTION
**Issue #**: #29

**Description of changes**:

The PR adds handling of `nodeAgent.podLabels` and `dcgmAgent.podLabels` Helm values to allow additional labels on agent and dcgm pods.

**Testing Done**:

- Running `helm template .` produces no difference with the latest release.
- Running `helm template --set nodeAgent.podLabels.team=team1 --set dcgmAgent.podLabels.team=team2 .` produces the expected result:
```
diff -Nru -U 8 yamls/eks-node-monitoring-agent/templates/daemonset.yaml yamls-updated/eks-node-monitoring-agent/templates/daemonset.yaml
--- yamls/eks-node-monitoring-agent/templates/daemonset.yaml	2025-12-17 15:16:31
+++ yamls-updated/eks-node-monitoring-agent/templates/daemonset.yaml	2025-12-17 16:54:14
@@ -26,16 +26,17 @@
     metadata:
       labels:
         app.kubernetes.io/name: eks-node-monitoring-agent
         helm.sh/chart: eks-node-monitoring-agent
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "1.4.2"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
+        team: team1

diff -Nru -U 8 yamls/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml yamls-updated/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
--- yamls/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml	2025-12-17 15:16:31
+++ yamls-updated/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml	2025-12-17 16:54:14
@@ -17,16 +17,17 @@
     rollingUpdate:
       maxUnavailable: 10%
     type: RollingUpdate
   template:
     metadata:
       labels:
         k8s-app: dcgm-server
         version: v1
+        team: team2
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
