### PR TITLE
fix: Bump go version to fix CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN dnf install -y dnf-plugins-core && \
 # =============================================================================
 # Stage 3: Go builder to compile the application
 # =============================================================================
-FROM public.ecr.aws/docker/library/golang:1.26.1 AS go-builder
+FROM public.ecr.aws/docker/library/golang:1.26.2 AS go-builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Fix failing CI with error:
```
#11 16.51   systemd-libs-252.23-11.amzn2023.x86_64                                        
#11 16.51 
#11 16.51 Complete!
#11 CANCELED

#10 [systemd-builder 2/2] RUN dnf install -y systemd-devel &&     dnf clean all
#10 15.63 Last metadata expiration check: 0:00:15 ago on Thu Apr 16 16:01:13 2026.
#10 16.55 Dependencies resolved.
#10 CANCELED
------
 > [go-builder 5/8] RUN GOPROXY=direct go mod download:
0.074 go: go.mod requires go >= 1.26.2 (running go 1.26.1; GOTOOLCHAIN=local)
------
Dockerfile:39
--------------------
  37 |     # Cache Go module dependencies
  38 |     COPY go.mod go.sum ./
  39 | >>> RUN GOPROXY=direct go mod download
  40 |     
  41 |     # Copy source code
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c GOPROXY=direct go mod download" did not complete successfully: exit code: 1
make: *** [Makefile:227: docker-build] Error 1

```

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
