### PR TITLE
feat(chart): make liveness/startup probes configurable, raise default cpu limit

### DIFF
--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -51,6 +51,14 @@
                     "description": "Health probe port for the eks node monitoring agent. Used for both the --probe-address arg and the liveness probe.",
                     "default": 8002
                 },
+                "livenessProbe": {
+                    "$ref": "#/definitions/Probe",
+                    "description": "Liveness probe timing for the eks node monitoring agent. Path and port are derived from probePort; supply timing fields to override Kubernetes defaults."
+                },
+                "startupProbe": {
+                    "$ref": "#/definitions/Probe",
+                    "description": "Optional startup probe for the eks node monitoring agent. When unset, no startup probe is rendered. Path and port are derived from probePort."
+                },
                 "resources": {
                     "$ref": "#/definitions/Resources"
                 },
@@ -157,6 +165,34 @@
                 },
                 "cpu": {
                     "type": "string"
+                }
+            }
+        },
+        "Probe": {
+            "title": "Probe",
+            "type": "object",
+            "description": "Probe timing fields. Path and port are derived from probePort.",
+            "additionalProperties": false,
+            "properties": {
+                "initialDelaySeconds": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "timeoutSeconds": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "periodSeconds": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "successThreshold": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "failureThreshold": {
+                    "type": "integer",
+                    "minimum": 1
                 }
             }
         },

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -64,13 +64,15 @@ The following table lists the configurable parameters for this chart and their d
 | nodeAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policyfor the eks-node-monitoring-agent |
 | nodeAgent.image.region | string | `"us-west-2"` | ECR repository region for the eks-node-monitoring-agent |
 | nodeAgent.image.tag | string | `"v1.6.4-eksbuild.1"` | Image tag for the eks-node-monitoring-agent |
+| nodeAgent.livenessProbe | object | `{}` | Liveness probe timing for the eks-node-monitoring-agent. Path and port are derived from probePort. |
 | nodeAgent.monitors | object | `{}` | Per-monitor configuration keyed by plugin name. See the main README for details. |
 | nodeAgent.podAnnotations | object | `{}` | Pod annotations applied to the eks-node-monitoring-agent |
 | nodeAgent.podLabels | object | `{}` | Pod labels applied to the eks-node-monitoring-agent |
 | nodeAgent.probePort | int | `8002` | Health probe port for the eks-node-monitoring-agent. Used for both the --probe-address arg and the liveness probe. |
 | nodeAgent.resizePolicy | list | `[]` | Container resize policy for in-place pod vertical scaling (requires Kubernetes 1.33+) |
-| nodeAgent.resources | object | `{"limits":{"cpu":"250m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"30Mi"}}` | Container resources for the eks-node-monitoring-agent |
+| nodeAgent.resources | object | `{"limits":{"cpu":"500m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"30Mi"}}` | Container resources for the eks-node-monitoring-agent |
 | nodeAgent.securityContext | object | `{"capabilities":{"add":["NET_ADMIN"]},"privileged":true}` | Container Security context for the eks-node-monitoring-agent |
+| nodeAgent.startupProbe | object | `{}` | Optional startup probe for the eks-node-monitoring-agent. When unset, no startup probe is rendered. |
 | nodeAgent.tolerations | list | `[{"operator":"Exists"}]` | Deployment tolerations for the eks-node-monitoring-agent |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":"10%"},"type":"RollingUpdate"}` | Update strategy for all daemon sets |
 

--- a/charts/eks-node-monitoring-agent/templates/daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/daemonset.yaml
@@ -64,6 +64,16 @@ spec:
             httpGet:
               path: /healthz
               port: {{ .Values.nodeAgent.probePort | default 8002 }}
+            {{- with .Values.nodeAgent.livenessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.nodeAgent.startupProbe }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ $.Values.nodeAgent.probePort | default 8002 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.nodeAgent.resizePolicy }}
           resizePolicy:
             {{- toYaml . | nindent 12 }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -78,8 +78,12 @@ nodeAgent:
       cpu: 10m
       memory: 30Mi
     limits:
-      cpu: 250m
+      cpu: 500m
       memory: 200Mi
+  # -- Liveness probe timing for the eks-node-monitoring-agent. Path and port are derived from probePort.
+  livenessProbe: {}
+  # -- Optional startup probe for the eks-node-monitoring-agent. When unset, no startup probe is rendered.
+  startupProbe: {}
   # -- Container resize policy for in-place pod vertical scaling (requires Kubernetes 1.33+)
   resizePolicy: []
   # -- Container Security context for the eks-node-monitoring-agent


### PR DESCRIPTION
## Summary

Fixes the startup race documented in #158: `eks-node-monitoring-agent` pods restart twice on every freshly-provisioned, contention-heavy node before stabilizing, producing `KubePodCrashLooping` alerts.

Three coordinated changes, all backwards-compatible:

1. **Expose `nodeAgent.livenessProbe` timing in chart values** (`templates/daemonset.yaml`, `values.yaml`). Empty default `{}` preserves current k8s probe defaults — no behavior change for existing users. Operators can now set `timeoutSeconds`, `failureThreshold`, etc. without forking the chart.
2. **Add optional `nodeAgent.startupProbe`**. Empty default `{}` means no startup probe is rendered; opting in lets operators absorb the monitor-init burst without loosening the steady-state liveness probe. Path and port are derived from `probePort` for consistency.
3. **Raise default `nodeAgent.resources.limits.cpu` from `250m` to `500m`**. Agent steady-state usage is ~5–10m; the prior limit caused CFS throttling during parallel monitor initialization, which is the actual root cause of the `/healthz` timeouts. Memory limit is unchanged. This is the only change that affects existing users — and it makes things strictly better for the most common failure mode.

`charts/configuration.schema.json` is updated with a `Probe` definition referenced from both new fields, so EKS addon `configurationValues` can pass them through validation.

## Render verification

Default values (no override) — startupProbe correctly absent, liveness gets k8s defaults:

```yaml
livenessProbe:
  httpGet:
    path: /healthz
    port: 8002
resources:
  limits:
    cpu: 500m
    memory: 200Mi
  requests:
    cpu: 10m
    memory: 30Mi
```

With `nodeAgent.livenessProbe.timeoutSeconds=5`, `nodeAgent.startupProbe.failureThreshold=12`:

```yaml
livenessProbe:
  httpGet:
    path: /healthz
    port: 8002
  timeoutSeconds: 5
startupProbe:
  httpGet:
    path: /healthz
    port: 8002
  failureThreshold: 12
```

## Test plan

- [x] `helm lint ./charts/eks-node-monitoring-agent` passes
- [x] `helm template` renders correct output for default and override cases (above)
- [x] `make helm-docs` regenerates README cleanly
- [x] `configuration.schema.json` is valid JSON and `Probe` is reachable from `NodeAgent.{livenessProbe,startupProbe}`
- [ ] CI checks on this PR

## Backwards compatibility

- Default render of `livenessProbe` is byte-identical to current main (empty `{}` produces no merged fields).
- `startupProbe` is not rendered when empty, so no new probe appears for users who don't opt in.
- `resources.limits.cpu` default change is the one observable diff. Operators who care can pin via values or `configurationValues`.

Refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
