### PR TITLE
Collect NPA metric and report as Node condition

### DIFF
--- a/docs/node-health-issues.adoc
+++ b/docs/node-health-issues.adoc
@@ -299,6 +299,18 @@ The monitoring condition is `NetworkingReady` for issues in the following table 
 |Condition
 |The loopback interface is missing from this instance, causing failure of services depending on local connectivity.
 
+|NPABPFRecoveryError
+|Event
+|The Network Policy Agent encountered errors recovering or loading its BPF programs/maps after a restart. This is typically self-healing as the agent re-creates state on the next policy reconcile, so it is surfaced as a Warning.
+
+|NPANotRunning
+|Condition
+|The Network Policy Agent process was not found running on this Auto Mode node for more than 15 minutes.
+
+|NPARepeatedlyRestart
+|Event
+|The Network Policy Agent has restarted 5 or more times within a single poll interval, indicating a crash loop that may disrupt network policy enforcement. Often caused by a non-node-local issue (e.g. bad config or control-plane input), so it is surfaced as a Warning rather than triggering node replacement.
+
 |NetworkSysctl
 |Event
 |This node's network `sysctl` settings are potentially incorrect.

--- a/monitors/networking/monitor.go
+++ b/monitors/networking/monitor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/eks-node-monitoring-agent/monitors/networking/ipamd"
 	"github.com/aws/eks-node-monitoring-agent/monitors/networking/iptables"
 	"github.com/aws/eks-node-monitoring-agent/monitors/networking/networkutils"
+	"github.com/aws/eks-node-monitoring-agent/monitors/networking/npa"
 	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 	"github.com/aws/eks-node-monitoring-agent/pkg/osext"
 	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
@@ -179,6 +180,20 @@ func (m *NetworkingMonitor) Register(ctx context.Context, mgr monitor.Manager) e
 		return nil
 	})
 
+	// NPA (Network Policy Agent) detection — Auto Mode only. Driven here so its
+	// conditions surface under this monitor's NetworkingReady condition.
+	npaEnabled := slices.Contains(m.runtimeContext.Tags(), config.EKSAuto)
+	var npaDetector *npa.Detector
+	if npaEnabled {
+		npaDetector = npa.New(mgr, m.log)
+		subscriptionArgs = append(subscriptionArgs, util.SubscriptionArgs[string]{
+			Handler: npaDetector.HandleLogs,
+			SubscriptionFn: func() (<-chan string, error) {
+				return mgr.Subscribe(resource.ResourceTypeFile, []resource.Part{resource.Part(config.NPALogPath)})
+			},
+		})
+	}
+
 	for _, subArgs := range subscriptionArgs {
 		handler, err := util.NewChannelHandlerFromSubscriptionArgs(m.manager, subArgs)
 		if err != nil {
@@ -199,6 +214,14 @@ func (m *NetworkingMonitor) Register(ctx context.Context, mgr monitor.Manager) e
 		util.NewChannelHandler(func(time.Time) error { return m.handleMACAddressPolicy() }, util.TimeTickWithJitterContext(ctx, 5*time.Minute)),
 	} {
 		go handler.Start(ctx)
+	}
+
+	// NPA (Network Policy Agent) D-Bus state monitoring (crash-loop + not-running) — Auto Mode only.
+	if npaEnabled {
+		go util.NewChannelHandler(
+			func(time.Time) error { return npaDetector.HandleState() },
+			util.TimeTickWithJitterContext(ctx, 5*time.Minute),
+		).Start(ctx)
 	}
 
 	// EFA hardware counter monitoring

--- a/monitors/networking/monitor_test.go
+++ b/monitors/networking/monitor_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -836,5 +837,38 @@ func TestCheckIPAMD_DetectsInconsistentIP(t *testing.T) {
 		t.Fatal(ctx.Err())
 	case got := <-mockManager.res:
 		assert.Equal(t, "IPAMDInconsistentState", got.Reason)
+	}
+}
+
+// TestNPAGate_SkipsWithoutEKSAutoTag verifies the Auto-mode gate: NPA detection
+// is only wired when the runtime context carries the EKSAuto tag. The default
+// test runtime context has no EKSAuto tag, so the NPA log handler is not
+// subscribed and a matching NPA log line must produce no condition.
+func TestNPAGate_SkipsWithoutEKSAutoTag(t *testing.T) {
+	// Precondition: the test runtime context must not be Auto, otherwise the
+	// gate would (correctly) wire NPA up and this test wouldn't be meaningful.
+	if slices.Contains(config.GetRuntimeContext().Tags(), config.EKSAuto) {
+		t.Skip("runtime context has the EKSAuto tag; gate test not applicable")
+	}
+
+	mgr := &mockManager{obs: observer.BaseObserver{}, res: make(chan monitor.Condition, 5)}
+	mon := NewNetworkingMonitor()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := mon.Register(ctx, mgr); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// A matching NPA recovery-error line; with the gate off, no handler consumes
+	// it as an NPA signal, so no condition should be emitted.
+	mgr.obs.Broadcast("mock", "Failed to recover the BPF state")
+
+	select {
+	case c := <-mgr.res:
+		t.Fatalf("expected no condition without EKSAuto tag, but got %q", c.Reason)
+	case <-time.After(100 * time.Millisecond):
+		// no condition emitted — gate working as intended
 	}
 }

--- a/monitors/networking/npa/npa.go
+++ b/monitors/networking/npa/npa.go
@@ -1,0 +1,196 @@
+// Package npa implements health detection for the Network Policy Agent (NPA).
+//
+// It is NOT a standalone monitor. The networking monitor constructs a Detector
+// and drives its handlers, so all NPA conditions are emitted through the
+// networking monitor's manager and therefore surface under the NetworkingReady
+// node condition. NPA detection runs on Auto Mode nodes only.
+//
+// Severity policy (mirrors IPAMD):
+//   - NPANotRunning        Fatal   (persistently down; systemd can't recover it)
+//   - NPARepeatedlyRestart Warning (crash loop; root cause often not node-local)
+//   - NPABPFRecoveryError  Warning (startup BPF recovery error; self-heals via reconcile)
+package npa
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/go-logr/logr"
+
+	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
+)
+
+const (
+	// Unit is the systemd unit name for the Network Policy Agent.
+	Unit = "aws-network-policy-agent.service"
+
+	// repeatedRestartThreshold is the systemd NRestarts delta within a single
+	// poll interval that indicates a crash loop.
+	repeatedRestartThreshold uint32 = 5
+
+	// consistencyWindow is how long NPA must be continuously not-running before
+	// the NPANotRunning condition is emitted.
+	consistencyWindow = 15 * time.Minute
+)
+
+// Detector holds the state and logic for NPA health checks. Create one with New
+// and drive it from the networking monitor's Register (D-Bus state polling +
+// log subscription).
+type Detector struct {
+	manager           monitor.Manager
+	log               logr.Logger
+	npaNotRunningTime time.Time // the last time NPA was first observed not running
+	previousRestarts  uint32    // last observed systemd NRestarts baseline
+}
+
+// New returns a Detector that emits conditions through the given manager. Pass
+// the networking monitor's manager so conditions surface under NetworkingReady.
+func New(manager monitor.Manager, log logr.Logger) *Detector {
+	return &Detector{manager: manager, log: log}
+}
+
+// stringProp reads a string-valued systemd unit property via D-Bus, returning
+// "" if it can't be read. Used for best-effort diagnostic enrichment.
+func stringProp(dc *dbus.Conn, prop string) string {
+	p, err := dc.GetUnitPropertyContext(context.Background(), Unit, prop)
+	if err != nil {
+		return ""
+	}
+	s, _ := p.Value.Value().(string)
+	return s
+}
+
+// HandleState polls systemd via D-Bus for NPA crash-loop (NRestarts delta) and
+// not-running (ActiveState) signals. SubState/Result are read best-effort and
+// folded into the condition message for diagnostics. Called on a fixed interval.
+func (d *Detector) HandleState() error {
+	dc, err := dbus.NewWithContext(context.Background())
+	if err != nil {
+		d.log.Error(err, "failed to connect to D-Bus")
+		return nil
+	}
+	defer dc.Close()
+
+	// ActiveState drives not-running detection. If we can't read it, skip this
+	// cycle rather than assuming NPA is down.
+	property, err := dc.GetUnitPropertyContext(context.Background(), Unit, "ActiveState")
+	if err != nil {
+		d.log.Error(err, "failed to get ActiveState for NPA")
+		return nil
+	}
+	active := property.Value.Value().(string) == "active"
+
+	// Best-effort diagnostics: why/how the unit is in its current state.
+	subState := stringProp(dc, "SubState") // e.g. running / dead / failed / auto-restart
+	result := stringProp(dc, "Result")     // e.g. success / exit-code / signal / oom-kill / watchdog
+
+	// --- NPANotRunning ---
+	if err := d.checkNotRunning(active, subState, result); err != nil {
+		return err
+	}
+	// If NPA is not running, skip the crash-loop check (no point reading NRestarts).
+	if !active {
+		return nil
+	}
+
+	// --- NPARepeatedlyRestart ---
+	properties, err := dc.GetAllPropertiesContext(context.Background(), Unit)
+	if err != nil {
+		d.log.Error(err, "failed to get NPA unit properties")
+		return nil
+	}
+	nRestarts, ok := properties["NRestarts"]
+	if !ok {
+		return nil
+	}
+	currentRestarts, ok := nRestarts.(uint32)
+	if !ok {
+		return nil
+	}
+	return d.checkRepeatedlyRestart(currentRestarts, subState, result)
+}
+
+// checkNotRunning applies the consistency window logic for the NPANotRunning
+// condition. The first time NPA is observed not running, the detection time is
+// recorded but no condition is emitted. Only once NPA has been continuously not
+// running for at least consistencyWindow is NPANotRunning emitted (Fatal).
+// Observing NPA active resets the window.
+func (d *Detector) checkNotRunning(active bool, subState, result string) error {
+	if active {
+		d.npaNotRunningTime = time.Time{} // reset — NPA is running
+		return nil
+	}
+
+	now := time.Now()
+	if d.npaNotRunningTime.IsZero() {
+		d.npaNotRunningTime = now
+		return nil
+	}
+	if now.Sub(d.npaNotRunningTime) >= consistencyWindow {
+		return d.manager.Notify(context.Background(),
+			reasons.NPANotRunning.
+				Builder().
+				Message(fmt.Sprintf("NPA is not running on this Auto Mode node (SubState=%q, Result=%q)", subState, result)).
+				Build(),
+		)
+	}
+	return nil
+}
+
+// checkRepeatedlyRestart computes the delta of systemd restart counts since the
+// last poll and emits NPARepeatedlyRestart (Warning) if the delta meets the
+// threshold. The current restart count is always recorded as the new baseline.
+func (d *Detector) checkRepeatedlyRestart(currentRestarts uint32, subState, result string) error {
+	delta := currentRestarts - d.previousRestarts
+	d.previousRestarts = currentRestarts
+
+	if delta >= repeatedRestartThreshold {
+		return d.manager.Notify(context.Background(),
+			reasons.NPARepeatedlyRestart.
+				Builder().
+				Message(fmt.Sprintf("NPA restarted %d times in last poll interval (threshold: %d, SubState=%q, Result=%q)",
+					delta, repeatedRestartThreshold, subState, result)).
+				Build(),
+		)
+	}
+	return nil
+}
+
+// HandleLogs pattern-matches NPA error log lines from the startup BPF recovery
+// flow. Both recovery-level and map-level failures map to the single
+// NPABPFRecoveryError condition (Warning) since they originate from the same
+// best-effort recovery path and share the same remediation.
+func (d *Detector) HandleLogs(line string) error {
+	// Recovery failures (bpf_client.go lines 184, 416)
+	if strings.Contains(line, "Failed to recover the BPF state") ||
+		strings.Contains(line, "BPF State Recovery failed error") {
+		return d.manager.Notify(context.TODO(),
+			reasons.NPABPFRecoveryError.
+				Builder().
+				Message("NPA BPF state recovery failed after restart").
+				MinOccurrences(2).
+				Build(),
+		)
+	}
+
+	// eBPF map errors (bpf_client.go lines 390, 439, 471)
+	if strings.Contains(line, "failed to recover global maps") ||
+		strings.Contains(line, "got err for ingress in-mem map") ||
+		strings.Contains(line, "got err for egress in-mem map") ||
+		strings.Contains(line, "got err for cluster policy ingress in-mem map") ||
+		strings.Contains(line, "got err for cluster policy egress in-mem map") {
+		return d.manager.Notify(context.TODO(),
+			reasons.NPABPFRecoveryError.
+				Builder().
+				Message("NPA eBPF map recovery/write error detected").
+				MinOccurrences(2).
+				Build(),
+		)
+	}
+
+	return nil
+}

--- a/monitors/networking/npa/npa_test.go
+++ b/monitors/networking/npa/npa_test.go
@@ -1,0 +1,178 @@
+package npa
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+
+	"context"
+	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/api/monitor/resource"
+	"github.com/aws/eks-node-monitoring-agent/pkg/observer"
+)
+
+// mockManager implements monitor.Manager for unit tests. It records emitted
+// conditions on the res channel and serves subscriptions from a BaseObserver.
+type mockManager struct {
+	err error
+	obs observer.BaseObserver
+	res chan monitor.Condition
+}
+
+func (m *mockManager) Subscribe(resource.Type, []resource.Part) (<-chan string, error) {
+	return m.obs.Subscribe(), m.err
+}
+
+func (m *mockManager) Notify(ctx context.Context, condition monitor.Condition) error {
+	m.res <- condition
+	return nil
+}
+
+func newTestManager() *mockManager {
+	return &mockManager{
+		obs: observer.BaseObserver{},
+		res: make(chan monitor.Condition, 5),
+	}
+}
+
+func newTestDetector(mgr *mockManager) *Detector {
+	return New(mgr, logr.Discard())
+}
+
+func assertCondition(t *testing.T, mgr *mockManager, reason string, severity monitor.Severity) {
+	t.Helper()
+	select {
+	case c := <-mgr.res:
+		assert.Equal(t, reason, c.Reason)
+		assert.Equal(t, severity, c.Severity)
+	case <-time.After(time.Second):
+		t.Fatalf("expected condition %q, but none was emitted", reason)
+	}
+}
+
+func assertNoCondition(t *testing.T, mgr *mockManager) {
+	t.Helper()
+	select {
+	case c := <-mgr.res:
+		t.Fatalf("expected no condition, but got %q", c.Reason)
+	case <-time.After(50 * time.Millisecond):
+		// no condition emitted — success
+	}
+}
+
+// --- NPARepeatedlyRestart (checkRepeatedlyRestart) — Warning ---
+
+func TestCheckRepeatedlyRestart(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		previousRestarts uint32
+		currentRestarts  uint32
+		expectCondition  bool
+	}{
+		{"DeltaAtThresholdTriggers", 0, 5, true},
+		{"DeltaAboveThresholdTriggers", 10, 20, true},
+		{"DeltaBelowThresholdNoTrigger", 0, 4, false},
+		{"NoChangeNoTrigger", 7, 7, false},
+		{"SingleRestartNoTrigger", 3, 4, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := newTestManager()
+			d := newTestDetector(mgr)
+			d.previousRestarts = tc.previousRestarts
+
+			err := d.checkRepeatedlyRestart(tc.currentRestarts, "auto-restart", "signal")
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.currentRestarts, d.previousRestarts)
+
+			if tc.expectCondition {
+				assertCondition(t, mgr, "NPARepeatedlyRestart", monitor.SeverityWarning)
+			} else {
+				assertNoCondition(t, mgr)
+			}
+		})
+	}
+}
+
+// --- NPANotRunning (checkNotRunning) — Fatal ---
+
+func TestCheckNotRunning_FirstDetectionNoEmit(t *testing.T) {
+	mgr := newTestManager()
+	d := newTestDetector(mgr)
+
+	err := d.checkNotRunning(false, "dead", "exit-code")
+	assert.NoError(t, err)
+	assert.False(t, d.npaNotRunningTime.IsZero(), "detection time should be recorded")
+	assertNoCondition(t, mgr)
+}
+
+func TestCheckNotRunning_WithinWindowNoEmit(t *testing.T) {
+	mgr := newTestManager()
+	d := newTestDetector(mgr)
+	d.npaNotRunningTime = time.Now().Add(-5 * time.Minute)
+
+	err := d.checkNotRunning(false, "dead", "exit-code")
+	assert.NoError(t, err)
+	assertNoCondition(t, mgr)
+}
+
+func TestCheckNotRunning_AfterWindowEmits(t *testing.T) {
+	mgr := newTestManager()
+	d := newTestDetector(mgr)
+	d.npaNotRunningTime = time.Now().Add(-16 * time.Minute)
+
+	err := d.checkNotRunning(false, "dead", "exit-code")
+	assert.NoError(t, err)
+	assertCondition(t, mgr, "NPANotRunning", monitor.SeverityFatal)
+}
+
+func TestCheckNotRunning_ResetOnRecovery(t *testing.T) {
+	mgr := newTestManager()
+	d := newTestDetector(mgr)
+	d.npaNotRunningTime = time.Now().Add(-16 * time.Minute)
+
+	err := d.checkNotRunning(true, "running", "success")
+	assert.NoError(t, err)
+	assert.True(t, d.npaNotRunningTime.IsZero(), "detection time should reset when NPA is active")
+	assertNoCondition(t, mgr)
+}
+
+// --- HandleLogs — all map to NPABPFRecoveryError (Warning) ---
+
+func TestHandleLogs(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		line            string
+		expectCondition bool
+	}{
+		// Recovery failures → NPABPFRecoveryError
+		{"RecoveryFailedToRecover", "ERROR Failed to recover the BPF state", true},
+		{"RecoveryStateRecoveryFailed", "BPF State Recovery failed error: something", true},
+		// eBPF map errors → NPABPFRecoveryError
+		{"GlobalMaps", "failed to recover global maps", true},
+		{"IngressInMem", "got err for ingress in-mem map", true},
+		{"EgressInMem", "got err for egress in-mem map", true},
+		{"ClusterPolicyIngressInMem", "got err for cluster policy ingress in-mem map", true},
+		{"ClusterPolicyEgressInMem", "got err for cluster policy egress in-mem map", true},
+		// Non-matching → no condition
+		{"RandomLine", "some random log line", false},
+		{"StartupLine", "NPA started successfully", false},
+		{"EmptyLine", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := newTestManager()
+			d := newTestDetector(mgr)
+
+			err := d.HandleLogs(tc.line)
+			assert.NoError(t, err)
+
+			if tc.expectCondition {
+				assertCondition(t, mgr, "NPABPFRecoveryError", monitor.SeverityWarning)
+			} else {
+				assertNoCondition(t, mgr)
+			}
+		})
+	}
+}

--- a/pkg/config/hostpath.go
+++ b/pkg/config/hostpath.go
@@ -28,4 +28,5 @@ var (
 	PCIDevicesPath     = ToHostPath("/proc/bus/pci/devices")
 	CRIEndpoint        = "unix://" + ToHostPath("/run/containerd/containerd.sock")
 	IPAMDLogPath       = ToHostPath("/var/log/aws-routed-eni/ipamd.log")
+	NPALogPath         = ToHostPath("/var/log/aws-routed-eni/network-policy-agent.log")
 )

--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -249,6 +249,18 @@ var (
         template:        "MissingLoopbackInterface",
         defaultSeverity: "Fatal",
     }
+    NPABPFRecoveryError = ReasonMeta{
+        template:        "NPABPFRecoveryError",
+        defaultSeverity: "Warning",
+    }
+    NPANotRunning = ReasonMeta{
+        template:        "NPANotRunning",
+        defaultSeverity: "Fatal",
+    }
+    NPARepeatedlyRestart = ReasonMeta{
+        template:        "NPARepeatedlyRestart",
+        defaultSeverity: "Warning",
+    }
     NetworkSysctl = ReasonMeta{
         template:        "NetworkSysctl",
         defaultSeverity: "Warning",

--- a/pkg/reasons/reasons.yaml
+++ b/pkg/reasons/reasons.yaml
@@ -246,6 +246,29 @@ NetworkingReady:
     DefaultSeverity: 'Fatal'
     Description: >-
       This interface appears to not be up or there are network issues.
+  NPARepeatedlyRestart:
+    Template: 'NPARepeatedlyRestart'
+    DefaultSeverity: 'Warning'
+    Description: >-
+      The Network Policy Agent has restarted 5 or more times within a single
+      poll interval, indicating a crash loop that may disrupt network policy
+      enforcement. Often caused by a non-node-local issue (e.g. bad config or
+      control-plane input), so it is surfaced as a Warning rather than triggering
+      node replacement.
+  NPANotRunning:
+    Template: 'NPANotRunning'
+    DefaultSeverity: 'Fatal'
+    Description: >-
+      The Network Policy Agent process was not found running on this
+      Auto Mode node for more than 15 minutes.
+  NPABPFRecoveryError:
+    Template: 'NPABPFRecoveryError'
+    DefaultSeverity: 'Warning'
+    Description: >-
+      The Network Policy Agent encountered errors recovering or loading its
+      BPF programs/maps after a restart. This is typically self-healing as the
+      agent re-creates state on the next policy reconcile, so it is surfaced as
+      a Warning.
   EFAErrorMetric:
     Template: 'EFAErrorMetric'
     DefaultSeverity: 'Warning'


### PR DESCRIPTION
## Problem

NPA (Network Policy Agent) crash-looped for ~18h undetected because NMA had no NPA-specific health monitoring. This adds NPA health detection on EKS
Auto Mode nodes, surfaced through NMA's existing pipeline under `NetworkingReady`. The checks live in the networking monitor (peer to the IPAMD checks), so they inherit the `NetworkingReady` condition type.

## What this adds

| Signal | Source | Severity | Surfaces as | Fires when | Why this severity |
|--------|--------|----------|-------------|-----------|-------------------|
| `NPANotRunning` | D-Bus `ActiveState` | **Fatal** | `NetworkingReady` condition (→ auto-repair) | down ≥ 15 min | Persistently down → terminal; node replacement is the fix. |
| `NPARepeatedlyRestart` | D-Bus `NRestarts` | **Warning** | node Event | ≥ 5 restarts in one poll | Crash loop; root cause often not node-local, so replacing the node may not help → alarm, don't auto-repair. |
| `NPABPFRecoveryError` | NPA log | **Warning** | node Event | ≥ 2 matching error lines | Best-effort startup recovery that self-heals on the next reconcile → not terminal. |

Scope: **Auto Mode only**. Severity mirrors IPAMD's split (persistent-down = Fatal, restart/recovery = Warning).

### Deferred to a follow-up PR

**Policy-sync drift** — the authoritative "policy actually not enforced" signal. It needs NPA to expose desired-vs-loaded policy counts as Prometheus gauges on its existing metrics endpoint; NMA would then scrape them and emit `NPAPolicySyncFailure` (Fatal) on sustained drift. Also deferred: NPA health-endpoint liveness, and moving these signals onto the shared metrics transport (separate effort).

## Testing

**Unit**: detection logic (`checkRepeatedlyRestart`, `checkNotRunning`,
`HandleLogs`) incl. threshold/window edges, and the Auto-only gate.

**On-node** (custom AMI pinned to a beta Auto Mode cluster):
- `NPABPFRecoveryError`: appended matching error lines to the NPA log to mock the
  failure — NMA tailed the log and emitted the Warning. ✅
- `NPARepeatedlyRestart`: SIGKILL'd NPA ≥5× within one poll to force systemd auto-restarts — NMA detected the loop via D-Bus and emitted the Warning. ✅
- `NPANotRunning`: masked NPA and held > 15 min — `NetworkingReady` flipped to  `False` (Fatal). ✅ <!-- update once the window elapses -->
- Negatives: sub-threshold restarts and a short (<15 min) outage produced no
  condition.

**Performance**: not covered. Footprint is small — one D-Bus poll (2 property
reads) every 5 min plus an append-driven log tail — but there is no formal
perf/load test. Calling this out as a known gap.

## Recovery model

- **Warning** (`NPARepeatedlyRestart`, `NPABPFRecoveryError`) → node Event. No state to clear; it just stops firing once the issue goes away. 
- **Fatal** (`NPANotRunning`) → `NetworkingReady=False`. It does not self-clear; recovery is node auto-repair replacing the node (same as IPAMD's Fatal conditions today).

