### PR TITLE
fix(nvidia): emit FabricManagerNotRunning Fatal when FM has failed

### DIFF
--- a/monitors/nvidia/dcgm/dcgm_watchfield.go
+++ b/monitors/nvidia/dcgm/dcgm_watchfield.go
@@ -31,17 +31,21 @@ func (s *DCGMSystem) WatchFields(ctx context.Context) ([]monitor.Condition, erro
 	var conditions []monitor.Condition
 
 	for _, fieldValue := range fieldValues {
-		// skip if there's no issue with the field or no new data was provided.
-		if fieldValue.Status == dcgmapi.DCGM_ST_OK || fieldValue.Status == dcgmapi.DCGM_ST_NO_DATA {
-			continue
-		}
-
-		// Fabric fields emit their own condition types and may suppress emission
-		// for healthy/unsupported states, so they are handled separately.
+		// Fabric fields encode health in the field value, not in fieldValue.Status,
+		// so they must be handled before the OK/NO_DATA gate below. DCGM returns
+		// DCGM_ST_OK for a successfully-read fabric field even when the value
+		// indicates Failure (e.g. FM_STATUS=Failure on a node where
+		// nvidia-fabricmanager.service has exited). The handler suppresses
+		// emission for healthy/unsupported states internally.
 		if c, handled := handleFabricField(fieldValue); handled {
 			if c != nil {
 				conditions = append(conditions, *c)
 			}
+			continue
+		}
+
+		// skip if there's no issue with the field or no new data was provided.
+		if fieldValue.Status == dcgmapi.DCGM_ST_OK || fieldValue.Status == dcgmapi.DCGM_ST_NO_DATA {
 			continue
 		}
 

--- a/monitors/nvidia/dcgm/dcgm_watchfield_test.go
+++ b/monitors/nvidia/dcgm/dcgm_watchfield_test.go
@@ -66,7 +66,7 @@ func TestFields(t *testing.T) {
 
 	t.Run("FabricManagerStatusSuccess", func(t *testing.T) {
 		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
-		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
 		binary.LittleEndian.PutUint64(fieldValue.Value[:], 3) // DcgmFMStatusSuccess
 		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
 		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
@@ -77,7 +77,7 @@ func TestFields(t *testing.T) {
 
 	t.Run("FabricManagerStatusNotSupported", func(t *testing.T) {
 		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
-		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
 		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0) // DcgmFMStatusNotSupported
 		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
 		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
@@ -88,7 +88,7 @@ func TestFields(t *testing.T) {
 
 	t.Run("FabricManagerStatusInProgress", func(t *testing.T) {
 		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
-		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
 		binary.LittleEndian.PutUint64(fieldValue.Value[:], 2) // DcgmFMStatusInProgress
 		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
 		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
@@ -99,7 +99,7 @@ func TestFields(t *testing.T) {
 
 	t.Run("FabricManagerStatusFailure", func(t *testing.T) {
 		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
-		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
 		binary.LittleEndian.PutUint64(fieldValue.Value[:], 4) // DcgmFMStatusFailure
 		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
 		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
@@ -114,7 +114,7 @@ func TestFields(t *testing.T) {
 
 	t.Run("FabricManagerStatusNotStarted", func(t *testing.T) {
 		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS}
-		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
 		binary.LittleEndian.PutUint64(fieldValue.Value[:], 1) // DcgmFMStatusNotStarted
 		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
 		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
@@ -125,7 +125,7 @@ func TestFields(t *testing.T) {
 
 	t.Run("FabricHealthMaskFailure", func(t *testing.T) {
 		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK}
-		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
 		binary.LittleEndian.PutUint64(fieldValue.Value[:], 1) // non-zero = failure
 		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
 		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
@@ -140,7 +140,7 @@ func TestFields(t *testing.T) {
 
 	t.Run("FabricHealthMaskHealthy", func(t *testing.T) {
 		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK}
-		fieldValue.Status = dcgmapi.DCGM_ST_BADPARAM
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
 		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0) // zero = healthy
 		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
 		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
The fabric-field handler in WatchFields was sitting behind the DCGM_ST_OK/DCGM_ST_NO_DATA early-continue gate. DCGM returns DCGM_ST_OK for a successfully-read field even when the field's value indicates failure (FM status = 4 means the fabricmanager service is in Failed state), so the handler was never invoked in production and FabricManagerNotRunning was never emitted.

Move handleFabricField above the OK/NO_DATA gate. Update the fabric subtests to use DCGM_ST_OK so they exercise the production-realistic path; the previous DCGM_ST_BADPARAM setup masked the bug.

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
