### PR TITLE
feat(log-collector): capture Linux PSI metrics in diagnostic bundle

### DIFF
--- a/pkg/log_collector/collect/accessor_test.go
+++ b/pkg/log_collector/collect/accessor_test.go
@@ -30,6 +30,7 @@ func TestLogCollectorAccessor(t *testing.T) {
 		&collect.System{},
 		&collect.Nodeadm{},
 		&collect.Throttles{},
+		&collect.Pressure{},
 		&collect.Sandbox{},
 		&collect.Kubernetes{},
 		&collect.Networking{},

--- a/pkg/log_collector/collect/pressure.go
+++ b/pkg/log_collector/collect/pressure.go
@@ -1,0 +1,43 @@
+package collect
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// Pressure collects Linux Pressure Stall Information (PSI) snapshots from
+// /proc/pressure/{cpu,memory,io} for inclusion in the diagnostic log bundle.
+// PSI may be unavailable on older cgroup-v1 kernels or when disabled via the
+// kernel boot parameter psi=0; missing files are skipped silently rather than
+// failing the bundle.
+type Pressure struct{}
+
+var _ Collector = (*Pressure)(nil)
+
+// pressureResources is the fixed set of PSI files exposed under /proc/pressure
+// on Linux kernels with PSI enabled.
+var pressureResources = []string{"cpu", "memory", "io"}
+
+// Collect copies the raw PSI files into the bundle under system/. Each file is
+// captured independently so a missing or unreadable resource does not abort
+// collection of the others.
+func (p *Pressure) Collect(acc *Accessor) error {
+	var merr error
+	for _, name := range pressureResources {
+		merr = errors.Join(merr, capturePressure(acc, name))
+	}
+	return merr
+}
+
+func capturePressure(acc *Accessor, name string) error {
+	src := filepath.Join(acc.cfg.Root, "/proc/pressure/", name)
+	data, err := os.ReadFile(src)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return acc.WriteOutput("system/pressure_"+name+".txt", data)
+}

--- a/pkg/log_collector/collect/pressure_test.go
+++ b/pkg/log_collector/collect/pressure_test.go
@@ -1,0 +1,109 @@
+package collect_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/eks-node-monitoring-agent/pkg/log_collector/collect"
+)
+
+func TestPressureCollect(t *testing.T) {
+	const (
+		cpuContent = "some avg10=0.10 avg60=0.20 avg300=0.30 total=12345\n" +
+			"full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n"
+		memContent = "some avg10=1.00 avg60=2.00 avg300=3.00 total=98765\n" +
+			"full avg10=0.50 avg60=1.00 avg300=1.50 total=54321\n"
+		ioContent = "some avg10=4.00 avg60=5.00 avg300=6.00 total=11111\n" +
+			"full avg10=2.00 avg60=2.50 avg300=3.00 total=22222\n"
+	)
+
+	tests := []struct {
+		name       string
+		populate   map[string]string // path under /proc/pressure -> contents
+		wantFiles  map[string]string // path under destination -> expected contents
+		wantAbsent []string          // paths under destination that must not exist
+	}{
+		{
+			name: "all three pressure files present",
+			populate: map[string]string{
+				"cpu":    cpuContent,
+				"memory": memContent,
+				"io":     ioContent,
+			},
+			wantFiles: map[string]string{
+				"system/pressure_cpu.txt":    cpuContent,
+				"system/pressure_memory.txt": memContent,
+				"system/pressure_io.txt":     ioContent,
+			},
+		},
+		{
+			name:     "psi disabled (no files present)",
+			populate: nil,
+			wantAbsent: []string{
+				"system/pressure_cpu.txt",
+				"system/pressure_memory.txt",
+				"system/pressure_io.txt",
+			},
+		},
+		{
+			name: "only cpu present (partial kernel support)",
+			populate: map[string]string{
+				"cpu": cpuContent,
+			},
+			wantFiles: map[string]string{
+				"system/pressure_cpu.txt": cpuContent,
+			},
+			wantAbsent: []string{
+				"system/pressure_memory.txt",
+				"system/pressure_io.txt",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			dst := t.TempDir()
+
+			pressureDir := filepath.Join(root, "proc", "pressure")
+			if err := os.MkdirAll(pressureDir, 0o755); err != nil {
+				t.Fatalf("setup: mkdir pressure dir: %v", err)
+			}
+			for name, content := range tc.populate {
+				path := filepath.Join(pressureDir, name)
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+					t.Fatalf("setup: write %s: %v", path, err)
+				}
+			}
+
+			acc, err := collect.NewAccessor(collect.Config{
+				Root:        root,
+				Destination: dst,
+			})
+			if err != nil {
+				t.Fatalf("NewAccessor: %v", err)
+			}
+
+			if err := (&collect.Pressure{}).Collect(acc); err != nil {
+				t.Fatalf("Collect: %v", err)
+			}
+
+			for rel, want := range tc.wantFiles {
+				got, err := os.ReadFile(filepath.Join(dst, rel))
+				if err != nil {
+					t.Errorf("expected %s to be written, got err %v", rel, err)
+					continue
+				}
+				if string(got) != want {
+					t.Errorf("%s: contents mismatch\nwant: %q\n got: %q", rel, want, string(got))
+				}
+			}
+			for _, rel := range tc.wantAbsent {
+				if _, err := os.Stat(filepath.Join(dst, rel)); !os.IsNotExist(err) {
+					t.Errorf("expected %s to be absent, got err=%v", rel, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/logcollection/collectors.go
+++ b/pkg/logcollection/collectors.go
@@ -93,5 +93,6 @@ var collectorMap = map[v1alpha1.LogCategory][]collect.Collector{
 		&collect.AutoMode{},
 		&collect.System{},
 		&collect.Throttles{},
+		&collect.Pressure{},
 	},
 }


### PR DESCRIPTION

**Issue #, if available**:
Closes #168

**Description of changes**:
Add a Pressure collector that reads /proc/pressure/{cpu,memory,io} and writes the raw contents to system/pressure_<resource>.txt as part of the on-demand NodeDiagnostic log bundle, giving operators node-level CPU, memory, and IO stall data alongside the existing throttle artifacts.

The collector is forensic-only and is registered under LogCategorySystem next to the existing Throttles collector. Missing pressure files are skipped silently so the bundle does not fail on older cgroup-v1 kernels or nodes booted with psi=0; per-file errors are aggregated via errors.Join so one failure cannot abort the others.


**Testing Done**:
* Added unit tests
* Deployed to my dev cluster and validated that the log collection works as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
