### PR TITLE
chore: Fix race condition in nodediagnostic CRD

### DIFF
--- a/e2e/suites/monitors/nvidia_monitor.go
+++ b/e2e/suites/monitors/nvidia_monitor.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	computeTypeLabelKey = "eks.amazonaws.com/compute-type"
-	computeTypeAuto = "auto"
+	computeTypeAuto     = "auto"
 )
 
 func NvidiaMonitor(awsCfg aws.Config) types.Feature {

--- a/pkg/controllers/nodediagnostic.go
+++ b/pkg/controllers/nodediagnostic.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -82,31 +83,41 @@ func (c *nodeDiagnosticController) Register(ctx context.Context, m controllerrun
 		return err
 	}
 
-	// Register watch event handler for mid-capture cancellation.
-	// This runs outside the Reconcile queue, so it can cancel a blocked capture immediately.
-	// Use GetInformer (not GetInformerForKind) to ensure we get the same informer instance
-	// that controller-runtime uses for the controller's watch.
-	informer, err := m.GetCache().GetInformer(ctx, &v1alpha1.NodeDiagnostic{})
-	if err != nil {
-		return fmt.Errorf("failed to get informer for NodeDiagnostic: %w", err)
-	}
+	// Attach the mid-capture cancellation event handler as a manager runnable
+	// so it runs after the cache has started. Calling GetInformer directly
+	// here would trigger synchronous API discovery against the cluster IP,
+	// which can block for ~30s on a TCP SYN timeout if kube-proxy has not yet
+	// programmed the DNAT rule for the kubernetes service. Deferring until
+	// the cache is ready avoids that startup race and the resulting panic.
+	mgrCache := m.GetCache()
+	return m.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		logger := log.FromContext(ctx).WithName("capture-cancel-watcher")
 
-	logger := log.FromContext(ctx).WithName("capture-cancel-watcher")
-	logger.Info("registering informer event handler for mid-capture cancellation")
-	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			c.handleSpecChange(logger, oldObj, newObj)
-		},
-		DeleteFunc: func(obj interface{}) {
-			c.handleDelete(logger, obj)
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to add event handler: %w", err)
-	}
-	logger.Info("informer event handler registered", "hasSynced", reg.HasSynced())
+		informer, err := mgrCache.GetInformer(ctx, &v1alpha1.NodeDiagnostic{})
+		if err != nil {
+			return fmt.Errorf("failed to get informer for NodeDiagnostic: %w", err)
+		}
 
-	return nil
+		logger.Info("registering informer event handler for mid-capture cancellation")
+		reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				c.handleSpecChange(logger, oldObj, newObj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				c.handleDelete(logger, obj)
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add event handler: %w", err)
+		}
+		logger.Info("informer event handler registered", "hasSynced", reg.HasSynced())
+
+		// Block until the manager shuts down. Runnables must block until ctx
+		// is done; returning early would cause the manager to treat this
+		// runnable as finished.
+		<-ctx.Done()
+		return nil
+	}))
 }
 
 func (c *nodeDiagnosticController) Reconcile(ctx context.Context, nodeDiagnostic *v1alpha1.NodeDiagnostic) (reconcile.Result, error) {


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

Fix a startup race between `nodeDiagnosticController.Register()` and kube-proxy iptables programming that causes NMA to panic with a 30-second TCP SYN timeout on freshly-booted nodes.

Register() called m.GetCache().GetInformer(ctx, &v1alpha1.NodeDiagnostic{}) synchronously during manager initialization. GetInformer requires a REST mapping for the target GVK; if the mapping isn't cached, controller-runtime's deferred REST mapper performs live API discovery (GET /api, GET /apis) against the in-cluster API server (https://kubernetes.default.svc, resolved to the cluster IP 172.20.0.1:443).

On a node whose kube-proxy has not yet completed its first SyncProxyRules, there is no DNAT entry for the cluster IP. The kernel sends a SYN, no endpoint responds, and the kernel retransmits per net.ipv4.tcp_syn_retries=6, yielding a ~30s timeout before ECONNREFUSED/EHOSTUNREACH surfaces. Once the SYN is in flight to a virtual IP without a DNAT rule, late-arriving iptables rules don't retroactively apply to the existing conntrack entry, so kube-proxy completing its sync mid-wait doesn't help.

The returned error propagates to utilruntime.Must(run()) in 
main.go 93, panicking the process and in turn causing the NMA pod restart.

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
