### PR TITLE
Add example for overriding ports in configuration

### DIFF
--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters for this chart and their d
 | global.podLabels | object | `{}` | Labels applied to eks-node-monitoring-agent and dcgm-exporter (can be overridden by component-specific labels) |
 | imagePullSecrets | list | `[]` | Docker registry pull secrets |
 | nameOverride | string | `"eks-node-monitoring-agent"` | A name override for the chart |
-| nodeAgent.additionalArgs | list | `[]` | List of addittional container arguments for the eks-node-monitoring-agent |
+| nodeAgent.additionalArgs | list | `[]` | List of additional container arguments for the eks-node-monitoring-agent. The agent binds to ports 8002 (health probe) and 8080 (metrics) on the host network by default. To avoid port conflicts, override with:   additionalArgs:     - "--probe-address=:8002"     - "--metrics-address=:8003" |
 | nodeAgent.affinity | object | see [`values.yaml`](./values.yaml) | Map of pod affinities for the eks-node-monitoring-agent |
 | nodeAgent.image.account | string | `"602401143452"` | ECR repository account number for the eks-node-monitoring-agent |
 | nodeAgent.image.containerRegistry | string | `""` | Full container registry URL override (e.g., 602401143452.dkr.ecr.us-west-2.amazonaws.com). When set, this takes precedence over account/endpoint/region/domain fields. |

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -42,7 +42,12 @@ nodeAgent:
     account: "602401143452"
     # -- Container pull policyfor the eks-node-monitoring-agent
     pullPolicy: IfNotPresent
-  # -- List of addittional container arguments for the eks-node-monitoring-agent
+  # -- List of additional container arguments for the eks-node-monitoring-agent.
+  # The agent binds to ports 8002 (health probe) and 8080 (metrics) on the host
+  # network by default. To avoid port conflicts, override with:
+  #   additionalArgs:
+  #     - "--probe-address=:8002"
+  #     - "--metrics-address=:8003"
   additionalArgs: []
   # -- Map of pod affinities for the eks-node-monitoring-agent
   affinity:


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Adds an example to allow setting the ports for metrics server and probe server. Closing out https://github.com/aws/containers-roadmap/issues/2521

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
