### PR TITLE
feat(kernel): Add ClockUnsynchronized clock-sync detection

### DIFF
--- a/docs/node-health-issues.adoc
+++ b/docs/node-health-issues.adoc
@@ -181,6 +181,10 @@ The monitoring condition is `KernelReady` for issues in the following table that
 |Event
 |The number of open files is approaching the maximum number of possible open files given the current kernel settings, after which opening new files will fail.
 
+|ClockUnsynchronized
+|Event
+|The kernel clock is not being disciplined by any time source. This is detected via `adjtimex(2)` reporting the `STA_UNSYNC` status flag and is daemon-agnostic across chrony, ntpd, and systemd-timesyncd. Clock drift can break time-sensitive workloads such as short-lived token validation.
+
 |ConntrackExceededKernel
 |Event
 |Connection tracking exceeded the maximum for the kernel and new connections could not be established, which can result in packet loss.

--- a/monitors/kernel/monitor.go
+++ b/monitors/kernel/monitor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
 	"github.com/aws/eks-node-monitoring-agent/pkg/util"
 	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -65,6 +66,7 @@ func (m *KernelMonitor) Register(ctx context.Context, mgr monitor.Manager) error
 		util.NewChannelHandler(func(time.Time) error { return m.handleOpenedFiles() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
 		util.NewChannelHandler(func(time.Time) error { return m.handleEnvironment() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
 		util.NewChannelHandler(func(time.Time) error { return m.handleZram() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
+		util.NewChannelHandler(func(time.Time) error { return m.handleClockSync() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
 	} {
 		go handler.Start(ctx)
 	}
@@ -407,4 +409,32 @@ func (k *KernelMonitor) checkZram(origSize, compSize, disksize int64, deviceName
 	}
 	return nil
 
+}
+
+// ~~~~ clock sync ~~~~
+
+func (k *KernelMonitor) handleClockSync() error {
+	// SAFETY: a zeroed Timex is mode 0 (read-only); adjtimex never mutates the clock here.
+	var buf unix.Timex
+	if _, err := unix.Adjtimex(&buf); err != nil {
+		// state unknown, so emit nothing.
+		k.logger.V(1).Info("adjtimex failed, skipping clock-sync check", "error", err)
+		return nil
+	}
+	return k.checkClockSync(buf.Status)
+}
+
+func (k *KernelMonitor) checkClockSync(status int32) error {
+	// STA_UNSYNC means the kernel clock is not disciplined by any time source. It is
+	// daemon-agnostic (chrony, ntpd, systemd-timesyncd) and self-calibrated by the
+	// kernel, so there is no threshold to configure; it clears once time is disciplined.
+	if status&unix.STA_UNSYNC == 0 {
+		return nil
+	}
+	return k.manager.Notify(context.Background(),
+		reasons.ClockUnsynchronized.
+			Builder().
+			Message("The kernel clock is not synchronized to any time source (STA_UNSYNC); time drift may break time-sensitive workloads").
+			Build(),
+	)
 }

--- a/monitors/kernel/monitor_test.go
+++ b/monitors/kernel/monitor_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 	"github.com/aws/eks-node-monitoring-agent/api/monitor/resource"
 )
@@ -308,6 +310,37 @@ func TestKernelPeriodic(t *testing.T) {
 		assert.Equal(t, 0, len(mockManager.res))
 
 		if err := mon.checkZram(99*1024*1024, 50*1024*1024, 1000*1024*1024, "zram2"); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, 0, len(mockManager.res))
+	})
+
+	t.Run("ClockUnsynchronized", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		mon := &KernelMonitor{}
+		mockManager := &mockManager{res: make(chan monitor.Condition, 5)}
+		mon.Register(ctx, mockManager)
+		if err := mon.checkClockSync(unix.STA_UNSYNC); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case monitorResult := <-mockManager.res:
+			assert.Equal(t, monitor.SeverityWarning, monitorResult.Severity)
+			assert.Equal(t, "ClockUnsynchronized", monitorResult.Reason)
+		}
+	})
+
+	t.Run("ClockSynchronizedNoop", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		mon := &KernelMonitor{}
+		mockManager := &mockManager{res: make(chan monitor.Condition, 5)}
+		mon.Register(ctx, mockManager)
+		// STA_UNSYNC clear (clock disciplined) plus an unrelated flag set must not fire.
+		if err := mon.checkClockSync(unix.STA_PLL); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, 0, len(mockManager.res))

--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -142,6 +142,10 @@ var (
         template:        "ApproachingMaxOpenFiles",
         defaultSeverity: "Warning",
     }
+    ClockUnsynchronized = ReasonMeta{
+        template:        "ClockUnsynchronized",
+        defaultSeverity: "Warning",
+    }
     ConntrackExceededKernel = ReasonMeta{
         template:        "ConntrackExceededKernel",
         defaultSeverity: "Warning",

--- a/pkg/reasons/reasons.yaml
+++ b/pkg/reasons/reasons.yaml
@@ -44,6 +44,14 @@ KernelReady:
       The number of open files is approaching the maximum number of possible
       open files given the current kernel settings, after which opening new
       files will fail.
+  ClockUnsynchronized:
+    Template: 'ClockUnsynchronized'
+    DefaultSeverity: 'Warning'
+    Description: >-
+      The kernel clock is not being disciplined by any time source. This is
+      detected via `adjtimex(2)` reporting the `STA_UNSYNC` status flag and is
+      daemon-agnostic across chrony, ntpd, and systemd-timesyncd. Clock drift
+      can break time-sensitive workloads such as short-lived token validation.
   ConntrackExceededKernel:
     Template: 'ConntrackExceededKernel'
     DefaultSeverity: 'Warning'


### PR DESCRIPTION
**Issue #, if available**:


**Description of changes**:

Detect when the kernel clock is no longer disciplined by a time source and surface it as the ClockUnsynchronized reason on the KernelReady NodeCondition. Detection uses adjtimex(2) with a zeroed Timex (read-only, mode 0) and inspects the STA_UNSYNC status flag, making it daemon-agnostic across chrony, ntpd, and systemd-timesyncd with no threshold to configure.

The reason is Warning, not Fatal: most clock-sync failures (dead/misconfigured daemon, unreachable time source, CPU starvation, boot-time step) are not fixed by node replacement, so triggering auto-repair would create a replacement loop without addressing the cause.


**Testing Done**:
* Added unit tests for the new detection
* Validated it node and verified:
```
Warning / KernelReady / ClockUnsynchronized: The kernel clock is not synchronized to any time source (STA_UNSYNC)
```
Agent log:
```
Reason=ClockUnsynchronized, Severity=Warning, conditionType=KernelReady at the 21:20:40Z
KernelReady=True
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
