### PR TITLE
feat: add ZRAM usage monitoring to kernel monitor

### DIFF
--- a/monitors/kernel/monitor.go
+++ b/monitors/kernel/monitor.go
@@ -64,6 +64,7 @@ func (m *KernelMonitor) Register(ctx context.Context, mgr monitor.Manager) error
 		util.NewChannelHandler(func(time.Time) error { return m.handleZombies() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
 		util.NewChannelHandler(func(time.Time) error { return m.handleOpenedFiles() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
 		util.NewChannelHandler(func(time.Time) error { return m.handleEnvironment() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
+		util.NewChannelHandler(func(time.Time) error { return m.handleZram() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
 	} {
 		go handler.Start(ctx)
 	}
@@ -348,4 +349,62 @@ func (k *KernelMonitor) checkEnvironment(envBytes []byte, pid int) error {
 		)
 	}
 	return nil
+}
+
+// ~~~~ zram ~~~~
+
+func (k *KernelMonitor) handleZram() error {
+	zramDirs, err := filepath.Glob(config.ToHostPath("/sys/block/zram*"))
+	if err != nil {
+		return err
+	}
+	if len(zramDirs) == 0 {
+		k.logger.V(1).Info("ZRAM devices not found on this node")
+		return nil
+	}
+	for _, dir := range zramDirs {
+		deviceName := filepath.Base(dir)
+		mmStatData, err := os.ReadFile(filepath.Join(dir, "mm_stat"))
+		if err != nil {
+			k.logger.V(1).Info("failed to read ZRAM mm_stat", "device", deviceName, "error", err)
+			continue
+		}
+		fields := strings.Fields(string(mmStatData))
+		// mm_stat format: orig_data_size compr_data_size mem_used_total ...
+		// We need at least the first 2 fields
+		if len(fields) < 2 {
+			k.logger.V(1).Info("invalid ZRAM mm_stat format", "device", deviceName, "fields", len(fields))
+			continue
+		}
+		origSize, _ := strconv.ParseInt(fields[0], 10, 64)
+		compSize, _ := strconv.ParseInt(fields[1], 10, 64)
+		if origSize == 0 {
+			continue
+		}
+		disksizeData, err := os.ReadFile(filepath.Join(dir, "disksize"))
+		if err != nil {
+			continue
+		}
+		disksize, _ := strconv.ParseInt(strings.TrimSpace(string(disksizeData)), 10, 64)
+		if err := k.checkZram(origSize, compSize, disksize, deviceName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k *KernelMonitor) checkZram(origSize, compSize, disksize int64, deviceName string) error {
+	if disksize == 0 {
+		return nil
+	}
+	usagePercent := float64(origSize) / float64(disksize)
+	if usagePercent > 0.10 {
+		return k.manager.Notify(context.Background(), monitor.Condition{
+			Reason:   "ZramHighUsage",
+			Message:  fmt.Sprintf("ZRAM device %s at %.1f%% capacity", deviceName, usagePercent*100),
+			Severity: monitor.SeverityWarning,
+		})
+	}
+	return nil
+
 }

--- a/monitors/kernel/monitor_test.go
+++ b/monitors/kernel/monitor_test.go
@@ -289,4 +289,51 @@ func TestKernelPeriodic(t *testing.T) {
 		}
 		assert.Equal(t, 0, len(mockManager.res))
 	})
+
+	t.Run("ZramHighUsageNoop", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		mon := &KernelMonitor{}
+		mockManager := &mockManager{res: make(chan monitor.Condition, 5)}
+		mon.Register(ctx, mockManager)
+
+		if err := mon.checkZram(10*1024*1024, 5*1024*1024, 1024*1024*1024, "zram0"); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, 0, len(mockManager.res))
+
+		if err := mon.checkZram(50*1024*1024, 25*1024*1024, 1024*1024*1024, "zram1"); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, 0, len(mockManager.res))
+
+		if err := mon.checkZram(99*1024*1024, 50*1024*1024, 1000*1024*1024, "zram2"); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, 0, len(mockManager.res))
+	})
+
+	t.Run("ZramHighUsageWarning", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		mon := &KernelMonitor{}
+		mockManager := &mockManager{res: make(chan monitor.Condition, 5)}
+		mon.Register(ctx, mockManager)
+		// 15% usage - above 10% threshold
+		origSize := int64(150 * 1024 * 1024)
+		compSize := int64(75 * 1024 * 1024)
+		diskSize := int64(1024 * 1024 * 1024)
+		if err := mon.checkZram(origSize, compSize, diskSize, "zram0"); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case monitorResult := <-mockManager.res:
+			assert.Equal(t, monitor.SeverityWarning, monitorResult.Severity)
+			assert.Equal(t, "ZramHighUsage", monitorResult.Reason)
+			assert.Contains(t, monitorResult.Message, "zram0")
+			assert.Contains(t, monitorResult.Message, "capacity")
+		}
+	})
 }


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Adds ZRAM usage monitoring to the kernel monitor. The agent now periodically (every 5 minutes) checks ZRAM compressed RAM devices by reading /sys/block/zram*/mm_stat and disksize. When a ZRAM device's usage exceeds 10% of its disk capacity, a ZramHighUsage warning condition is reported.

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
