### PR TITLE
fix: ci builds and deploys code changes in the PR

### DIFF
--- a/.github/actions/ci/kubetest2/action.yaml
+++ b/.github/actions/ci/kubetest2/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: 'Test filter pattern (e.g., Test/DaemonSetReady)'
     required: false
     default: ''
+  nodediagnostic_bucket:
+    description: 'S3 bucket for NodeDiagnostic log collection testing'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -90,6 +94,12 @@ runs:
         # Add filter if provided
         if [ -n "\${TEST_FILTER}" ]; then
           TEST_CMD="\${TEST_CMD} --test.run '\${TEST_FILTER}'"
+        fi
+
+        # Add nodediagnostic bucket if provided
+        NODEDIAG_BUCKET="${{ inputs.nodediagnostic_bucket }}"
+        if [ -n "\${NODEDIAG_BUCKET}" ]; then
+          TEST_CMD="\${TEST_CMD} --nodediagnostic-bucket-name=\${NODEDIAG_BUCKET}"
         fi
         
         echo "Executing: \${TEST_CMD}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,3 +170,4 @@ jobs:
           test_filter: ${{ inputs.test_filter }}
           image: ${{ steps.resolve-image.outputs.image }}
           ami_type: ${{ inputs.ami_type }}
+          nodediagnostic_bucket: ${{ secrets.CI_TEST_BUCKET }}


### PR DESCRIPTION
**Issue #, if available**:

The current set up only tests the image that is provided in the charts to test against all the e2e test cases.

**Description of changes**:

This PR will actually build the NMA image for a submitted PR and then deploy it to a test account. Also adds `--nodediagnostic-bucket-name` flag to ensure full test-suite is executed.

**Testing Done**:

A: Checking if CI picks up code from the PR:

1. Created this PR on my fork: https://github.com/shvbsle/eks-node-monitoring-agent/pull/3/changes
2. The CR has a new line of code in `e2e/setup/e2e.go`. The test verification is simply to ensure that kubetest2 is running the newly built code which adds a log-line "noop canary: installing agent with image:"
3. In the CI workflow here we can see:
```
Executing: /home/runner/work/eks-node-monitoring-agent/eks-node-monitoring-agent/bin/e2e.test --test.v --test.timeout 30m --install=true --image=***/eks-node-monitoring-agent:ci-ci-3-0b95708-b799f5a5-f52e-42e4-af66-27192b17ed45-amd64
2026/02/27 21:27:56 noop canary: installing agent with image: ***/eks-node-monitoring-agent:ci-ci-3-0b95708-b799f5a5-f52e-42e4-af66-27192b17ed45-amd64
```
[workflow](https://github.com/shvbsle/eks-node-monitoring-agent/actions/runs/22503711142/job/65197682707)

B. Check if CI is able to catch failures introduced in the code:

1. To trigger this test-case, I created a PR which did not have the fix in this [PR](https://github.com/aws/eks-node-monitoring-agent/pull/57). 
2. Triggering the CI now correctly fails as expected:
```
    --- FAIL: Test/LogCollection (180.99s)
        --- FAIL: Test/LogCollection/CollectLogs (180.29s)
            --- FAIL: Test/LogCollection/CollectLogs/ip-192-168-130-120.***.compute.internal (60.08s)
            --- FAIL: Test/LogCollection/CollectLogs/ip-192-168-231-38.***.compute.internal (60.11s)
            --- FAIL: Test/LogCollection/CollectLogs/ip-192-168-255-78.***.compute.internal (60.09s)
```
[workflow](https://github.com/shvbsle/eks-node-monitoring-agent/actions/runs/22507822328/job/65210740514)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
