### PR TITLE
Move neuron and nvidia e2e tests to separate block

### DIFF
--- a/e2e/setup/e2e.go
+++ b/e2e/setup/e2e.go
@@ -158,13 +158,19 @@ func TestWrapper(t *testing.T, Testenv env.Environment) {
 		Testenv.TestInParallel(t,
 			monitors.ExporterImpl(),
 			monitors.KernelMonitor(),
-			monitors.NeuronMonitor(),
 			monitors.StressFileObserver(),
 		)
 	})
 
-	// Run nvidia monitor test after all parallel monitors complete.
-	Testenv.Test(t, monitors.NvidiaMonitor(awsCfg))
+	// Accelerated hardware monitors run in parallel after the core monitors.
+	// Neuron and Nvidia are mutually exclusive on a node, so only one will
+	// run amongst the two on accelerated hardware and will skip on all others.
+	t.Run("AcceleratedMonitors", func(t *testing.T) {
+		Testenv.TestInParallel(t,
+			monitors.NvidiaMonitor(awsCfg),
+			monitors.NeuronMonitor(),
+		)
+	})
 
 	// test the addon configuration if the agent is installed as an EKS Addon.
 	// this is disruptive, so it must run alone.


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
As titled, we want to run the accelerated hardware e2e tests in parallel and they are mutually exclusive.

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
