### PR TITLE
Add `-o short-iso-precise` to all journalctl invocations

### DIFF
--- a/pkg/diagnostic/logger.go
+++ b/pkg/diagnostic/logger.go
@@ -122,7 +122,7 @@ func systemdStatus(services ...string) []byte {
 }
 
 func journalctl(unit string) []byte {
-	if out, err := exec.Command("journalctl", "--unit", unit).Output(); err != nil {
+	if out, err := exec.Command("journalctl", "-o", "short-iso-precise", "--unit", unit).Output(); err != nil {
 		return []byte(fmt.Sprintf("failed to call journalctl due to: %s", err))
 	} else {
 		return out

--- a/pkg/log_collector/collect/automode.go
+++ b/pkg/log_collector/collect/automode.go
@@ -14,12 +14,12 @@ func (c *AutoMode) Collect(acc *Accessor) error {
 		return nil
 	}
 	return errors.Join(
-		acc.CommandOutput([]string{"journalctl", "-u", "eks-healthchecker"}, "automode/eks-healthchecker.txt", CommandOptionsNone),
-		acc.CommandOutput([]string{"journalctl", "-u", "kube-proxy"}, "automode/kube-proxy.txt", CommandOptionsNone),
-		acc.CommandOutput([]string{"journalctl", "-u", "coredns-bootstrap"}, "automode/coredns-boostrap.txt", CommandOptionsNone),
-		acc.CommandOutput([]string{"journalctl", "-u", "coredns"}, "automode/coredns.txt", CommandOptionsNone),
-		acc.CommandOutput([]string{"journalctl", "-u", "eks-ebs-csi-driver"}, "automode/eks-ebs-csi-driver.txt", CommandOptionsNone),
-		acc.CommandOutput([]string{"journalctl", "-u", "eks-node-monitoring-agent"}, "automode/eks-node-monitoring-agent.txt", CommandOptionsNone),
-		acc.CommandOutput([]string{"journalctl", "-u", "eks-pod-identity-agent"}, "automode/eks-pod-identity-agent.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "eks-healthchecker"}, "automode/eks-healthchecker.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "kube-proxy"}, "automode/kube-proxy.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "coredns-bootstrap"}, "automode/coredns-boostrap.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "coredns"}, "automode/coredns.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "eks-ebs-csi-driver"}, "automode/eks-ebs-csi-driver.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "eks-node-monitoring-agent"}, "automode/eks-node-monitoring-agent.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "eks-pod-identity-agent"}, "automode/eks-pod-identity-agent.txt", CommandOptionsNone),
 	)
 }

--- a/pkg/log_collector/collect/containerd.go
+++ b/pkg/log_collector/collect/containerd.go
@@ -13,7 +13,7 @@ func (c *Containerd) Collect(acc *Accessor) error {
 	return errors.Join(
 		ctrdlogs(acc),
 		acc.CommandOutput([]string{"containerd", "config", "dump"}, "containerd/containerd-config.txt", CommandOptionsNone),
-		acc.CommandOutput([]string{"journalctl", "-u", "containerd"}, "containerd/containerd-log.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "containerd"}, "containerd/containerd-log.txt", CommandOptionsNone),
 		acc.CommandOutput([]string{"ctr", "version"}, "containerd/containerd-version.txt", CommandOptionsNone),
 		acc.CommandOutput([]string{"ctr", "namespaces", "list"}, "containerd/containerd-namespaces.txt", CommandOptionsNone),
 		acc.CommandOutput([]string{"ctr", "--namespace", "k8s.io", "images", "list"}, "containerd/containerd-images.txt", CommandOptionsNone),

--- a/pkg/log_collector/collect/kubernetes.go
+++ b/pkg/log_collector/collect/kubernetes.go
@@ -17,7 +17,7 @@ func (m Kubernetes) Collect(acc *Accessor) error {
 }
 
 func kubelet(acc *Accessor) error {
-	var merr = acc.CommandOutput([]string{"journalctl", "-u", "kubelet", "--since", "10 days ago"}, "kubelet/kubelet.log", CommandOptionsNone)
+	var merr = acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "kubelet", "--since", "10 days ago"}, "kubelet/kubelet.log", CommandOptionsNone)
 
 	// TODO: determine the source of the 'Access Denied' error that returns when
 	// calling systemctl.

--- a/pkg/log_collector/collect/networking.go
+++ b/pkg/log_collector/collect/networking.go
@@ -59,7 +59,7 @@ func ipInfo(acc *Accessor) error {
 }
 
 func multicard(acc *Accessor) error {
-	return acc.CommandOutput([]string{"journalctl", "-u", "configure-multicard-interfaces"}, "networking/configure-multicard-interfaces.txt", CommandOptionsNone)
+	return acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "configure-multicard-interfaces"}, "networking/configure-multicard-interfaces.txt", CommandOptionsNone)
 }
 
 func interfaces(acc *Accessor) error {

--- a/pkg/log_collector/collect/nodeadm.go
+++ b/pkg/log_collector/collect/nodeadm.go
@@ -6,7 +6,7 @@ type Nodeadm struct{}
 
 func (m Nodeadm) Collect(acc *Accessor) error {
 	return errors.Join(
-		acc.CommandOutput([]string{"journalctl", "-u", "nodeadm-config"}, "nodeadm/nodeadm-config.log", CommandOptionsNone),
-		acc.CommandOutput([]string{"journalctl", "-u", "nodeadm-run"}, "nodeadm/nodeadm-run.log", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "nodeadm-config"}, "nodeadm/nodeadm-config.log", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "nodeadm-run"}, "nodeadm/nodeadm-run.log", CommandOptionsNone),
 	)
 }

--- a/pkg/log_collector/collect/sandbox.go
+++ b/pkg/log_collector/collect/sandbox.go
@@ -7,6 +7,6 @@ type Sandbox struct{}
 func (m Sandbox) Collect(acc *Accessor) error {
 	return errors.Join(
 		// TODO: Only applicable on AL2. Remove after EoL
-		acc.CommandOutput([]string{"journalctl", "-u", "sandbox-image"}, "sandbox-image/sandbox-image-log.txt", CommandOptionsNone),
+		acc.CommandOutput([]string{"journalctl", "-o", "short-iso-precise", "-u", "sandbox-image"}, "sandbox-image/sandbox-image-log.txt", CommandOptionsNone),
 	)
 }


### PR DESCRIPTION
**Issue #, if available**:

#98 

**Description of changes**:

Nodes may operate in different timezones, making it difficult to correlate log entries when timestamps lack timezone information. Add `-o short-iso-precise` to all journalctl calls to produce full ISO 8601 timestamps with timezone offset and microsecond precision.

Reference:
* https://www.freedesktop.org/software/systemd/man/latest/journalctl.html

Cross-reference:
* https://github.com/awslabs/amazon-eks-ami/pull/2151

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.