### PR TITLE
fix(networking): allowlist kube-proxy IPVS-mode reject chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ go.work.sum
 
 # VSCode
 .vscode
+
+# graphify code knowledge graph output
+graphify-out

--- a/monitors/networking/iptables/parser.go
+++ b/monitors/networking/iptables/parser.go
@@ -93,6 +93,17 @@ func (rule IPTablesRule) IsExpectedRejectRule(allowedChains []string) bool {
 			strings.Contains(rule.rejectWith, "icmp-port-unreachable")) {
 		// kube service with no endpoints
 		return true
+	} else if rule.table == "KUBE-IPVS-FILTER" || rule.table == "KUBE-IPVS-OUT-FILTER" {
+		// kube-proxy (IPVS mode) installs these chains to reject or drop traffic
+		// destined for service VIPs on the main netns and to block node access to
+		// load balancer VIPs. The chains are fully managed by kube-proxy and
+		// flushed on every sync.
+		return true
+	} else if rule.table == "KUBE-SOURCE-RANGES-FIREWALL" {
+		// kube-proxy installs this chain when a Service sets
+		// spec.loadBalancerSourceRanges. It drops packets from source IPs that
+		// are not in the allowed ranges.
+		return true
 	} else if strings.HasPrefix(rule.table, "cali-") {
 		// Calico managed chains use DROP rules as part of normal network policy enforcement
 		return true

--- a/monitors/networking/iptables/parser_test.go
+++ b/monitors/networking/iptables/parser_test.go
@@ -57,6 +57,23 @@ func TestIPTablesRuleParser(t *testing.T) {
 		}
 	})
 
+	t.Run("ExpectedRejectRuleKubeProxyIPVS", func(t *testing.T) {
+		// kube-proxy (IPVS mode) manages KUBE-IPVS-FILTER and KUBE-IPVS-OUT-FILTER,
+		// and manages KUBE-SOURCE-RANGES-FIREWALL whenever any Service sets
+		// spec.loadBalancerSourceRanges. The chains are flushed and rewritten by
+		// kube-proxy on every sync, so matching on the chain name is sufficient.
+		//   https://github.com/aws/eks-node-monitoring-agent/issues/150
+		for _, ruleRaw := range []string{
+			`-A KUBE-IPVS-FILTER -m conntrack --ctstate NEW -m set --match-set KUBE-IPVS-IPS dst -j REJECT --reject-with icmp-port-unreachable`,
+			`-A KUBE-IPVS-OUT-FILTER -s 10.0.0.1 -m ipvs --vaddr 10.0.0.1 --vproto tcp --vport 443 -j DROP`,
+			`-A KUBE-SOURCE-RANGES-FIREWALL -j DROP`,
+		} {
+			rule, err := iptables.ParseIPTablesRule(ruleRaw)
+			assert.NoError(t, err)
+			assert.Truef(t, rule.IsExpectedRejectRule(nil), ruleRaw)
+		}
+	})
+
 	t.Run("ExpectedRejectRuleCustomChain", func(t *testing.T) {
 		chains := []string{"filter/MY-CUSTOM-CHAIN", "filter/CUSTOM-CHAIN"}
 		for _, ruleRaw := range []string{


### PR DESCRIPTION
**Issue #, if available**:
#150 

**Description of changes**:
Extend IsExpectedRejectRule to recognize the iptables chains that kube-proxy installs and fully manages in IPVS mode and for Services with loadBalancerSourceRanges:
```
  - KUBE-IPVS-FILTER (k/k#72236)
  - KUBE-IPVS-OUT-FILTER (k/k#119656)
  - KUBE-SOURCE-RANGES-FIREWALL
```

**Testing Done**:
* Unit testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
