### PR TITLE
feat(release): add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -11,3 +11,8 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
     - run: hack/check-generate.sh
+  validate-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - run: hack/validate-release.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,50 @@
+name: "[Release] Create GitHub Release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'aws/eks-node-monitoring-agent'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag matches Chart.yaml version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CHART_VERSION=$(grep '^version:' charts/eks-node-monitoring-agent/Chart.yaml | awk '{print $2}')
+          if [ "${TAG_VERSION}" != "${CHART_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match Chart.yaml version (${CHART_VERSION})"
+            exit 1
+          fi
+          echo "RELEASE_VERSION=${TAG_VERSION}" >> "${GITHUB_ENV}"
+
+      - name: Extract changelog for this release
+        id: changelog
+        run: |
+          VERSION="v${RELEASE_VERSION}"
+          # Extract the section for this version from CHANGELOG.md
+          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          if [ -z "${NOTES}" ]; then
+            NOTES="Release ${VERSION}"
+          fi
+          # Write to file to preserve multiline content
+          echo "${NOTES}" > /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file /tmp/release-notes.md \
+            --verify-tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,15 +15,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
-        with:
-          fetch-depth: 0
 
       - name: Validate tag matches Chart.yaml version
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           CHART_VERSION=$(grep '^version:' charts/eks-node-monitoring-agent/Chart.yaml | awk '{print $2}')
+          APP_VERSION=$(grep '^appVersion:' charts/eks-node-monitoring-agent/Chart.yaml | awk '{print $2}')
           if [ "${TAG_VERSION}" != "${CHART_VERSION}" ]; then
             echo "::error::Tag version (${TAG_VERSION}) does not match Chart.yaml version (${CHART_VERSION})"
+            exit 1
+          fi
+          if [ "${TAG_VERSION}" != "${APP_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match Chart.yaml appVersion (${APP_VERSION})"
             exit 1
           fi
           echo "RELEASE_VERSION=${TAG_VERSION}" >> "${GITHUB_ENV}"
@@ -32,8 +35,10 @@ jobs:
         id: changelog
         run: |
           VERSION="v${RELEASE_VERSION}"
+          # Escape regex metacharacters in version string for safe awk matching
+          ESCAPED_VERSION=$(printf '%s' "${VERSION}" | sed 's/[.[\(*^$+?{|\\]/\\&/g')
           # Extract the section for this version from CHANGELOG.md
-          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          NOTES=$(awk "/^## \\[${ESCAPED_VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
           if [ -z "${NOTES}" ]; then
             NOTES="Release ${VERSION}"
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,21 +29,9 @@ jobs:
             echo "::error::Tag version (${TAG_VERSION}) does not match Chart.yaml appVersion (${APP_VERSION})"
             exit 1
           fi
-          echo "RELEASE_VERSION=${TAG_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Extract changelog for this release
-        id: changelog
-        run: |
-          VERSION="v${RELEASE_VERSION}"
-          # Escape regex metacharacters in version string for safe awk matching
-          ESCAPED_VERSION=$(printf '%s' "${VERSION}" | sed 's/[.[\(*^$+?{|\\]/\\&/g')
-          # Extract the section for this version from CHANGELOG.md
-          NOTES=$(awk "/^## \\[${ESCAPED_VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
-          if [ -z "${NOTES}" ]; then
-            NOTES="Release ${VERSION}"
-          fi
-          # Write to file to preserve multiline content
-          echo "${NOTES}" > /tmp/release-notes.md
+        run: hack/extract-changelog.sh "${GITHUB_REF_NAME}" > /tmp/release-notes.md
 
       - name: Create GitHub Release
         env:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,75 @@
+# Releasing
+
+This document describes how to create a new release of the EKS Node Monitoring Agent.
+
+## Prerequisites
+
+- Push access to the `aws/eks-node-monitoring-agent` repository
+- Permissions to create tags and GitHub releases
+
+## Release process
+
+### 1. Update version and changelog
+
+In a PR against `main`, update the following files:
+
+- **`charts/eks-node-monitoring-agent/Chart.yaml`**: Bump both `version` and `appVersion` to the new version (they must match).
+- **`CHANGELOG.md`**: Add a new section for the release using [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+  ```markdown
+  ## [v1.6.0]
+
+  ### What's Changed
+  - Description of change ([commit](link))
+
+  [v1.6.0]: https://github.com/aws/eks-node-monitoring-agent/compare/v1.5.2...v1.6.0
+  ```
+
+The `validate-release` CI check on every PR verifies that:
+- `version` and `appVersion` in `Chart.yaml` match
+- `CHANGELOG.md` has an entry for the current chart version
+
+### 2. Merge the PR
+
+Once the version bump PR is reviewed and merged to `main`, the `Publish Charts` workflow automatically packages and publishes the Helm chart to the `gh-pages` branch.
+
+### 3. Create and push the tag
+
+After the PR is merged, create an annotated tag on `main` and push it:
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v1.6.0 -m "Release v1.6.0"
+git push origin v1.6.0
+```
+
+### 4. Automatic release creation
+
+Pushing the tag triggers the `[Release] Create GitHub Release` workflow, which:
+
+1. Validates the tag version matches `Chart.yaml` `version` and `appVersion`
+2. Extracts release notes from the `CHANGELOG.md` section for that version
+3. Creates a GitHub release with those notes
+
+The release will appear at `https://github.com/aws/eks-node-monitoring-agent/releases`.
+
+## Validation scripts
+
+The release tooling lives in `hack/` and can be run locally:
+
+```bash
+# Validate Chart.yaml versions match and CHANGELOG.md has the right entry
+hack/validate-release.sh
+
+# Extract changelog notes for a specific version
+hack/extract-changelog.sh v1.5.2
+
+# Run all release script tests
+hack/test-release-scripts.sh
+```
+
+## Troubleshooting
+
+- **Release workflow fails with "Tag version does not match Chart.yaml version"**: The tag you pushed doesn't match the version in `Chart.yaml`. Ensure the version bump PR was merged before tagging.
+- **Release workflow fails with "No changelog entry found"**: Add a `## [vX.Y.Z]` section to `CHANGELOG.md` and merge it before tagging.
+- **`validate-release` CI check fails on a PR**: Either `version` and `appVersion` in `Chart.yaml` don't match, or `CHANGELOG.md` is missing an entry for the current chart version. Fix both before merging.

--- a/hack/extract-changelog.sh
+++ b/hack/extract-changelog.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# extract-changelog.sh - Extract release notes for a given version from CHANGELOG.md
+#
+# Usage: ./hack/extract-changelog.sh <version> [changelog-file]
+#   version:        Semver tag (e.g., v1.5.2)
+#   changelog-file: Path to CHANGELOG.md (default: CHANGELOG.md)
+#
+# Expects headings in Keep a Changelog format: ## [vX.Y.Z]
+# Exits non-zero if no section is found for the given version.
+set -euo pipefail
+
+VERSION="${1:?Usage: extract-changelog.sh <version> [changelog-file]}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+if [ ! -f "${CHANGELOG}" ]; then
+    echo "::error::Changelog file not found: ${CHANGELOG}" >&2
+    exit 1
+fi
+
+# Escape regex metacharacters in version string for safe awk matching
+ESCAPED_VERSION=$(printf '%s' "${VERSION}" | sed 's/[.[\(*^$+?{|\\]/\\&/g')
+
+NOTES=$(awk "/^## \\[${ESCAPED_VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" "${CHANGELOG}")
+
+# Trim leading/trailing blank lines (portable across macOS and Linux)
+NOTES=$(printf '%s' "${NOTES}" | awk 'NF{found=1} found' | awk '{lines[NR]=$0} END{if(NR>0){while(NR>0 && lines[NR]=="") NR--; for(i=1;i<=NR;i++) print lines[i]}}')
+
+if [ -z "${NOTES}" ]; then
+    echo "::error::No changelog entry found for ${VERSION} in ${CHANGELOG}" >&2
+    echo "Expected a heading matching: ## [${VERSION}]" >&2
+    exit 1
+fi
+
+echo "${NOTES}"

--- a/hack/test-release-scripts.sh
+++ b/hack/test-release-scripts.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# test-release-scripts.sh - Tests for extract-changelog.sh and validate-release.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMPDIR=$(mktemp -d)
+trap "rm -rf ${TMPDIR}" EXIT
+
+PASSED=0
+FAILED=0
+
+pass() { PASSED=$((PASSED + 1)); echo "  ✅ $1"; }
+fail() { FAILED=$((FAILED + 1)); echo "  ❌ $1"; }
+
+# ---------------------------------------------------------------------------
+# extract-changelog.sh tests
+# ---------------------------------------------------------------------------
+echo "Testing extract-changelog.sh"
+
+# Create a test changelog
+cat > "${TMPDIR}/CHANGELOG.md" <<'TESTEOF'
+# Changelog
+
+## [v1.6.0]
+
+### What's Changed
+- Added new feature X
+- Fixed bug Y
+
+## [v1.5.2]
+
+### What's Changed
+- Update base DCGM image to resolve CVEs
+
+## [v1.5.1]
+
+### What's Changed
+- Initial release
+
+[v1.6.0]: https://github.com/example/repo/compare/v1.5.2...v1.6.0
+[v1.5.2]: https://github.com/example/repo/compare/v1.5.1...v1.5.2
+TESTEOF
+
+# Test 1: Extract existing version
+OUTPUT=$("${SCRIPT_DIR}/extract-changelog.sh" "v1.5.2" "${TMPDIR}/CHANGELOG.md" 2>/dev/null)
+if echo "${OUTPUT}" | grep -q "Update base DCGM image"; then
+    pass "extracts notes for existing version"
+else
+    fail "extracts notes for existing version (got: ${OUTPUT})"
+fi
+
+# Test 2: Extract first version (no preceding section)
+OUTPUT=$("${SCRIPT_DIR}/extract-changelog.sh" "v1.6.0" "${TMPDIR}/CHANGELOG.md" 2>/dev/null)
+if echo "${OUTPUT}" | grep -q "Added new feature X"; then
+    pass "extracts notes for first version in file"
+else
+    fail "extracts notes for first version in file (got: ${OUTPUT})"
+fi
+
+# Test 3: Fail on missing version
+if "${SCRIPT_DIR}/extract-changelog.sh" "v9.9.9" "${TMPDIR}/CHANGELOG.md" > /dev/null 2>&1; then
+    fail "should fail for missing version"
+else
+    pass "fails for missing version"
+fi
+
+# Test 4: Fail on missing changelog file
+if "${SCRIPT_DIR}/extract-changelog.sh" "v1.5.2" "${TMPDIR}/nonexistent.md" > /dev/null 2>&1; then
+    fail "should fail for missing file"
+else
+    pass "fails for missing changelog file"
+fi
+
+# Test 5: Fail when no version argument given
+if "${SCRIPT_DIR}/extract-changelog.sh" 2>/dev/null; then
+    fail "should fail with no arguments"
+else
+    pass "fails with no arguments"
+fi
+
+# Test 6: Version with dots is matched literally (not as regex wildcards)
+cat > "${TMPDIR}/CHANGELOG-dots.md" <<'TESTEOF'
+# Changelog
+
+## [v1.5.2]
+
+### What's Changed
+- Real entry
+
+## [v1X5Y2]
+
+### What's Changed
+- Fake entry from regex wildcard match
+TESTEOF
+
+OUTPUT=$("${SCRIPT_DIR}/extract-changelog.sh" "v1.5.2" "${TMPDIR}/CHANGELOG-dots.md" 2>/dev/null)
+if echo "${OUTPUT}" | grep -q "Real entry" && ! echo "${OUTPUT}" | grep -q "Fake entry"; then
+    pass "dots in version are matched literally"
+else
+    fail "dots in version are matched literally (got: ${OUTPUT})"
+fi
+
+# ---------------------------------------------------------------------------
+# validate-release.sh tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "Testing validate-release.sh"
+
+# Test 7: Pass with matching versions and changelog entry
+cat > "${TMPDIR}/Chart.yaml" <<'TESTEOF'
+apiVersion: v2
+name: test-chart
+version: 1.5.2
+appVersion: 1.5.2
+TESTEOF
+
+if "${SCRIPT_DIR}/validate-release.sh" "${TMPDIR}/Chart.yaml" "${TMPDIR}/CHANGELOG.md" > /dev/null 2>&1; then
+    pass "passes with matching versions and changelog"
+else
+    fail "passes with matching versions and changelog"
+fi
+
+# Test 8: Fail when version and appVersion mismatch
+cat > "${TMPDIR}/Chart-mismatch.yaml" <<'TESTEOF'
+apiVersion: v2
+name: test-chart
+version: 1.5.2
+appVersion: 1.5.1
+TESTEOF
+
+if "${SCRIPT_DIR}/validate-release.sh" "${TMPDIR}/Chart-mismatch.yaml" "${TMPDIR}/CHANGELOG.md" > /dev/null 2>&1; then
+    fail "should fail when version != appVersion"
+else
+    pass "fails when version != appVersion"
+fi
+
+# Test 9: Fail when changelog entry is missing for chart version
+cat > "${TMPDIR}/Chart-new.yaml" <<'TESTEOF'
+apiVersion: v2
+name: test-chart
+version: 9.9.9
+appVersion: 9.9.9
+TESTEOF
+
+if "${SCRIPT_DIR}/validate-release.sh" "${TMPDIR}/Chart-new.yaml" "${TMPDIR}/CHANGELOG.md" > /dev/null 2>&1; then
+    fail "should fail when changelog entry missing"
+else
+    pass "fails when changelog entry missing for chart version"
+fi
+
+# ---------------------------------------------------------------------------
+# Validate against the real repo files
+# ---------------------------------------------------------------------------
+echo ""
+echo "Testing against actual repo files"
+
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REAL_CHART="${REPO_ROOT}/charts/eks-node-monitoring-agent/Chart.yaml"
+REAL_CHANGELOG="${REPO_ROOT}/CHANGELOG.md"
+
+if [ -f "${REAL_CHART}" ] && [ -f "${REAL_CHANGELOG}" ]; then
+    if "${SCRIPT_DIR}/validate-release.sh" "${REAL_CHART}" "${REAL_CHANGELOG}" > /dev/null 2>&1; then
+        pass "real Chart.yaml and CHANGELOG.md are in sync"
+    else
+        fail "real Chart.yaml and CHANGELOG.md are NOT in sync"
+    fi
+else
+    echo "  ⏩ Skipped (repo files not found)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+TOTAL=$((PASSED + FAILED))
+echo "Results: ${PASSED}/${TOTAL} passed, ${FAILED} failed"
+
+if [ "${FAILED}" -gt 0 ]; then
+    exit 1
+fi

--- a/hack/validate-release.sh
+++ b/hack/validate-release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# validate-release.sh - Validate that Chart.yaml version and appVersion match,
+# and that CHANGELOG.md has an entry for the current chart version.
+#
+# Usage: ./hack/validate-release.sh [chart-yaml] [changelog-file]
+#
+# This script is run in CI (pr-check) to catch issues before a release tag is pushed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CHART_YAML="${1:-${REPO_ROOT}/charts/eks-node-monitoring-agent/Chart.yaml}"
+CHANGELOG="${2:-${REPO_ROOT}/CHANGELOG.md}"
+
+ERRORS=0
+
+# Extract versions from Chart.yaml
+CHART_VERSION=$(grep '^version:' "${CHART_YAML}" | awk '{print $2}')
+APP_VERSION=$(grep '^appVersion:' "${CHART_YAML}" | awk '{print $2}')
+
+if [ -z "${CHART_VERSION}" ]; then
+    echo "::error::Could not read version from ${CHART_YAML}"
+    ERRORS=$((ERRORS + 1))
+fi
+
+if [ -z "${APP_VERSION}" ]; then
+    echo "::error::Could not read appVersion from ${CHART_YAML}"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# Validate version and appVersion match
+if [ "${CHART_VERSION}" != "${APP_VERSION}" ]; then
+    echo "::error::Chart.yaml version (${CHART_VERSION}) does not match appVersion (${APP_VERSION})"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "✅ Chart.yaml version and appVersion match: ${CHART_VERSION}"
+fi
+
+# Validate CHANGELOG.md has an entry for this version
+VERSION="v${CHART_VERSION}"
+if "${SCRIPT_DIR}/extract-changelog.sh" "${VERSION}" "${CHANGELOG}" > /dev/null 2>&1; then
+    echo "✅ CHANGELOG.md has entry for ${VERSION}"
+else
+    echo "::error::CHANGELOG.md is missing entry for ${VERSION}"
+    echo "   Expected a heading matching: ## [${VERSION}]"
+    ERRORS=$((ERRORS + 1))
+fi
+
+if [ "${ERRORS}" -gt 0 ]; then
+    echo ""
+    echo "❌ Release validation failed with ${ERRORS} error(s)"
+    exit 1
+fi
+
+echo ""
+echo "✅ Release validation passed"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that creates GitHub releases when a version tag (`v*`) is pushed
- Validates that the pushed tag matches both `version` and `appVersion` in `Chart.yaml`
- Extracts release notes from `CHANGELOG.md` automatically — **fails** if no entry is found (no silent fallback)
- Adds `validate-release` CI check on every PR to catch changelog/version drift early
- Includes 10 shell tests covering all release scripts
- Adds maintainer release documentation at `docs/releasing.md`
- Closes #46

## Changes
| File | Description |
|------|-------------|
| `.github/workflows/release.yaml` | Release workflow triggered on `v*` tag push |
| `.github/workflows/pr-check.yaml` | Added `validate-release` job to PR checks |
| `hack/extract-changelog.sh` | Extracts release notes for a version from `CHANGELOG.md` |
| `hack/validate-release.sh` | Validates `Chart.yaml` versions match and changelog entry exists |
| `hack/test-release-scripts.sh` | 10 tests for the release scripts |
| `docs/releasing.md` | Release process documentation for maintainers |

## How it works

### On every PR (`pr-check.yaml`):
`validate-release.sh` verifies:
1. `Chart.yaml` `version` and `appVersion` match
2. `CHANGELOG.md` has a `## [vX.Y.Z]` entry for the current chart version

This prevents merging PRs that would break the release workflow.

### On tag push (`release.yaml`):
1. Validates tag matches both `version` and `appVersion` in `Chart.yaml`
2. `extract-changelog.sh` extracts release notes from `CHANGELOG.md` (fails if missing — no silent fallback to generic notes)
3. Creates a GitHub release via `gh release create`

### Release process for maintainers:
1. In a PR: bump `Chart.yaml` version/appVersion, add `CHANGELOG.md` entry
2. Merge to `main`
3. Tag and push: `git tag -a v1.6.0 -m "Release v1.6.0" && git push origin v1.6.0`
4. Workflow creates the GitHub release automatically

See `docs/releasing.md` for full details.

## Test plan
- [x] YAML syntax validated for both workflow files
- [x] `hack/test-release-scripts.sh` — 10/10 tests pass:
  - Extracts notes for existing versions
  - Fails for missing versions (no silent fallback)
  - Fails for missing changelog file
  - Fails with no arguments
  - Dots in versions matched literally (not as regex wildcards)
  - Passes with matching Chart.yaml versions and changelog
  - Fails when version != appVersion
  - Fails when changelog entry missing
  - Real repo `Chart.yaml` and `CHANGELOG.md` are in sync
- [x] Workflow only runs on `aws/eks-node-monitoring-agent` (not forks)
- [ ] Test with a tag push on the upstream repo after merge