### PR TITLE
fix(nvidia/dcgm): decode fabric health mask sub-fields to avoid false positives

### DIFF
--- a/monitors/nvidia/dcgm/dcgm_watchfield.go
+++ b/monitors/nvidia/dcgm/dcgm_watchfield.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	dcgmapi "github.com/NVIDIA/go-dcgm/pkg/dcgm"
@@ -100,17 +101,44 @@ func handleFabricField(fv dcgmapi.FieldValue_v2) (*monitor.Condition, bool) {
 			Build()
 		return &c, true
 	case dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK:
-		if fv.Int64() == 0 {
+		mask := fv.Int64()
+		// The mask packs several 2-bit sub-fields, each decoded as
+		// (mask >> shift) & widthMask following NVIDIA's
+		// DCGM_GPU_FABRIC_HEALTH_TEST macro. A non-zero mask is NOT sufficient
+		// to declare a fault: the boolean sub-fields encode 0=NotSupported,
+		// 1=True (fault asserted), 2=False (explicitly healthy), so a healthy
+		// GPU can report a non-zero mask (e.g. 0x80 decodes to
+		// access_timeout_recovery=False). Only the True/fault state of a
+		// sub-field is flagged; this is what eliminates the false positives
+		// from the previous "any non-zero mask is a fault" logic.
+		faults := fabricHealthMaskFaults(mask)
+		if len(faults) == 0 {
 			return nil, true
 		}
 		c := reasons.NvidiaFabricError.
 			Builder().
-			Message(fmt.Sprintf("GPU fabric health mask: 0x%x", fv.Int64())).
+			Message(fmt.Sprintf("GPU fabric health mask 0x%x: %s", mask, strings.Join(faults, ", "))).
 			Build()
 		return &c, true
 	default:
 		return nil, false
 	}
+}
+
+// fabricHealthMaskFaults decodes the faulting sub-fields of a fabric health
+// mask (field 174). Each sub-field is extracted as (mask >> shift) & widthMask
+// (mirroring NVIDIA's DCGM_GPU_FABRIC_HEALTH_TEST macro) and reported only when
+// it is in a fault state. Returns the faults as "name=value" strings, or an
+// empty slice when the mask indicates no fault.
+func fabricHealthMaskFaults(mask int64) []string {
+	var faults []string
+	for _, sf := range fabricHealthSubFields {
+		v := (mask >> sf.shift) & sf.widthMask
+		if sf.fault(v) {
+			faults = append(faults, fmt.Sprintf("%s=%d", sf.name, v))
+		}
+	}
+	return faults
 }
 
 // ref: https://github.com/NVIDIA/DCGM/blob/6e947dcac9b3160d61d98fea4741d51d4bec5c1f/dcgmlib/dcgm_fields.h#L99-L103
@@ -142,6 +170,40 @@ const (
 	DcgmFMStatusInProgress   int64 = 2
 	DcgmFMStatusSuccess      int64 = 3
 )
+
+// fabricHealthSubField describes one sub-field packed into the
+// DCGM_FI_DEV_FABRIC_HEALTH_MASK value. Each sub-field is decoded as
+// (mask >> shift) & widthMask, matching NVML_GPU_FABRIC_HEALTH_GET. For the
+// boolean sub-fields the value encoding is 0=NotSupported, 1=True, 2=False,
+// so only value 1 (the fault asserted) is flagged; NotSupported and False
+// are healthy.
+//
+// The shift/width/value defines are sourced from NVIDIA's published NVML API
+// reference; note the nvml.h vendored via go-dcgm only defines the DEGRADED_BW
+// sub-field and lists a stale WIDTH of 0x11.
+// ref: https://docs.nvidia.com/deploy/nvml-api/group__nvmlFabricDefs.html (NVML_GPU_FABRIC_HEALTH_MASK_*, NVML_GPU_FABRIC_HEALTH_GET)
+// ref: https://github.com/NVIDIA/DCGM/blob/master/dcgmlib/dcgm_fields.h (DCGM_FI_DEV_FABRIC_HEALTH_MASK = 174)
+type fabricHealthSubField struct {
+	name      string
+	shift     uint
+	widthMask int64
+	fault     func(v int64) bool
+}
+
+// faultWhenTrue reports a fault only for the True state (value 1).
+func faultWhenTrue(v int64) bool { return v == 1 }
+
+var fabricHealthSubFields = []fabricHealthSubField{
+	// Boolean sub-fields: 0=NotSupported, 1=True (fault), 2=False (healthy).
+	{name: "degraded_bw", shift: 0, widthMask: 0x3, fault: faultWhenTrue},
+	{name: "route_recovery", shift: 2, widthMask: 0x3, fault: faultWhenTrue},
+	{name: "route_unhealthy", shift: 4, widthMask: 0x3, fault: faultWhenTrue},
+	{name: "access_timeout_recovery", shift: 6, widthMask: 0x3, fault: faultWhenTrue},
+	// Incorrect configuration: 0=NotSupported, 1=None (correct), >=2=incorrect.
+	{name: "incorrect_configuration", shift: 8, widthMask: 0xf, fault: func(v int64) bool { return v >= 2 }},
+	// partition_assigned (shift 12) is informational, not a health fault, so
+	// it is intentionally omitted.
+}
 
 var clockThrottleReasons = map[int64]string{
 	DCGM_CLOCKS_THROTTLE_REASON_GPU_IDLE:       "gpu_idle",

--- a/monitors/nvidia/dcgm/dcgm_watchfield_test.go
+++ b/monitors/nvidia/dcgm/dcgm_watchfield_test.go
@@ -123,17 +123,20 @@ func TestFields(t *testing.T) {
 		assert.Empty(t, conditions)
 	})
 
-	t.Run("FabricHealthMaskFailure", func(t *testing.T) {
+	// A mask with a sub-field in the True/fault state is flagged, and the
+	// message names the faulting sub-field.
+	t.Run("FabricHealthMaskFault", func(t *testing.T) {
 		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK}
 		fieldValue.Status = dcgmapi.DCGM_ST_OK
-		binary.LittleEndian.PutUint64(fieldValue.Value[:], 1) // non-zero = failure
+		// route_unhealthy=True (value 1 at shift 4) is a genuine fault.
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0x10)
 		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
 		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
 		conditions, err := dcgmSystem.WatchFields(context.TODO())
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, []monitor.Condition{{
 			Reason:   "NvidiaFabricError",
-			Message:  "GPU fabric health mask: 0x1",
+			Message:  "GPU fabric health mask 0x10: route_unhealthy=1",
 			Severity: monitor.SeverityFatal,
 		}}, conditions)
 	})
@@ -147,6 +150,38 @@ func TestFields(t *testing.T) {
 		conditions, err := dcgmSystem.WatchFields(context.TODO())
 		assert.NoError(t, err)
 		assert.Empty(t, conditions)
+	})
+
+	// Regression test: a mask of 0x80 decodes to access_timeout_recovery=False
+	// (value 2 at shift 6) with every other sub-field NotSupported. That is a
+	// fully healthy GPU, but the old "any non-zero mask is a fault" check
+	// flagged it, causing the false-positive node disruptions this fix prevents.
+	t.Run("FabricHealthMaskFalseStateHealthy", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK}
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0x80) // access_timeout_recovery=False
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
+	// Multiple faulting sub-fields are all reported. degraded_bw=True (0x1) and
+	// route_unhealthy=True (0x10) combine to 0x11.
+	t.Run("FabricHealthMaskMultipleFaults", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK}
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0x11)
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []monitor.Condition{{
+			Reason:   "NvidiaFabricError",
+			Message:  "GPU fabric health mask 0x11: degraded_bw=1, route_unhealthy=1",
+			Severity: monitor.SeverityFatal,
+		}}, conditions)
 	})
 
 	t.Run("GetResultForBadStatus", func(t *testing.T) {


### PR DESCRIPTION
The fabric health handler flagged DCGM_FI_DEV_FABRIC_HEALTH_MASK (field 174) as a fault whenever the mask was non-zero. The mask is a packed bitfield of 2-bit sub-fields decoded as `(mask >> shift) & width` (mirroring NVIDIA's DCGM_GPU_FABRIC_HEALTH_TEST macro), where the value encoding is `0=NotSupported, 1=True (fault), 2=False (healthy)`. Non-zero therefore does NOT imply a fault: e.g. mask `0x80` decodes to `access_timeout_recovery=False` (value 2 at shift 6), a fully healthy GPU. Treating any non-zero mask as an error
produced false-positive node disruptions.

Decode each sub-field and flag only the True/fault state, preserving the granular signal the mask provides. The condition message now names the faulting sub-fields (e.g. "GPU fabric health mask 0x10: route_unhealthy=1") to aid triage.

ref: https://docs.nvidia.com/deploy/nvml-api/group__nvmlFabricDefs.html

**Issue #, if available**:

**Description of changes**:

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
