### PR TITLE
Bump wait time for instance to be terminated

### DIFF
--- a/e2e/suites/monitors/nvidia_monitor.go
+++ b/e2e/suites/monitors/nvidia_monitor.go
@@ -108,7 +108,7 @@ func NvidiaMonitor(awsCfg aws.Config) types.Feature {
 			t.Logf("waiting for node object %q to be deleted from cluster", oldNodeName)
 			if err := wait.For(
 				conditions.New(cfg.Client().Resources()).ResourceDeleted(targetNode),
-				wait.WithTimeout(5*time.Minute),
+				wait.WithTimeout(10*time.Minute),
 				wait.WithContext(ctx),
 			); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Bumping up the wait time to add more grace for instances to be terminated after deleting the node object.

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
