### PR TITLE
feat(nvidia): Add fabric manager detection

### DIFF
--- a/docs/node-health-issues.adoc
+++ b/docs/node-health-issues.adoc
@@ -41,6 +41,10 @@ If auto repair is enabled, the repair actions that are listed start 10 minutes a
 |Condition
 |A DCGM health check failed in a fatal manner.
 
+|FabricManagerNotRunning
+|Condition
+|The NVIDIA Fabric Manager service is not running on this NVSwitch-equipped instance. Fabric Manager is required for multi-GPU NVLink communication. Without it, multi-GPU workloads will fail or silently degrade.
+
 |NeuronDMAError
 |Condition
 |A DMA engine encountered an unrecoverable error.
@@ -64,6 +68,10 @@ If auto repair is enabled, the repair actions that are listed start 10 minutes a
 |NvidiaDoubleBitError
 |Condition
 |A double bit error was produced by the GPU driver.
+
+|NvidiaFabricError
+|Condition
+|One or more GPUs reported a non-success fabric status, indicating NVSwitch fabric training failure. Affected GPUs cannot participate in multi-GPU NVLink communication. This condition persists across reboots and requires instance replacement.
 
 |NvidiaNCCLError
 |Event

--- a/monitors/nvidia/dcgm/dcgm_client.go
+++ b/monitors/nvidia/dcgm/dcgm_client.go
@@ -192,6 +192,9 @@ func (d *dcgmHelper) Reconcile(ctx context.Context) (bool, error) {
 			// SXID errors caused by the NVSwitch.
 			dcgmapi.DCGM_FI_DEV_NVSWITCH_FATAL_ERRORS,
 			dcgmapi.DCGM_FI_DEV_NVSWITCH_NON_FATAL_ERRORS,
+			// Fabric Manager status and GPU fabric health for NVSwitch instances.
+			dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS,
+			dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK,
 		})
 		if err != nil {
 			return false, err

--- a/monitors/nvidia/dcgm/dcgm_watchfield.go
+++ b/monitors/nvidia/dcgm/dcgm_watchfield.go
@@ -35,6 +35,16 @@ func (s *DCGMSystem) WatchFields(ctx context.Context) ([]monitor.Condition, erro
 		if fieldValue.Status == dcgmapi.DCGM_ST_OK || fieldValue.Status == dcgmapi.DCGM_ST_NO_DATA {
 			continue
 		}
+
+		// Fabric fields emit their own condition types and may suppress emission
+		// for healthy/unsupported states, so they are handled separately.
+		if c, handled := handleFabricField(fieldValue); handled {
+			if c != nil {
+				conditions = append(conditions, *c)
+			}
+			continue
+		}
+
 		conditionMessage := fmt.Sprintf("DCGM detected fieldID %d with statusCode %d", fieldValue.FieldID, fieldValue.Status)
 
 		fieldValueMapper, ok := fieldValueMappers[fieldValue.FieldID]
@@ -59,6 +69,46 @@ func (s *DCGMSystem) WatchFields(ctx context.Context) ([]monitor.Condition, erro
 	return conditions, nil
 }
 
+// handleFabricField checks whether the field is a fabric-related field and
+// returns the appropriate condition. Returns (nil, true) when the field is
+// recognized but healthy, and (*condition, true) when unhealthy. Returns
+// (nil, false) when the field is not a fabric field.
+func handleFabricField(fv dcgmapi.FieldValue_v2) (*monitor.Condition, bool) {
+	switch fv.FieldID {
+	case dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS:
+		status := fv.Int64()
+		// NotSupported: FM not applicable (e.g. single-GPU, or rack-level NVSwitch like GB200/GB300).
+		// NotStarted: FM hasn't started yet; skipped to avoid false positives on instances
+		// where FM is not needed but DCGM doesn't report NotSupported (e.g. GB200/GB300).
+		// InProgress: FM is still performing fabric training during boot.
+		// Success: FM is running and healthy.
+		if status == DcgmFMStatusSuccess || status == DcgmFMStatusNotSupported ||
+			status == DcgmFMStatusInProgress || status == DcgmFMStatusNotStarted {
+			return nil, true
+		}
+		name := fabricManagerStatusNames[status]
+		if name == "" {
+			name = fmt.Sprintf("Unknown(%d)", status)
+		}
+		c := reasons.FabricManagerNotRunning.
+			Builder().
+			Message(fmt.Sprintf("Fabric Manager status: %s", name)).
+			Build()
+		return &c, true
+	case dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK:
+		if fv.Int64() == 0 {
+			return nil, true
+		}
+		c := reasons.NvidiaFabricError.
+			Builder().
+			Message(fmt.Sprintf("GPU fabric health mask: 0x%x", fv.Int64())).
+			Build()
+		return &c, true
+	default:
+		return nil, false
+	}
+}
+
 // ref: https://github.com/NVIDIA/DCGM/blob/6e947dcac9b3160d61d98fea4741d51d4bec5c1f/dcgmlib/dcgm_fields.h#L99-L103
 const (
 	// Nothing is running on the GPU and the clocks are dropping to Idle state
@@ -81,6 +131,14 @@ const (
 	DCGM_CLOCKS_THROTTLE_REASON_DISPLAY_CLOCKS int64 = 0x0000000000000100
 )
 
+// Fabric Manager status values from dcgmFabricManagerStatus_t (dcgm_structs.h).
+const (
+	DcgmFMStatusNotSupported int64 = 0
+	DcgmFMStatusNotStarted   int64 = 1
+	DcgmFMStatusInProgress   int64 = 2
+	DcgmFMStatusSuccess      int64 = 3
+)
+
 var clockThrottleReasons = map[int64]string{
 	DCGM_CLOCKS_THROTTLE_REASON_GPU_IDLE:       "gpu_idle",
 	DCGM_CLOCKS_THROTTLE_REASON_CLOCKS_SETTING: "clocks_setting",
@@ -91,6 +149,16 @@ var clockThrottleReasons = map[int64]string{
 	DCGM_CLOCKS_THROTTLE_REASON_HW_THERMAL:     "hw_thermal",
 	DCGM_CLOCKS_THROTTLE_REASON_HW_POWER_BRAKE: "hw_power_brake",
 	DCGM_CLOCKS_THROTTLE_REASON_DISPLAY_CLOCKS: "display_clocks",
+}
+
+var fabricManagerStatusNames = map[int64]string{
+	0: "NotSupported",
+	1: "NotStarted",
+	2: "InProgress",
+	3: "Success",
+	4: "Failure",
+	5: "Unrecognized",
+	6: "NvmlTooOld",
 }
 
 var fieldValueMappers = map[dcgmapi.Short]func(dcgmapi.FieldValue_v2) (bool, string){

--- a/monitors/nvidia/dcgm/dcgm_watchfield_test.go
+++ b/monitors/nvidia/dcgm/dcgm_watchfield_test.go
@@ -64,6 +64,91 @@ func TestFields(t *testing.T) {
 		assert.Empty(t, conditions)
 	})
 
+	t.Run("FabricManagerStatusSuccess", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
+		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 3) // DcgmFMStatusSuccess
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
+	t.Run("FabricManagerStatusNotSupported", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
+		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0) // DcgmFMStatusNotSupported
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
+	t.Run("FabricManagerStatusInProgress", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
+		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 2) // DcgmFMStatusInProgress
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
+	t.Run("FabricManagerStatusFailure", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
+		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 4) // DcgmFMStatusFailure
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []monitor.Condition{{
+			Reason:   "FabricManagerNotRunning",
+			Message:  "Fabric Manager status: Failure",
+			Severity: monitor.SeverityFatal,
+		}}, conditions)
+	})
+
+	t.Run("FabricManagerStatusNotStarted", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
+		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 1) // DcgmFMStatusNotStarted
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
+	t.Run("FabricHealthMaskFailure", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK}
+		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 1) // non-zero = failure
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []monitor.Condition{{
+			Reason:   "NvidiaFabricError",
+			Message:  "GPU fabric health mask: 0x1",
+			Severity: monitor.SeverityFatal,
+		}}, conditions)
+	})
+
+	t.Run("FabricHealthMaskHealthy", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK}
+		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0) // zero = healthy
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
 	t.Run("GetResultForBadStatus", func(t *testing.T) {
 		for _, test := range []struct {
 			fieldValue      dcgmapi.FieldValue_v2

--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -24,6 +24,10 @@ var (
         template:        "DCGMHealthCode%d",
         defaultSeverity: "Fatal",
     }
+    FabricManagerNotRunning = ReasonMeta{
+        template:        "FabricManagerNotRunning",
+        defaultSeverity: "Fatal",
+    }
     NeuronDMAError = ReasonMeta{
         template:        "NeuronDMAError",
         defaultSeverity: "Fatal",
@@ -46,6 +50,10 @@ var (
     }
     NvidiaDoubleBitError = ReasonMeta{
         template:        "NvidiaDoubleBitError",
+        defaultSeverity: "Fatal",
+    }
+    NvidiaFabricError = ReasonMeta{
+        template:        "NvidiaFabricError",
         defaultSeverity: "Fatal",
     }
     NvidiaNCCLError = ReasonMeta{

--- a/pkg/reasons/reasons.yaml
+++ b/pkg/reasons/reasons.yaml
@@ -322,6 +322,21 @@ AcceleratedHardwareReady:
     DefaultSeverity: 'Warning'
     Description: >-
       A non-critical GPU error occurred.
+  FabricManagerNotRunning:
+    Template: 'FabricManagerNotRunning'
+    DefaultSeverity: 'Fatal'
+    Description: >-
+      The NVIDIA Fabric Manager service is not running on this NVSwitch-equipped
+      instance. Fabric Manager is required for multi-GPU NVLink communication.
+      Without it, multi-GPU workloads will fail or silently degrade.
+  NvidiaFabricError:
+    Template: 'NvidiaFabricError'
+    DefaultSeverity: 'Fatal'
+    Description: >-
+      One or more GPUs reported a non-success fabric status, indicating NVSwitch
+      fabric training failure. Affected GPUs cannot participate in multi-GPU
+      NVLink communication. This condition persists across reboots and requires
+      instance replacement.
   NeuronDMAError:
     Template: 'NeuronDMAError'
     DefaultSeverity: 'Fatal'


### PR DESCRIPTION
**Issue #, if available**:
#141 

**Description of changes**:
Add support for fabric manager detection in NMA

### Files Changed

| File | Change |
|------|--------|
| `monitors/nvidia/dcgm/dcgm_client.go` | Add fields 170, 174 to `FieldGroupCreate` |
| `monitors/nvidia/dcgm/dcgm_watchfield.go` | Add `handleFabricField()` with handlers for both fields |
| `monitors/nvidia/dcgm/dcgm_watchfield_test.go` | 7 new test cases covering all FM status values and health mask |
| `pkg/reasons/reasons.yaml` | Add `FabricManagerNotRunning` and `NvidiaFabricError` |
| `pkg/reasons/reasons.go` | Auto-generated via `make generate` |
| `docs/node-health-issues.adoc` | Auto-generated via `make generate` |

### Behavior Matrix — Field 170 (Fabric Manager Status)

| Status Value | Name | Action |
|-------------|------|--------|
| 0 | NotSupported | Skip (not an NVSwitch instance) |
| 1 | NotStarted | Skip (not an NVSwitch instance) |
| 2 | InProgress | Skip (boot-time training) |
| 3 | Success | Healthy, no condition |
| 4 | Failure | Emit `FabricManagerNotRunning` Fatal |
| 5 | Unrecognized | Emit `FabricManagerNotRunning` Fatal |
| 6 | NvmlTooOld | Emit `FabricManagerNotRunning` Fatal |

### Behavior — Field 174 (Fabric Health Mask)

| Value | Action |
|-------|--------|
| 0 | Healthy, no condition |
| Non-zero | Emit `NvidiaFabricError` Fatal |

**Testing Done**:

### Unit Tests (implemented)

7 test cases in `dcgm_watchfield_test.go`:
- FM status: Success, NotSupported, NotStarted, InProgress → no condition
- FM status: Failure → `FabricManagerNotRunning` Fatal
- Health mask: zero → no condition
- Health mask: non-zero → `NvidiaFabricError` Fatal

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
