### PR TITLE
chore: Refine nvidia e2e test execution

### DIFF
--- a/e2e/suites/monitors/nvidia_monitor.go
+++ b/e2e/suites/monitors/nvidia_monitor.go
@@ -23,6 +23,11 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/types"
 )
 
+const (
+	computeTypeLabelKey = "eks.amazonaws.com/compute-type"
+	computeTypeAuto = "auto"
+)
+
 func NvidiaMonitor(awsCfg aws.Config) types.Feature {
 	var targetNode *corev1.Node
 	ec2Client := ec2.NewFromConfig(awsCfg)
@@ -73,17 +78,26 @@ func NvidiaMonitor(awsCfg aws.Config) types.Feature {
 		}).
 		Assess("NodeReplacement", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			oldNodeName := targetNode.Name
-			t.Logf("terminating node %q to mimic node repair", oldNodeName)
 
-			instanceId, err := validation.ParseProviderID(targetNode.Spec.ProviderID)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if _, err := ec2Client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
-				InstanceIds: []string{instanceId},
-			}); err != nil {
-				t.Fatal(err)
+			// On EKS Auto mode, the EC2 instance is owned by an AWS-managed
+			// service principal and customer roles are explicitly denied
+			// ec2:TerminateInstances. Instead, deleting the Node object lets
+			// Karpenter's termination finalizer drain and terminate the
+			// backing instance. On MNG/self-managed nodes, we terminate the
+			// instance directly to mimic a node repair event.
+			if targetNode.Labels[computeTypeLabelKey] == computeTypeAuto {
+				t.Logf("auto mode node detected; skipping direct EC2 termination and relying on karpenter finalizer on node delete")
+			} else {
+				t.Logf("terminating node %q to mimic node repair", oldNodeName)
+				instanceId, err := validation.ParseProviderID(targetNode.Spec.ProviderID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := ec2Client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+					InstanceIds: []string{instanceId},
+				}); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			t.Logf("deleting node object %q from cluster", oldNodeName)


### PR DESCRIPTION
**Issue #, if available**:
The recently added NodeReplacement subtest calls ec2:TerminateInstances directly on the GPU node's instance. On EKS Auto mode, instances are owned by an AWS-managed service principal and customer roles are explicitly denied ec2:TerminateInstances via a resource-based policy, so the test fails with UnauthorizedOperation.


**Description of changes**:

Branch on the node label `eks.amazonaws.com/compute-type:`
* Auto mode (`compute-type=auto`): skip the direct EC2 termination. Deleting the Node object is sufficient - Karpenter's termination finalizer drains the node and terminates the backing EC2 instance, and a replacement nvidia node is provisioned automatically.
* MNG / self-managed: unchanged - terminate the instance directly to mimic a node repair event, then delete the Node object.

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
