### PR TITLE
Make probe and affinities configurable

### DIFF
--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -24,6 +24,10 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "affinity": {
+                    "type": "object",
+                    "description": "Map of pod affinities for the eks-node-monitoring-agent"
+                },
                 "additionalArgs": {
                     "type": "array",
                     "description": "Additional arguments passed to the eks node monitoring agent pod",
@@ -41,6 +45,11 @@
                     "$ref": "#/definitions/StringMap",
                     "description": "Labels applied to the eks node monitoring agent pod. These labels are merged with any global pod labels, with component specific labels taking precedence in the case of a conflict.",
                     "default": {}
+                },
+                "probePort": {
+                    "type": "integer",
+                    "description": "Health probe port for the eks node monitoring agent. Used for both the --probe-address arg and the liveness probe.",
+                    "default": 8002
                 },
                 "resources": {
                     "$ref": "#/definitions/Resources"
@@ -83,6 +92,10 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "affinity": {
+                    "type": "object",
+                    "description": "Map of dcgm pod affinities"
+                },
                 "podAnnotations": {
                     "$ref": "#/definitions/StringMap",
                     "description": "Annotations applied to the eks node monitoring agent pod. These annotations are merged with any global pod annotations, with component specific annotations taking precedence in the case of a conflict.",

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -55,12 +55,13 @@ The following table lists the configurable parameters for this chart and their d
 | global.podLabels | object | `{}` | Labels applied to eks-node-monitoring-agent and dcgm-exporter (can be overridden by component-specific labels) |
 | imagePullSecrets | list | `[]` | Docker registry pull secrets |
 | nameOverride | string | `"eks-node-monitoring-agent"` | A name override for the chart |
-| nodeAgent.additionalArgs | list | `[]` | List of additional container arguments for the eks-node-monitoring-agent. The agent binds to ports 8002 (health probe) and 8080 (metrics) on the host network by default. To avoid port conflicts, override with:   additionalArgs:     - "--probe-address=:8002"     - "--metrics-address=:8003" |
 | nodeAgent.affinity | object | see [`values.yaml`](./values.yaml) | Map of pod affinities for the eks-node-monitoring-agent |
 | nodeAgent.image.account | string | `"602401143452"` | ECR repository account number for the eks-node-monitoring-agent |
+| nodeAgent.image.additionalArgs | list | `["--metrics-address=:8003"]` | List of additional container arguments for the eks-node-monitoring-agent |
 | nodeAgent.image.containerRegistry | string | `""` | Full container registry URL override (e.g., 602401143452.dkr.ecr.us-west-2.amazonaws.com). When set, this takes precedence over account/endpoint/region/domain fields. |
 | nodeAgent.image.domain | string | `"amazonaws.com"` | ECR repository domain for the eks-node-monitoring-agent |
 | nodeAgent.image.endpoint | string | `"ecr"` | ECR repository endpoint for the eks-node-monitoring-agent |
+| nodeAgent.image.probePort | int | `8002` | Health probe port for the eks-node-monitoring-agent. Used for both the --probe-address arg and the liveness probe. |
 | nodeAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policyfor the eks-node-monitoring-agent |
 | nodeAgent.image.region | string | `"us-west-2"` | ECR repository region for the eks-node-monitoring-agent |
 | nodeAgent.image.tag | string | `"v1.6.1-eksbuild.1"` | Image tag for the eks-node-monitoring-agent |

--- a/charts/eks-node-monitoring-agent/templates/daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/daemonset.yaml
@@ -49,8 +49,7 @@ spec:
           image: {{ template "eks-node-monitoring-agent.image" . }}
           imagePullPolicy: {{ .Values.nodeAgent.image.pullPolicy }}
           args:
-            - --probe-address=:8002
-            - --metrics-address=:8003
+            - --probe-address=:{{ .Values.nodeAgent.probePort | default 8002 }}
             {{- with .Values.nodeAgent.additionalArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -64,7 +63,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8002
+              port: {{ .Values.nodeAgent.probePort | default 8002 }}
           {{- with .Values.nodeAgent.resizePolicy }}
           resizePolicy:
             {{- toYaml . | nindent 12 }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -42,13 +42,12 @@ nodeAgent:
     account: "602401143452"
     # -- Container pull policyfor the eks-node-monitoring-agent
     pullPolicy: IfNotPresent
-  # -- List of additional container arguments for the eks-node-monitoring-agent.
-  # The agent binds to ports 8002 (health probe) and 8080 (metrics) on the host
-  # network by default. To avoid port conflicts, override with:
-  #   additionalArgs:
-  #     - "--probe-address=:8002"
-  #     - "--metrics-address=:8003"
-  additionalArgs: []
+    # -- Health probe port for the eks-node-monitoring-agent.
+    # Used for both the --probe-address arg and the liveness probe.
+    probePort: 8002
+    # -- List of additional container arguments for the eks-node-monitoring-agent
+    additionalArgs:
+      - "--metrics-address=:8003"
   # -- Map of pod affinities for the eks-node-monitoring-agent
   affinity:
     nodeAffinity:

--- a/e2e/setup/manifests/agent.tpl.yaml
+++ b/e2e/setup/manifests/agent.tpl.yaml
@@ -315,7 +315,6 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --probe-address=:8002
-            - --metrics-address=:8003
           env:
             - name: HOST_ROOT
               value: /host

--- a/e2e/suites/addon/configuration_values.json
+++ b/e2e/suites/addon/configuration_values.json
@@ -1,26 +1,16 @@
 {
     "nodeAgent": {
+        "probePort": 9002,
+        "additionalArgs": ["--metrics-address=:9003"],
         "resources": {
-            "limits": {
-                "memory": "999Mi",
-                "cpu": "999m"
-            },
-            "requests": {
-                "memory": "999Mi",
-                "cpu": "999m"
-            }
+            "limits": { "memory": "999Mi", "cpu": "999m" },
+            "requests": { "memory": "999Mi", "cpu": "999m" }
         }
     },
     "dcgmAgent": {
         "resources": {
-            "limits": {
-                "memory": "999Mi",
-                "cpu": "999m"
-            },
-            "requests": {
-                "memory": "999Mi",
-                "cpu": "999m"
-            }
+            "limits": { "memory": "999Mi", "cpu": "999m" },
+            "requests": { "memory": "999Mi", "cpu": "999m" }
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Allow configurations via addon and values on probe ports and affinities

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
