### PR TITLE
Fix nvidia device count mismatch unit test

### DIFF
--- a/hack/generate-instance-info/main.go
+++ b/hack/generate-instance-info/main.go
@@ -33,8 +33,8 @@ import (
 // Only entries where at least one field beyond InstanceType is non-zero
 // are written to the JSONL.
 type instanceInfo struct {
-	InstanceType  string `json:"instanceType"`
-	NvidiaGPUCount uint  `json:"nvidiaGpuCount,omitempty"`
+	InstanceType   string `json:"instanceType"`
+	NvidiaGPUCount uint   `json:"nvidiaGpuCount,omitempty"`
 }
 
 const outputPath = "internal/pkg/instanceinfo/instance-info.jsonl"

--- a/monitors/nvidia/dcgm/dcgm.go
+++ b/monitors/nvidia/dcgm/dcgm.go
@@ -18,16 +18,16 @@ func NewDCGMSystem(dcgmClient DCGM, diagType dcgmapi.DiagType) *DCGMSystem {
 // InstanceTypeInfoProvider, primarily for testing.
 func NewDCGMSystemWithInstanceTypeInfoProvider(dcgmClient DCGM, diagType dcgmapi.DiagType, provider instanceinfo.InstanceTypeInfoProvider) *DCGMSystem {
 	return &DCGMSystem{
-		dcgm:                    dcgmClient,
-		diagType:                diagType,
+		dcgm:                     dcgmClient,
+		diagType:                 diagType,
 		instanceTypeInfoProvider: provider,
 		fieldValueWindow:         5 * time.Minute,
 	}
 }
 
 type DCGMSystem struct {
-	dcgm                    DCGM
-	diagType                dcgmapi.DiagType
+	dcgm                     DCGM
+	diagType                 dcgmapi.DiagType
 	instanceTypeInfoProvider instanceinfo.InstanceTypeInfoProvider
 
 	// fieldValueWindow is the time window used to fetch changes in field

--- a/monitors/nvidia/dcgm/dcgm_devices_test.go
+++ b/monitors/nvidia/dcgm/dcgm_devices_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/internal/pkg/instanceinfo"
 	"github.com/aws/eks-node-monitoring-agent/monitors/nvidia/dcgm"
 	"github.com/aws/eks-node-monitoring-agent/monitors/nvidia/dcgm/fake"
-	"github.com/aws/eks-node-monitoring-agent/internal/pkg/instanceinfo"
 )
 
 func TestDeviceCount(t *testing.T) {

--- a/monitors/nvidia/dcgm/fake/dcgm.go
+++ b/monitors/nvidia/dcgm/fake/dcgm.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	dcgmapi "github.com/NVIDIA/go-dcgm/pkg/dcgm"
-	"github.com/aws/eks-node-monitoring-agent/monitors/nvidia/dcgm"
 	"github.com/aws/eks-node-monitoring-agent/internal/pkg/instanceinfo"
+	"github.com/aws/eks-node-monitoring-agent/monitors/nvidia/dcgm"
 )
 
 var _ dcgm.DCGM = &FakeDcgm{}

--- a/monitors/nvidia/monitor.go
+++ b/monitors/nvidia/monitor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 	"github.com/aws/eks-node-monitoring-agent/api/monitor/resource"
+	"github.com/aws/eks-node-monitoring-agent/internal/pkg/instanceinfo"
 	"github.com/aws/eks-node-monitoring-agent/monitors/nvidia/dcgm"
 	"github.com/aws/eks-node-monitoring-agent/monitors/nvidia/nccl"
 	"github.com/aws/eks-node-monitoring-agent/pkg/config"
@@ -43,17 +44,19 @@ func NewNvidiaMonitor() *nvidiaMonitor {
 				dcgm.FeaturePolicyViolations,
 			},
 		}),
-		sysInfo:  &sysInfo{},
-		tickFunc: util.TimeTickWithJitterContext,
+		sysInfo:                  &sysInfo{},
+		tickFunc:                 util.TimeTickWithJitterContext,
+		instanceTypeInfoProvider: instanceinfo.NewInstanceTypeInfoProvider(),
 	}
 }
 
 // NewNvidiaMonitorWithDeps creates an nvidiaMonitor with injectable dependencies for testing.
-func NewNvidiaMonitorWithDeps(dcgmClient dcgm.DCGM, sys SysInfo, tickFunc TickFunc) *nvidiaMonitor {
+func NewNvidiaMonitorWithDeps(dcgmClient dcgm.DCGM, sys SysInfo, tickFunc TickFunc, provider instanceinfo.InstanceTypeInfoProvider) *nvidiaMonitor {
 	return &nvidiaMonitor{
-		dcgmClient: dcgmClient,
-		sysInfo:    sys,
-		tickFunc:   tickFunc,
+		dcgmClient:               dcgmClient,
+		sysInfo:                  sys,
+		tickFunc:                 tickFunc,
+		instanceTypeInfoProvider: provider,
 	}
 }
 
@@ -63,9 +66,10 @@ type TickFunc func(ctx context.Context, d time.Duration) <-chan time.Time
 
 // nvidiaMonitor detects issues on nvidia GPUs
 type nvidiaMonitor struct {
-	dcgmClient dcgm.DCGM
-	sysInfo    SysInfo
-	tickFunc   TickFunc
+	dcgmClient               dcgm.DCGM
+	sysInfo                  SysInfo
+	tickFunc                 TickFunc
+	instanceTypeInfoProvider instanceinfo.InstanceTypeInfoProvider
 }
 
 func (m *nvidiaMonitor) Name() string {
@@ -85,7 +89,7 @@ func (m *nvidiaMonitor) Register(ctx context.Context, mgr monitor.Manager) error
 	if !slices.Contains(config.GetRuntimeContext().Tags(), config.EKSAuto) && strings.Contains(m.sysInfo.Arch(), "arm") {
 		logger.Info("NVIDIA-based monitoring is disabled for the arm64 architecture in this version of the agent")
 	} else {
-		dcgmSystem := dcgm.NewDCGMSystem(m.dcgmClient, dcgm.GetDiagType())
+		dcgmSystem := dcgm.NewDCGMSystemWithInstanceTypeInfoProvider(m.dcgmClient, dcgm.GetDiagType(), m.instanceTypeInfoProvider)
 
 		// DCGM Reconcile - maintains connection to DCGM host
 		go func() {

--- a/monitors/nvidia/monitor_test.go
+++ b/monitors/nvidia/monitor_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 	"github.com/aws/eks-node-monitoring-agent/api/monitor/resource"
+	"github.com/aws/eks-node-monitoring-agent/internal/pkg/instanceinfo"
 	"github.com/aws/eks-node-monitoring-agent/monitors/nvidia"
 	"github.com/aws/eks-node-monitoring-agent/monitors/nvidia/dcgm/fake"
 	"github.com/aws/eks-node-monitoring-agent/pkg/observer"
@@ -54,7 +55,13 @@ func newMonitorWithDcgm() (monitor.Monitor, *fake.FakeDcgm) {
 	mockDcgm := &fake.FakeDcgm{
 		PolicyChan: make(chan dcgmapi.PolicyViolation, 5),
 	}
-	nvidiaMonitor := nvidia.NewNvidiaMonitorWithDeps(mockDcgm, &mockSysInfo{}, immediateTick)
+	// Provide a fake InstanceTypeInfoProvider with a zero expected GPU count so
+	// the new instance-type validation in DeviceCount() never fires and the
+	// existing DCGM-vs-/dev mismatch path is the only source of conditions.
+	provider := &fake.FakeInstanceTypeInfoProvider{
+		Info: &instanceinfo.InstanceInfo{InstanceType: "test", NvidiaGPUCount: 0},
+	}
+	nvidiaMonitor := nvidia.NewNvidiaMonitorWithDeps(mockDcgm, &mockSysInfo{}, immediateTick, provider)
 	return nvidiaMonitor, mockDcgm
 }
 


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Fix a hidden IMDS dependency introduced in #121 that caused
`TestNvidiaMonitor/NvidiaDeviceCountMismatch` to fail with
`context deadline exceeded` in CI environments where the EC2 IMDS
endpoint is unreachable but doesn't fail fast.

#121 added expected-GPU-count validation against the EC2 instance type
by wiring a real `instanceinfo.NewInstanceTypeInfoProvider()` into
`dcgm.NewDCGMSystem`. The provider calls IMDS the first time it
resolves an instance type. The nvidia monitor's test helper
(`NewNvidiaMonitorWithDeps`) only let callers inject a fake DCGM
client and tick function, so once `Register()` constructed the
`DCGMSystem`, the `DeviceCount` goroutine reached the real provider
and blocked on the SDK's IMDS retry budget until the 5s test timeout
fired. On developer machines the IMDS call usually fails fast and the
test passes; on CI hosts where the endpoint hangs, it times out.

The fix:
- Add `instanceTypeInfoProvider` to `nvidiaMonitor`, populate it in
  `NewNvidiaMonitor()` with the real provider, and accept it as a
  parameter to `NewNvidiaMonitorWithDeps()` for tests.
- Construct the `DCGMSystem` via `NewDCGMSystemWithInstanceTypeInfoProvider`
  so the injected provider reaches `DeviceCount`.
- Update the existing test helper to pass a `FakeInstanceTypeInfoProvider`
  with `NvidiaGPUCount: 0`, so the new instance-type validation path
  stays inert and the existing DCGM-vs-`/dev` mismatch assertion is
  unchanged.

**Testing Done**:

- `make release` — green; `monitors/nvidia` runs in ~0.8s.
- Reproduced the original failure by pointing the AWS SDK at an
  unreachable IMDS endpoint (`AWS_EC2_METADATA_SERVICE_ENDPOINT=http://10.255.255.1/`):
  - Without this fix: `--- FAIL: TestNvidiaMonitor/NvidiaDeviceCountMismatch (5.00s)`
    with `context deadline exceeded` — matches the CI failure signature.
  - With this fix: `--- PASS: TestNvidiaMonitor/NvidiaDeviceCountMismatch (0.05s)`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
