### PR TITLE
feat: collect automode component logs in dedicated folder

### DIFF
--- a/pkg/log_collector/collect/automode.go
+++ b/pkg/log_collector/collect/automode.go
@@ -1,0 +1,25 @@
+package collect
+
+import (
+	"errors"
+)
+
+type AutoMode struct{}
+
+var _ Collector = (*AutoMode)(nil)
+
+func (c *AutoMode) Collect(acc *Accessor) error {
+	if !acc.cfg.hasAnyTag(TagEKSAuto) {
+		// skip collection for non-Auto nodes which do not have below components running via systemd
+		return nil
+	}
+	return errors.Join(
+		acc.CommandOutput([]string{"journalctl", "-u", "eks-healthchecker"}, "automode/eks-healthchecker.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-u", "kube-proxy"}, "automode/kube-proxy.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-u", "coredns-bootstrap"}, "automode/coredns-boostrap.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-u", "coredns"}, "automode/coredns.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-u", "eks-ebs-csi-driver"}, "automode/eks-ebs-csi-driver.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-u", "eks-node-monitoring-agent"}, "automode/eks-node-monitoring-agent.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-u", "eks-pod-identity-agent"}, "automode/eks-pod-identity-agent.txt", CommandOptionsNone),
+	)
+}

--- a/pkg/logcollection/collectors.go
+++ b/pkg/logcollection/collectors.go
@@ -90,6 +90,7 @@ var collectorMap = map[v1alpha1.LogCategory][]collect.Collector{
 		&collect.Disk{},
 		&collect.Kernel{},
 		&collect.SELinux{},
+		&collect.AutoMode{},
 		&collect.System{},
 		&collect.Throttles{},
 	},


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**: In the current NodeDiagnostic state, certain Auto mode component logs are only visible if checking ./bottlerocket/logdog/bottlerocket-logs/journalctl.log`. And it requires fully parsing through the whole combined journal.
```
k enter i-012ccdbfed4d08eea
ip-10-0-148-107  /host/usr/bin  chroot /host journalctl -F _SYSTEMD_UNIT                               

coredns.service
coredns-bootstrap.service
eks-ebs-csi-driver.service
kube-proxy.service
eks-pod-identity-agent.service
eks-healthchecker.service
eks-node-monitoring-agent.service
..
```

This change separates out the automode components into a new folder within the tarball

**Testing Done**:
```
~/Desktop/nodelogs on ☁️  (us-east-1) ➜  ls -lah i-xxxxxxxxxxxx-logs/        
total 24
drwx------  18 cdirubb  staff   576B Mar  5 10:40 .
drwxr-xr-x   5 cdirubb  staff   160B Mar  5 10:40 ..
-rw-r--r--@  1 cdirubb  staff    10K Mar  5 10:40 .DS_Store
drwxr-xr-x   9 cdirubb  staff   288B Mar  5 10:40 automode
drwxr-xr-x   5 cdirubb  staff   160B Mar  5 10:40 bottlerocket
drwxr-xr-x   3 cdirubb  staff    96B Mar  5 10:40 cni
drwxr-xr-x  10 cdirubb  staff   320B Mar  5 10:40 containerd
drwxr-xr-x   9 cdirubb  staff   288B Mar  5 10:40 ipamd
drwxr-xr-x   5 cdirubb  staff   160B Mar  5 10:40 kernel
drwxr-xr-x   5 cdirubb  staff   160B Mar  5 10:40 kubelet
drwxr-xr-x   3 cdirubb  staff    96B Mar  5 10:40 modinfo
drwxr-xr-x  29 cdirubb  staff   928B Mar  5 10:40 networking
drwxr-xr-x   4 cdirubb  staff   128B Mar  5 10:40 nodeadm
drwxr-xr-x   3 cdirubb  staff    96B Mar  5 10:40 sandbox-image
drwxr-xr-x   7 cdirubb  staff   224B Mar  5 10:40 storage
drwxr-xr-x   3 cdirubb  staff    96B Mar  5 10:40 sysctls
drwxr-xr-x  12 cdirubb  staff   384B Mar  5 10:40 system
drwxr-xr-x   3 cdirubb  staff    96B Mar  5 10:40 var_log

~/Desktop/nodelogs on ☁️  (us-east-1) ✖ k ekslogs i-xxxxxxxxxxxx
✔ Transfer mode: node proxy API
⟳ Validating node(s)...
✔ All 1 node(s) validated
⟳ Creating NodeDiagnostic resources...
⟳ Waiting for log collection to complete (timeout: 300s)...
✔ Log collection completed on all nodes
⟳ Downloading log bundles...
✔ Saved: ./i-xxxxxxxxxxxx-logs.tar.gz (704K)

✔ Done — 1 log bundle(s) downloaded to ./

~/Desktop/nodelogs on ☁️  (us-east-1) ➜  ls -lah i-xxxxxxxxxxxx-logs/automode
total 6152
drwxr-xr-x   9 cdirubb  staff   288B Mar  5 10:36 .
drwx------  18 cdirubb  staff   576B Mar  5 10:36 ..
-rw-r--r--   1 cdirubb  staff   9.3K Mar  5 10:34 coredns-boostrap.txt
-rw-r--r--   1 cdirubb  staff   2.6M Mar  5 10:34 coredns.txt
-rw-r--r--   1 cdirubb  staff   493B Mar  5 10:34 eks-ebs-csi-driver.txt
-rw-r--r--   1 cdirubb  staff    27K Mar  5 10:34 eks-healthchecker.txt
-rw-r--r--   1 cdirubb  staff   362K Mar  5 10:34 eks-node-monitoring-agent.txt
-rw-r--r--   1 cdirubb  staff    15K Mar  5 10:34 eks-pod-identity-agent.txt
-rw-r--r--   1 cdirubb  staff   4.9K Mar  5 10:34 kube-proxy.txt
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
