### PR TITLE
fix(e2e): ignore DCGM health code 122 (IMEX unhealthy) in soak tests

### DIFF
--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -2,290 +2,289 @@ package reasons
 
 var (
 
-	// reasons for the AcceleratedHardwareReady condition.
+    // reasons for the AcceleratedHardwareReady condition.
 
-	DCGMDiagnosticFailure = ReasonMeta{
-		template:        "DCGMDiagnosticFailure",
-		defaultSeverity: "Fatal",
-	}
-	DCGMError = ReasonMeta{
-		template:        "DCGMError",
-		defaultSeverity: "Fatal",
-	}
-	DCGMFieldError = ReasonMeta{
-		template:        "DCGMFieldError%d",
-		defaultSeverity: "Warning",
-	}
-	DCGMHealthCode = ReasonMeta{
-		template:        "DCGMHealthCode%d",
-		defaultSeverity: "Warning",
-	}
-	DCGMHealthCodeFatal = ReasonMeta{
-		template:        "DCGMHealthCode%d",
-		defaultSeverity: "Fatal",
-	}
-	NeuronDMAError = ReasonMeta{
-		template:        "NeuronDMAError",
-		defaultSeverity: "Fatal",
-	}
-	NeuronHBMUncorrectableError = ReasonMeta{
-		template:        "NeuronHBMUncorrectableError",
-		defaultSeverity: "Fatal",
-	}
-	NeuronNCUncorrectableError = ReasonMeta{
-		template:        "NeuronNCUncorrectableError",
-		defaultSeverity: "Fatal",
-	}
-	NeuronSRAMUncorrectableError = ReasonMeta{
-		template:        "NeuronSRAMUncorrectableError",
-		defaultSeverity: "Fatal",
-	}
-	NvidiaDeviceCountMismatch = ReasonMeta{
-		template:        "NvidiaDeviceCountMismatch",
-		defaultSeverity: "Warning",
-	}
-	NvidiaDoubleBitError = ReasonMeta{
-		template:        "NvidiaDoubleBitError",
-		defaultSeverity: "Fatal",
-	}
-	NvidiaNCCLError = ReasonMeta{
-		template:        "NvidiaNCCLError",
-		defaultSeverity: "Warning",
-	}
-	NvidiaNVLinkError = ReasonMeta{
-		template:        "NvidiaNVLinkError",
-		defaultSeverity: "Fatal",
-	}
-	NvidiaPCIeError = ReasonMeta{
-		template:        "NvidiaPCIeError",
-		defaultSeverity: "Warning",
-	}
-	NvidiaPageRetirement = ReasonMeta{
-		template:        "NvidiaPageRetirement",
-		defaultSeverity: "Warning",
-	}
-	NvidiaPowerError = ReasonMeta{
-		template:        "NvidiaPowerError",
-		defaultSeverity: "Warning",
-	}
-	NvidiaThermalError = ReasonMeta{
-		template:        "NvidiaThermalError",
-		defaultSeverity: "Warning",
-	}
-	NvidiaXIDError = ReasonMeta{
-		template:        "NvidiaXID%dError",
-		defaultSeverity: "Fatal",
-	}
-	NvidiaXIDWarning = ReasonMeta{
-		template:        "NvidiaXID%dWarning",
-		defaultSeverity: "Warning",
-	}
+    DCGMDiagnosticFailure = ReasonMeta{
+        template:        "DCGMDiagnosticFailure",
+        defaultSeverity: "Fatal",
+    }
+    DCGMError = ReasonMeta{
+        template:        "DCGMError",
+        defaultSeverity: "Fatal",
+    }
+    DCGMFieldError = ReasonMeta{
+        template:        "DCGMFieldError%d",
+        defaultSeverity: "Warning",
+    }
+    DCGMHealthCode = ReasonMeta{
+        template:        "DCGMHealthCode%d",
+        defaultSeverity: "Warning",
+    }
+    DCGMHealthCodeFatal = ReasonMeta{
+        template:        "DCGMHealthCode%d",
+        defaultSeverity: "Fatal",
+    }
+    NeuronDMAError = ReasonMeta{
+        template:        "NeuronDMAError",
+        defaultSeverity: "Fatal",
+    }
+    NeuronHBMUncorrectableError = ReasonMeta{
+        template:        "NeuronHBMUncorrectableError",
+        defaultSeverity: "Fatal",
+    }
+    NeuronNCUncorrectableError = ReasonMeta{
+        template:        "NeuronNCUncorrectableError",
+        defaultSeverity: "Fatal",
+    }
+    NeuronSRAMUncorrectableError = ReasonMeta{
+        template:        "NeuronSRAMUncorrectableError",
+        defaultSeverity: "Fatal",
+    }
+    NvidiaDeviceCountMismatch = ReasonMeta{
+        template:        "NvidiaDeviceCountMismatch",
+        defaultSeverity: "Warning",
+    }
+    NvidiaDoubleBitError = ReasonMeta{
+        template:        "NvidiaDoubleBitError",
+        defaultSeverity: "Fatal",
+    }
+    NvidiaNCCLError = ReasonMeta{
+        template:        "NvidiaNCCLError",
+        defaultSeverity: "Warning",
+    }
+    NvidiaNVLinkError = ReasonMeta{
+        template:        "NvidiaNVLinkError",
+        defaultSeverity: "Fatal",
+    }
+    NvidiaPCIeError = ReasonMeta{
+        template:        "NvidiaPCIeError",
+        defaultSeverity: "Warning",
+    }
+    NvidiaPageRetirement = ReasonMeta{
+        template:        "NvidiaPageRetirement",
+        defaultSeverity: "Warning",
+    }
+    NvidiaPowerError = ReasonMeta{
+        template:        "NvidiaPowerError",
+        defaultSeverity: "Warning",
+    }
+    NvidiaThermalError = ReasonMeta{
+        template:        "NvidiaThermalError",
+        defaultSeverity: "Warning",
+    }
+    NvidiaXIDError = ReasonMeta{
+        template:        "NvidiaXID%dError",
+        defaultSeverity: "Fatal",
+    }
+    NvidiaXIDWarning = ReasonMeta{
+        template:        "NvidiaXID%dWarning",
+        defaultSeverity: "Warning",
+    }
 
-	// reasons for the ContainerRuntimeReady condition.
+    // reasons for the ContainerRuntimeReady condition.
 
-	ContainerRuntimeFailed = ReasonMeta{
-		template:        "ContainerRuntimeFailed",
-		defaultSeverity: "Warning",
-	}
-	DeprecatedContainerdConfiguration = ReasonMeta{
-		template:        "DeprecatedContainerdConfiguration",
-		defaultSeverity: "Warning",
-	}
-	KubeletFailed = ReasonMeta{
-		template:        "KubeletFailed",
-		defaultSeverity: "Warning",
-	}
-	LivenessProbeFailures = ReasonMeta{
-		template:        "LivenessProbeFailures",
-		defaultSeverity: "Warning",
-	}
-	PodStuckTerminating = ReasonMeta{
-		template:        "PodStuckTerminating",
-		defaultSeverity: "Fatal",
-	}
-	ReadinessProbeFailures = ReasonMeta{
-		template:        "ReadinessProbeFailures",
-		defaultSeverity: "Warning",
-	}
-	RepeatedRestart = ReasonMeta{
-		template:        "%sRepeatedRestart",
-		defaultSeverity: "Warning",
-	}
-	ServiceFailedToStart = ReasonMeta{
-		template:        "ServiceFailedToStart",
-		defaultSeverity: "Warning",
-	}
+    ContainerRuntimeFailed = ReasonMeta{
+        template:        "ContainerRuntimeFailed",
+        defaultSeverity: "Warning",
+    }
+    DeprecatedContainerdConfiguration = ReasonMeta{
+        template:        "DeprecatedContainerdConfiguration",
+        defaultSeverity: "Warning",
+    }
+    KubeletFailed = ReasonMeta{
+        template:        "KubeletFailed",
+        defaultSeverity: "Warning",
+    }
+    LivenessProbeFailures = ReasonMeta{
+        template:        "LivenessProbeFailures",
+        defaultSeverity: "Warning",
+    }
+    PodStuckTerminating = ReasonMeta{
+        template:        "PodStuckTerminating",
+        defaultSeverity: "Fatal",
+    }
+    ReadinessProbeFailures = ReasonMeta{
+        template:        "ReadinessProbeFailures",
+        defaultSeverity: "Warning",
+    }
+    RepeatedRestart = ReasonMeta{
+        template:        "%sRepeatedRestart",
+        defaultSeverity: "Warning",
+    }
+    ServiceFailedToStart = ReasonMeta{
+        template:        "ServiceFailedToStart",
+        defaultSeverity: "Warning",
+    }
 
-	// reasons for the KernelReady condition.
+    // reasons for the KernelReady condition.
 
-	AppBlocked = ReasonMeta{
-		template:        "AppBlocked",
-		defaultSeverity: "Warning",
-	}
-	AppCrash = ReasonMeta{
-		template:        "AppCrash",
-		defaultSeverity: "Warning",
-	}
-	ApproachingKernelPidMax = ReasonMeta{
-		template:        "ApproachingKernelPidMax",
-		defaultSeverity: "Warning",
-	}
-	ApproachingMaxOpenFiles = ReasonMeta{
-		template:        "ApproachingMaxOpenFiles",
-		defaultSeverity: "Warning",
-	}
-	ConntrackExceededKernel = ReasonMeta{
-		template:        "ConntrackExceededKernel",
-		defaultSeverity: "Warning",
-	}
-	ExcessiveZombieProcesses = ReasonMeta{
-		template:        "ExcessiveZombieProcesses",
-		defaultSeverity: "Warning",
-	}
-	ForkFailedOutOfPIDs = ReasonMeta{
-		template:        "ForkFailedOutOfPIDs",
-		defaultSeverity: "Fatal",
-	}
-	KernelBug = ReasonMeta{
-		template:        "KernelBug",
-		defaultSeverity: "Warning",
-	}
-	LargeEnvironment = ReasonMeta{
-		template:        "LargeEnvironment",
-		defaultSeverity: "Warning",
-	}
-	RapidCron = ReasonMeta{
-		template:        "RapidCron",
-		defaultSeverity: "Warning",
-	}
-	SoftLockup = ReasonMeta{
-		template:        "SoftLockup",
-		defaultSeverity: "Warning",
-	}
+    AppBlocked = ReasonMeta{
+        template:        "AppBlocked",
+        defaultSeverity: "Warning",
+    }
+    AppCrash = ReasonMeta{
+        template:        "AppCrash",
+        defaultSeverity: "Warning",
+    }
+    ApproachingKernelPidMax = ReasonMeta{
+        template:        "ApproachingKernelPidMax",
+        defaultSeverity: "Warning",
+    }
+    ApproachingMaxOpenFiles = ReasonMeta{
+        template:        "ApproachingMaxOpenFiles",
+        defaultSeverity: "Warning",
+    }
+    ConntrackExceededKernel = ReasonMeta{
+        template:        "ConntrackExceededKernel",
+        defaultSeverity: "Warning",
+    }
+    ExcessiveZombieProcesses = ReasonMeta{
+        template:        "ExcessiveZombieProcesses",
+        defaultSeverity: "Warning",
+    }
+    ForkFailedOutOfPIDs = ReasonMeta{
+        template:        "ForkFailedOutOfPIDs",
+        defaultSeverity: "Fatal",
+    }
+    KernelBug = ReasonMeta{
+        template:        "KernelBug",
+        defaultSeverity: "Warning",
+    }
+    LargeEnvironment = ReasonMeta{
+        template:        "LargeEnvironment",
+        defaultSeverity: "Warning",
+    }
+    RapidCron = ReasonMeta{
+        template:        "RapidCron",
+        defaultSeverity: "Warning",
+    }
+    SoftLockup = ReasonMeta{
+        template:        "SoftLockup",
+        defaultSeverity: "Warning",
+    }
 
-	// reasons for the NetworkingReady condition.
+    // reasons for the NetworkingReady condition.
 
-	BandwidthInExceeded = ReasonMeta{
-		template:        "BandwidthInExceeded",
-		defaultSeverity: "Warning",
-	}
-	BandwidthOutExceeded = ReasonMeta{
-		template:        "BandwidthOutExceeded",
-		defaultSeverity: "Warning",
-	}
-	ConntrackExceeded = ReasonMeta{
-		template:        "ConntrackExceeded",
-		defaultSeverity: "Warning",
-	}
-	EFAErrorMetric = ReasonMeta{
-		template:        "EFAErrorMetric",
-		defaultSeverity: "Warning",
-	}
-	IPAMDInconsistentState = ReasonMeta{
-		template:        "IPAMDInconsistentState",
-		defaultSeverity: "Warning",
-	}
-	IPAMDNoIPs = ReasonMeta{
-		template:        "IPAMDNoIPs",
-		defaultSeverity: "Warning",
-	}
-	IPAMDNotReady = ReasonMeta{
-		template:        "IPAMDNotReady",
-		defaultSeverity: "Fatal",
-	}
-	IPAMDNotRunning = ReasonMeta{
-		template:        "IPAMDNotRunning",
-		defaultSeverity: "Fatal",
-	}
-	IPAMDRepeatedlyRestart = ReasonMeta{
-		template:        "IPAMDRepeatedlyRestart",
-		defaultSeverity: "Warning",
-	}
-	InterfaceNotRunning = ReasonMeta{
-		template:        "InterfaceNotRunning",
-		defaultSeverity: "Fatal",
-	}
-	InterfaceNotUp = ReasonMeta{
-		template:        "InterfaceNotUp",
-		defaultSeverity: "Fatal",
-	}
-	KubeProxyNotReady = ReasonMeta{
-		template:        "KubeProxyNotReady",
-		defaultSeverity: "Warning",
-	}
-	LinkLocalExceeded = ReasonMeta{
-		template:        "LinkLocalExceeded",
-		defaultSeverity: "Warning",
-	}
-	MACAddressPolicyMisconfigured = ReasonMeta{
-		template:        "MACAddressPolicyMisconfigured",
-		defaultSeverity: "Warning",
-	}
-	MissingDefaultRoutes = ReasonMeta{
-		template:        "MissingDefaultRoutes",
-		defaultSeverity: "Warning",
-	}
-	MissingIPRoutes = ReasonMeta{
-		template:        "MissingIPRoutes",
-		defaultSeverity: "Warning",
-	}
-	MissingIPRules = ReasonMeta{
-		template:        "MissingIPRules",
-		defaultSeverity: "Warning",
-	}
-	MissingLoopbackInterface = ReasonMeta{
-		template:        "MissingLoopbackInterface",
-		defaultSeverity: "Fatal",
-	}
-	NetworkSysctl = ReasonMeta{
-		template:        "NetworkSysctl",
-		defaultSeverity: "Warning",
-	}
-	PPSExceeded = ReasonMeta{
-		template:        "PPSExceeded",
-		defaultSeverity: "Warning",
-	}
-	PortConflict = ReasonMeta{
-		template:        "PortConflict",
-		defaultSeverity: "Warning",
-	}
-	UnexpectedRejectRule = ReasonMeta{
-		template:        "UnexpectedRejectRule",
-		defaultSeverity: "Warning",
-	}
+    BandwidthInExceeded = ReasonMeta{
+        template:        "BandwidthInExceeded",
+        defaultSeverity: "Warning",
+    }
+    BandwidthOutExceeded = ReasonMeta{
+        template:        "BandwidthOutExceeded",
+        defaultSeverity: "Warning",
+    }
+    ConntrackExceeded = ReasonMeta{
+        template:        "ConntrackExceeded",
+        defaultSeverity: "Warning",
+    }
+    EFAErrorMetric = ReasonMeta{
+        template:        "EFAErrorMetric",
+        defaultSeverity: "Warning",
+    }
+    IPAMDInconsistentState = ReasonMeta{
+        template:        "IPAMDInconsistentState",
+        defaultSeverity: "Warning",
+    }
+    IPAMDNoIPs = ReasonMeta{
+        template:        "IPAMDNoIPs",
+        defaultSeverity: "Warning",
+    }
+    IPAMDNotReady = ReasonMeta{
+        template:        "IPAMDNotReady",
+        defaultSeverity: "Fatal",
+    }
+    IPAMDNotRunning = ReasonMeta{
+        template:        "IPAMDNotRunning",
+        defaultSeverity: "Fatal",
+    }
+    IPAMDRepeatedlyRestart = ReasonMeta{
+        template:        "IPAMDRepeatedlyRestart",
+        defaultSeverity: "Warning",
+    }
+    InterfaceNotRunning = ReasonMeta{
+        template:        "InterfaceNotRunning",
+        defaultSeverity: "Fatal",
+    }
+    InterfaceNotUp = ReasonMeta{
+        template:        "InterfaceNotUp",
+        defaultSeverity: "Fatal",
+    }
+    KubeProxyNotReady = ReasonMeta{
+        template:        "KubeProxyNotReady",
+        defaultSeverity: "Warning",
+    }
+    LinkLocalExceeded = ReasonMeta{
+        template:        "LinkLocalExceeded",
+        defaultSeverity: "Warning",
+    }
+    MACAddressPolicyMisconfigured = ReasonMeta{
+        template:        "MACAddressPolicyMisconfigured",
+        defaultSeverity: "Warning",
+    }
+    MissingDefaultRoutes = ReasonMeta{
+        template:        "MissingDefaultRoutes",
+        defaultSeverity: "Warning",
+    }
+    MissingIPRoutes = ReasonMeta{
+        template:        "MissingIPRoutes",
+        defaultSeverity: "Warning",
+    }
+    MissingIPRules = ReasonMeta{
+        template:        "MissingIPRules",
+        defaultSeverity: "Warning",
+    }
+    MissingLoopbackInterface = ReasonMeta{
+        template:        "MissingLoopbackInterface",
+        defaultSeverity: "Fatal",
+    }
+    NetworkSysctl = ReasonMeta{
+        template:        "NetworkSysctl",
+        defaultSeverity: "Warning",
+    }
+    PPSExceeded = ReasonMeta{
+        template:        "PPSExceeded",
+        defaultSeverity: "Warning",
+    }
+    PortConflict = ReasonMeta{
+        template:        "PortConflict",
+        defaultSeverity: "Warning",
+    }
+    UnexpectedRejectRule = ReasonMeta{
+        template:        "UnexpectedRejectRule",
+        defaultSeverity: "Warning",
+    }
 
-	// reasons for the StorageReady condition.
+    // reasons for the StorageReady condition.
 
-	EBSInstanceIOPSExceeded = ReasonMeta{
-		template:        "EBSInstanceIOPSExceeded",
-		defaultSeverity: "Warning",
-	}
-	EBSInstanceThroughputExceeded = ReasonMeta{
-		template:        "EBSInstanceThroughputExceeded",
-		defaultSeverity: "Warning",
-	}
-	EBSVolumeIOPSExceeded = ReasonMeta{
-		template:        "EBSVolumeIOPSExceeded",
-		defaultSeverity: "Warning",
-	}
-	EBSVolumeThroughputExceeded = ReasonMeta{
-		template:        "EBSVolumeThroughputExceeded",
-		defaultSeverity: "Warning",
-	}
-	EtcHostsMountFailed = ReasonMeta{
-		template:        "EtcHostsMountFailed",
-		defaultSeverity: "Warning",
-	}
-	IODelays = ReasonMeta{
-		template:        "IODelays",
-		defaultSeverity: "Warning",
-	}
-	KubeletDiskUsageSlow = ReasonMeta{
-		template:        "KubeletDiskUsageSlow",
-		defaultSeverity: "Warning",
-	}
-	XFSSmallAverageClusterSize = ReasonMeta{
-		template:        "XFSSmallAverageClusterSize",
-		defaultSeverity: "Warning",
-	}
-)
+    EBSInstanceIOPSExceeded = ReasonMeta{
+        template:        "EBSInstanceIOPSExceeded",
+        defaultSeverity: "Warning",
+    }
+    EBSInstanceThroughputExceeded = ReasonMeta{
+        template:        "EBSInstanceThroughputExceeded",
+        defaultSeverity: "Warning",
+    }
+    EBSVolumeIOPSExceeded = ReasonMeta{
+        template:        "EBSVolumeIOPSExceeded",
+        defaultSeverity: "Warning",
+    }
+    EBSVolumeThroughputExceeded = ReasonMeta{
+        template:        "EBSVolumeThroughputExceeded",
+        defaultSeverity: "Warning",
+    }
+    EtcHostsMountFailed = ReasonMeta{
+        template:        "EtcHostsMountFailed",
+        defaultSeverity: "Warning",
+    }
+    IODelays = ReasonMeta{
+        template:        "IODelays",
+        defaultSeverity: "Warning",
+    }
+    KubeletDiskUsageSlow = ReasonMeta{
+        template:        "KubeletDiskUsageSlow",
+        defaultSeverity: "Warning",
+    }
+    XFSSmallAverageClusterSize = ReasonMeta{
+        template:        "XFSSmallAverageClusterSize",
+        defaultSeverity: "Warning",
+    })


### PR DESCRIPTION
**Issue #, if available**:

### Problem

After bumping the DCGM image, e2e tests started failing with:
node condition {Type:AcceleratedHardwareReady Status:False ... Reason:DCGMHealthCode122
Message:DCGM detected issues in health check system with error code 122}


### Root Cause

DCGM error code 122 (DCGM_FR_IMEX_UNHEALTHY) was introduced in newer DCGM versions. This code reports when the IMEX (Internode Memory Exchange) daemon or
domain status is unhealthy.

IMEX is only applicable to NVLink multi-node systems, specifically:
- NVIDIA GB200 NVL72
- DGX NVLink Multi-Node systems
- HGX NVLink Multi-Node systems

From [NVIDIA's official IMEX documentation](https://docs.nvidia.com/multi-node-nvlink-systems/imex-guide/overview.html):

│ "The IMEX service supports GPU memory export and import (NVLink P2P) and shared memory operations across OS domains in an NVLink multi-node deployment."

Standard EKS GPU instances (g4dn, p3, p4, p5, etc.) are not NVLink multi-node systems and do not have IMEX installed or configured. The DCGM health check
now flags this as unhealthy, causing false positive AcceleratedHardwareReady=False conditions.

**Testing Done**:
e2e and CI both pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
