### PR TITLE
chore: update NodeDiagnostic CRD for node destination

### DIFF
--- a/api/crds/eks.amazonaws.com_nodediagnostics.yaml
+++ b/api/crds/eks.amazonaws.com_nodediagnostics.yaml
@@ -64,8 +64,9 @@ spec:
                       type: string
                     type: array
                   destination:
-                    description: UploadDestination is a URL describing where to deliver
-                      a diagnostic artifact.
+                    description: |-
+                      UploadDestination is a URL describing where to deliver a diagnostic artifact.
+                      This can be set to "node" to temporarily store logs on the node for later collection.
                     type: string
                 required:
                 - destination

--- a/api/v1alpha1/nodediagnostic.go
+++ b/api/v1alpha1/nodediagnostic.go
@@ -49,6 +49,7 @@ type LogCapture struct {
 }
 
 // UploadDestination is a URL describing where to deliver a diagnostic artifact.
+// This can be set to "node" to temporarily store logs on the node for later collection.
 type UploadDestination string
 
 // LogCategory is a grouping of log sources to read from when performing a

--- a/charts/eks-node-monitoring-agent/README.md-e
+++ b/charts/eks-node-monitoring-agent/README.md-e
@@ -61,6 +61,7 @@ The following table lists the configurable parameters for this chart and their d
 | nodeAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policyfor the eks-node-monitoring-agent |
 | nodeAgent.image.region | string | `"us-west-2"` | ECR repository region for the eks-node-monitoring-agent |
 | nodeAgent.image.tag | string | `"v1.5.2-eksbuild.1"` | Image tag for the eks-node-monitoring-agent |
+| nodeAgent.monitors | object | `{}` | Per-monitor configuration keyed by plugin name. See the main README for details. |
 | nodeAgent.podAnnotations | object | `{}` | Pod annotations applied to the eks-node-monitoring-agent |
 | nodeAgent.podLabels | object | `{}` | Pod labels applied to the eks-node-monitoring-agent |
 | nodeAgent.resources | object | `{"limits":{"cpu":"250m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"30Mi"}}` | Container resources for the eks-node-monitoring-agent |

--- a/charts/eks-node-monitoring-agent/crds/eks.amazonaws.com_nodediagnostics.yaml
+++ b/charts/eks-node-monitoring-agent/crds/eks.amazonaws.com_nodediagnostics.yaml
@@ -64,8 +64,9 @@ spec:
                       type: string
                     type: array
                   destination:
-                    description: UploadDestination is a URL describing where to deliver
-                      a diagnostic artifact.
+                    description: |-
+                      UploadDestination is a URL describing where to deliver a diagnostic artifact.
+                      This can be set to "node" to temporarily store logs on the node for later collection.
                     type: string
                 required:
                 - destination

--- a/e2e/setup/manifests/agent.tpl.yaml
+++ b/e2e/setup/manifests/agent.tpl.yaml
@@ -66,8 +66,9 @@ spec:
                       type: string
                     type: array
                   destination:
-                    description: UploadDestination is a URL describing where to deliver
-                      a diagnostic artifact.
+                    description: |-
+                      UploadDestination is a URL describing where to deliver a diagnostic artifact.
+                      This can be set to "node" to temporarily store logs on the node for later collection.
                     type: string
                 required:
                 - destination


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**: Updated NodeDiagnostic `UploadDestination` CRD description to include option to utilize "node" and ran `make generate` to regenerate CRD

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
