### PR TITLE
ci: fix permissions for publishing charts

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
 jobs:
   publish-charts:
     runs-on: ubuntu-latest
@@ -12,6 +14,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Setup Helm"
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # 4.3.0
       - name: "Publish Charts"


### PR DESCRIPTION
**Issue #, if available**:
CI for publishing charts failing with:
https://github.com/aws/eks-node-monitoring-agent/actions/runs/19902689831/job/57050675940

```
Run hack/publish-charts.sh
Successfully packaged chart and saved it to: /home/runner/work/eks-node-monitoring-agent/eks-node-monitoring-agent/eks-node-monitoring-agent-1.4.2.tgz
fatal: path '/home/runner/work/eks-node-monitoring-agent/eks-node-monitoring-agent/eks-node-monitoring-agent-1.4.2.tgz' exists on disk, but not in 'origin/gh-pages'
/home/runner/work/eks-node-monitoring-agent/eks-node-monitoring-agent/eks-node-monitoring-agent-1.4.2.tgz
Switched to a new branch 'gh-pages'
branch 'gh-pages' set up to track 'origin/gh-pages'.
[gh-pages f0b0edb] Publish charts 8c55e64
 2 files changed, 20 insertions(+), 5 deletions(-)
 create mode 100644 eks-node-monitoring-agent-1.4.2.tgz
remote: Permission to aws/eks-node-monitoring-agent.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/aws/eks-node-monitoring-agent/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

**Description of changes**:
Attempting to fix permissions

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
