### PR TITLE
fix: update readme to reflect new pod-labels

### DIFF
--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters for this chart and their d
 | dcgmAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy for the dcgm-exporter |
 | dcgmAgent.image.region | string | `"us-west-2"` | ECR repository region for the dcgm-exporter |
 | dcgmAgent.image.tag | string | `"4.4.0-4.5.0-ubuntu22.04"` | Image tag for the dcgm-exporter |
+| dcgmAgent.podLabels | object | `{}` | Pod labels applied to the dcgm exporter |
 | dcgmAgent.resources | object | `{}` | Container resources for the dcgm deployment |
 | dcgmAgent.tolerations | list | `[]` | Deployment tolerations for the dcgm |
 | fullnameOverride | string | `"eks-node-monitoring-agent"` | A fullname override for the chart |
@@ -56,6 +57,7 @@ The following table lists the configurable parameters for this chart and their d
 | nodeAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policyfor the eks-node-monitoring-agent |
 | nodeAgent.image.region | string | `"us-west-2"` | ECR repository region for the eks-node-monitoring-agent |
 | nodeAgent.image.tag | string | `"v1.5.0-eksbuild.1"` | Image tag for the eks-node-monitoring-agent |
+| nodeAgent.podLabels | object | `{}` | Pod labels applied to the eks-node-monitoring-agent |
 | nodeAgent.resources | object | `{"limits":{"cpu":"250m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"30Mi"}}` | Container resources for the eks-node-monitoring-agent |
 | nodeAgent.securityContext | object | `{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}` | Container Security context for the eks-node-monitoring-agent |
 | nodeAgent.tolerations | list | `[{"operator":"Exists"}]` | Deployment tolerations for the eks-node-monitoring-agent |


### PR DESCRIPTION
**Issue #, if available**:
CI failed after merging the [PR that adds pod labels to NMA and dcgm](https://github.com/aws/eks-node-monitoring-agent/pull/30):
https://github.com/aws/eks-node-monitoring-agent/pull/35/checks

Sidenote: We need a CI that is able to verify customer's PRs are stable

**Description of changes**:
Changes generated with `make generate`

**Testing Done**:
As you can see the CI is succeeding

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
