### PR TITLE
feat: add agent version info during build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,16 @@ COPY . .
 ARG TARGETOS=linux
 ARG TARGETARCH
 ARG GOBUILDARGS=""
+ARG VERSION=build
+ARG GIT_COMMIT=unknown
 
 # Build the agent and chroot binaries with CGO enabled (required for systemd) and goroutine leak profiling
 RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=goroutineleakprofile \
-    go build ${GOBUILDARGS} -ldflags="-s -w" -o bin/eks-node-monitoring-agent ./cmd/eks-node-monitoring-agent/
+    go build ${GOBUILDARGS} \
+        -ldflags="-s -w \
+            -X github.com/aws/eks-node-monitoring-agent/internal/version.Version=${VERSION} \
+            -X github.com/aws/eks-node-monitoring-agent/internal/version.GitCommit=${GIT_COMMIT}" \
+        -o bin/eks-node-monitoring-agent ./cmd/eks-node-monitoring-agent/
 RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=goroutineleakprofile \
     go build ${GOBUILDARGS} -ldflags="-s -w" -o bin/chroot ./cmd/chroot/
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,18 @@ IMAGE_TAG ?= latest
 # Docker build arguments
 GOBUILDARGS ?=
 
+# Build identity (stamped into the binary via -ldflags -X).
+# VERSION resolves from the first available source:
+#   1. the chart's nodeAgent.image.tag (the canonical released version, and the
+#      same value the release pipeline uses to tag the image) — works in build
+#      environments without git metadata (e.g. Brazil),
+#   2. git describe for local/OSS checkouts,
+#   3. "build" as a final fallback.
+CHART_VALUES    := charts/eks-node-monitoring-agent/values.yaml
+CHART_IMAGE_TAG := $(shell yq '.nodeAgent.image.tag' $(CHART_VALUES) 2>/dev/null)
+VERSION    ?= $(if $(CHART_IMAGE_TAG),$(CHART_IMAGE_TAG),$(shell git describe --tags --always --dirty 2>/dev/null || echo build))
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
 # Multi-arch build platforms
 DOCKER_PLATFORMS ?= linux/amd64,linux/arm64
 
@@ -107,9 +119,12 @@ help: ## Show this help message
 # Development Targets
 # =============================================================================
 
+_version_pkg := github.com/aws/eks-node-monitoring-agent/internal/version
+LDFLAGS := -X $(_version_pkg).Version=$(VERSION) -X $(_version_pkg).GitCommit=$(GIT_COMMIT)
+
 .PHONY: build
 build: generate fmt vet ## Build Go code
-	go build -o $(OUTPUT_BIN)/eks-node-monitoring-agent ./cmd/eks-node-monitoring-agent
+	go build -ldflags "$(LDFLAGS)" -o $(OUTPUT_BIN)/eks-node-monitoring-agent ./cmd/eks-node-monitoring-agent
 	go build -o $(OUTPUT_BIN)/chroot ./cmd/chroot
 
 .PHONY: test
@@ -242,6 +257,8 @@ docker-build: ## Build and push multi-arch Docker image (requires IMAGE_REGISTRY
 	docker buildx build \
 		--platform $(DOCKER_PLATFORMS) \
 		--push \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		$(if $(GOBUILDARGS),--build-arg GOBUILDARGS="$(GOBUILDARGS)") \
 		-t $(IMAGE_URI) .
 

--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 	"github.com/aws/eks-node-monitoring-agent/api/v1alpha1"
+	"github.com/aws/eks-node-monitoring-agent/internal/version"
 	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
 	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 	"github.com/aws/eks-node-monitoring-agent/pkg/controllers"
@@ -103,6 +104,8 @@ func run() error {
 
 	logger := zap.New(zap.Level(zapraw.NewAtomicLevelAt(zapcore.Level(-verbosity)))).WithValues("hostname", hostname)
 	log.SetLogger(logger)
+
+	logger.Info("starting eks-node-monitoring-agent", "version", version.String())
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/NVIDIA/go-dcgm v0.0.0-20260603204728-453d82102783
-	github.com/aws/amazon-vpc-cni-k8s v1.22.1
+	github.com/aws/amazon-vpc-cni-k8s v1.22.0
 	github.com/aws/aws-sdk-go-v2 v1.41.12
 	github.com/aws/aws-sdk-go-v2/config v1.32.23
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.28

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00
 github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/amazon-vpc-cni-k8s v1.22.1 h1:O09tRZM9M/ZAD76rXrGDtq/QRXBYiqYXVaCYbJNPWUI=
-github.com/aws/amazon-vpc-cni-k8s v1.22.1/go.mod h1:J1KlqLYLWsxKSz4254rIwBnKlSfVa8WZww63Uzm7oX0=
-github.com/aws/amazon-vpc-resource-controller-k8s v1.7.18 h1:V/h33TgtVkR/1hkYVWU8RFD8i8h5G+xZ6eX9Hr0zKpk=
-github.com/aws/amazon-vpc-resource-controller-k8s v1.7.18/go.mod h1:iZa92r5f6vu42hQhyzrQa9UnxieNWcYmQ9DEKYMuXWo=
+github.com/aws/amazon-vpc-cni-k8s v1.22.0 h1:lkUxTIW2cF6OlXEWoUKZHuW/weYEiqnn6x7A7a2tI+w=
+github.com/aws/amazon-vpc-cni-k8s v1.22.0/go.mod h1:QYOUvUot/G6J3Rijrf0d4B/RoDJVBgsy50cwOrpqIGA=
+github.com/aws/amazon-vpc-resource-controller-k8s v1.7.16 h1:D24LKXSw7EW6UAEvqOs8GpHDkSl2tpJzQl3XklCMlXQ=
+github.com/aws/amazon-vpc-resource-controller-k8s v1.7.16/go.mod h1:si2JIXSCRR3NwFwUQNd2wMOk+aO7DruWsV+YIoYxBHI=
 github.com/aws/aws-sdk-go-v2 v1.41.12 h1:DIKX2c31ekm9RA2D9FBj1EWXx++9AdAqRw+e78Tq2Ck=
 github.com/aws/aws-sdk-go-v2 v1.41.12/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 h1:p1BBrg/Hhp6uK7zpejeI8QFXHJeC/mynzi04Sl03k9g=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,19 @@
+// Package version exposes the build-time identity of the agent binary.
+// Version and GitCommit are overridden at link time via -ldflags -X.
+package version
+
+import "fmt"
+
+// Version is the source revision the binary was built from.
+// Default "build" indicates an unstamped local build.
+var Version = "build"
+
+// GitCommit is the short git SHA the binary was built from.
+// Default "unknown" indicates an unstamped local build.
+var GitCommit = "unknown"
+
+// String returns the human-readable identity string in the form
+// "<Version> (<GitCommit>)".
+func String() string {
+	return fmt.Sprintf("%s (%s)", Version, GitCommit)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,32 @@
+package version
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+// TestStringDefault asserts String() returns the unstamped default identity.
+func TestStringDefault(t *testing.T) {
+	if got := String(); got != "build (unknown)" {
+		t.Errorf("String() = %q, want %q", got, "build (unknown)")
+	}
+}
+
+// TestStringFormatProperty verifies Property 1: for any pair of strings v and
+// c, String() returns exactly v + " (" + c + ")".
+//
+// Validates: Requirements 1.3, 5.4
+func TestStringFormatProperty(t *testing.T) {
+	origVersion, origCommit := Version, GitCommit
+	defer func() {
+		Version, GitCommit = origVersion, origCommit
+	}()
+
+	f := func(v, c string) bool {
+		Version, GitCommit = v, c
+		return String() == v+" ("+c+")"
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
**Issue #, if available**:
#99 

**Description of changes**:

The agent doesn't log its own version anywhere, so in Auto Mode there's no way to tell which build is running on a node when you're triaging. This wires that in.

Version and commit now live in a small internal/version package, set at link time with -ldflags -X. The Makefile pulls the version from the chart's nodeAgent.image.tag and falls back to git describe, and the commit comes from git rev-parse; both flow through the Dockerfile build args. main.go logs them on the first line at startup. Without the ldflags an ordinary go build still works, it just reports build (unknown).

**Testing Done**:
* Added unit tests for the change
* Built the code changes binary and validated against the latest shipped code:
```
strings bin/eks-node-monitoring-agent → v1.6.5-eksbuild.1
                                       → 6a989b4
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
