### PR TITLE
fix: CI runs only in parent repo

### DIFF
--- a/.github/workflows/bot-trigger.yaml
+++ b/.github/workflows/bot-trigger.yaml
@@ -6,7 +6,7 @@ on:
       - created
 jobs:
   bot:
-    if: ${{ github.event.issue.pull_request }}
+    if: ${{ github.repository == 'aws/eks-node-monitoring-agent' && github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions: write-all
     steps:

--- a/.github/workflows/bump-dcgm-exporter.yaml
+++ b/.github/workflows/bump-dcgm-exporter.yaml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   bump-dcgm-exporter:
+    if: ${{ github.repository == 'aws/eks-node-monitoring-agent' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   kubetest2-sweeper:
+    if: ${{ github.repository == 'aws/eks-node-monitoring-agent' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Adds repository checks so that CI only runs in parent repository and not in forks.

See: https://github.com/prasad0896/eks-node-monitoring-agent/actions/runs/24210669552

**Testing Done**:
No more CI in fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
