### PR TITLE
chore: Bump go from 1.26.2 to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN dnf install -y dnf-plugins-core && \
 # =============================================================================
 # Stage 3: Go builder to compile the application
 # =============================================================================
-FROM public.ecr.aws/docker/library/golang:1.26.2 AS go-builder
+FROM public.ecr.aws/docker/library/golang:1.26.3 AS go-builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/eks-node-monitoring-agent
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/NVIDIA/go-dcgm v0.0.0-20260603204728-453d82102783


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Updating go version from 1.26.2 to 1.26.4

**Testing Done**:
* Unit tests succeed
* Builds succed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
