### PR TITLE
feat(config): add event suppression settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,25 @@ nodeAgent:
         - "filter/MY-CUSTOM-CHAIN"
 ```
 
+Agent events can be suppressed with `disabledEvents` or tuned with `eventThresholds`. For example, suppress `LargeEnvironment` entirely or raise its environment variable count threshold from the default `1000` to `2000`:
+
+```yaml
+nodeAgent:
+  disabledEvents:
+    - LargeEnvironment
+  eventThresholds:
+    LargeEnvironment: 2000
+```
+
 ### Config File Format
 
 The agent reads a YAML config file mounted at `/etc/nma/config.yaml`. Omitted monitors default to enabled.
 
 ```yaml
+disabledEvents:
+  - LargeEnvironment
+eventThresholds:
+  LargeEnvironment: 2000
 monitors:
   kernel-monitor:
     enabled: true
@@ -84,6 +98,8 @@ monitors:
 ```
 
 Valid plugin names: `kernel-monitor`, `networking`, `storage-monitor`, `nvidia`, `neuron`, `runtime`.
+
+Supported event names: `LargeEnvironment`. Event names must be non-empty and must not include leading or trailing whitespace. Event thresholds must be positive integers.
 
 When a monitor is disabled:
 - Its health checks are not executed.

--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -63,6 +63,35 @@
                 "tolerations": {
                     "$ref": "#/definitions/Tolerations"
                 },
+                "disabledEvents": {
+                    "type": "array",
+                    "description": "Agent-level event names to suppress",
+                    "default": [],
+                    "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "pattern": "^\\S(?:.*\\S)?$",
+                        "enum": [
+                            "LargeEnvironment"
+                        ]
+                    }
+                },
+                "eventThresholds": {
+                    "type": "object",
+                    "description": "Per-event numeric thresholds keyed by event name",
+                    "default": {},
+                    "propertyNames": {
+                        "minLength": 1,
+                        "pattern": "^\\S(?:.*\\S)?$",
+                        "enum": [
+                            "LargeEnvironment"
+                        ]
+                    },
+                    "additionalProperties": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
                 "monitors": {
                     "type": "object",
                     "description": "Per-monitor configuration keyed by plugin name",

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -65,6 +65,8 @@ The following table lists the configurable parameters for this chart and their d
 | nodeAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policyfor the eks-node-monitoring-agent |
 | nodeAgent.image.region | string | `"us-west-2"` | ECR repository region for the eks-node-monitoring-agent |
 | nodeAgent.image.tag | string | `"v1.6.6-eksbuild.1"` | Image tag for the eks-node-monitoring-agent |
+| nodeAgent.disabledEvents | list | `[]` | Agent-level event names to suppress. Example: ["LargeEnvironment"]. |
+| nodeAgent.eventThresholds | object | `{}` | Per-event numeric thresholds keyed by event name. Example: { LargeEnvironment: 2000 }. |
 | nodeAgent.monitors | object | `{}` | Per-monitor configuration keyed by plugin name. See the main README for details. |
 | nodeAgent.podAnnotations | object | `{}` | Pod annotations applied to the eks-node-monitoring-agent |
 | nodeAgent.podLabels | object | `{}` | Pod labels applied to the eks-node-monitoring-agent |

--- a/charts/eks-node-monitoring-agent/templates/daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/daemonset.yaml
@@ -77,7 +77,7 @@ spec:
           volumeMounts:
             - name: host-root
               mountPath: /host
-            {{- if .Values.nodeAgent.monitors }}
+            {{- if or .Values.nodeAgent.monitors .Values.nodeAgent.disabledEvents .Values.nodeAgent.eventThresholds }}
             - name: monitor-config
               mountPath: /etc/nma
               readOnly: true
@@ -86,7 +86,7 @@ spec:
         - name: host-root
           hostPath:
             path: /
-        {{- if .Values.nodeAgent.monitors }}
+        {{- if or .Values.nodeAgent.monitors .Values.nodeAgent.disabledEvents .Values.nodeAgent.eventThresholds }}
         - name: monitor-config
           configMap:
             name: {{ include "eks-node-monitoring-agent.fullname" . }}-monitor-config

--- a/charts/eks-node-monitoring-agent/templates/monitor-configmap.yaml
+++ b/charts/eks-node-monitoring-agent/templates/monitor-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nodeAgent.monitors }}
+{{- if or .Values.nodeAgent.monitors .Values.nodeAgent.disabledEvents .Values.nodeAgent.eventThresholds }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,6 +8,16 @@ metadata:
     {{- include "eks-node-monitoring-agent.labels" . | nindent 4 }}
 data:
   config.yaml: |
+    {{- with .Values.nodeAgent.disabledEvents }}
+    disabledEvents:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeAgent.eventThresholds }}
+    eventThresholds:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeAgent.monitors }}
     monitors:
-      {{- toYaml .Values.nodeAgent.monitors | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -95,6 +95,10 @@ nodeAgent:
     - operator: Exists
   # -- Pod labels applied to the eks-node-monitoring-agent
   podLabels: {}
+  # -- Agent-level event names to suppress. Example: ["LargeEnvironment"].
+  disabledEvents: []
+  # -- Per-event numeric thresholds keyed by event name. Example: { LargeEnvironment: 2000 }.
+  eventThresholds: {}
   # -- Per-monitor configuration keyed by plugin name. See the main README for details.
   monitors: {}
   # -- Pod annotations applied to the eks-node-monitoring-agent

--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -220,6 +220,17 @@ func run() error {
 	}
 
 	// Inject per-monitor configuration into monitors that support it
+	if eventConfig := monitorConfig.GetEventConfig(); !eventConfig.IsZero() {
+		for _, mon := range enabledMonitors {
+			type eventConfigurable interface {
+				SetEventConfig(config.EventConfig)
+			}
+			if c, ok := mon.(eventConfigurable); ok {
+				c.SetEventConfig(eventConfig)
+				logger.Info("configured event settings", "monitor", mon.Name(), "disabledEvents", eventConfig.DisabledEvents, "eventThresholds", eventConfig.EventThresholds)
+			}
+		}
+	}
 	if chains := monitorConfig.GetAllowedIPTablesChains(); len(chains) > 0 {
 		for _, mon := range enabledMonitors {
 			type chainConfigurable interface {

--- a/monitors/kernel/monitor.go
+++ b/monitors/kernel/monitor.go
@@ -25,9 +25,15 @@ import (
 
 var _ monitor.Monitor = (*KernelMonitor)(nil)
 
+const (
+	largeEnvironmentEventName        = "LargeEnvironment"
+	defaultLargeEnvironmentThreshold = 1000
+)
+
 type KernelMonitor struct {
-	manager monitor.Manager
-	logger  logr.Logger
+	manager     monitor.Manager
+	logger      logr.Logger
+	eventConfig config.EventConfig
 }
 
 func (m *KernelMonitor) Name() string {
@@ -36,6 +42,10 @@ func (m *KernelMonitor) Name() string {
 
 func (m *KernelMonitor) Conditions() []monitor.Condition {
 	return []monitor.Condition{}
+}
+
+func (m *KernelMonitor) SetEventConfig(eventConfig config.EventConfig) {
+	m.eventConfig = eventConfig
 }
 
 func (m *KernelMonitor) Register(ctx context.Context, mgr monitor.Manager) error {
@@ -334,6 +344,9 @@ func (k *KernelMonitor) handleEnvironment() error {
 }
 
 func (k *KernelMonitor) checkEnvironment(envBytes []byte, pid int) error {
+	if k.eventConfig.IsEventDisabled(largeEnvironmentEventName) {
+		return nil
+	}
 	// split by null character separator and discard empty entries.
 	// see: https://www.man7.org/linux/man-pages/man7/environ.7.html
 	var envs []string
@@ -342,7 +355,8 @@ func (k *KernelMonitor) checkEnvironment(envBytes []byte, pid int) error {
 			envs = append(envs, env)
 		}
 	}
-	if envCount := len(envs); envCount > 1000 {
+	threshold := k.eventConfig.EventThreshold(largeEnvironmentEventName, defaultLargeEnvironmentThreshold)
+	if envCount := len(envs); envCount > threshold {
 		return k.manager.Notify(context.TODO(),
 			reasons.LargeEnvironment.
 				Builder().

--- a/monitors/kernel/monitor_test.go
+++ b/monitors/kernel/monitor_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 	"github.com/aws/eks-node-monitoring-agent/api/monitor/resource"
+	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 )
 
 // mockObserver provides a simple channel-based observer for testing
@@ -262,6 +263,54 @@ func TestKernelPeriodic(t *testing.T) {
 		mon.Register(ctx, mockManager)
 		var envs []byte
 		for i := range 1001 {
+			envs = append(envs, []byte(fmt.Sprintf("%d\x00", i))...)
+		}
+		if err := mon.checkEnvironment(envs, 0); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case monitorResult := <-mockManager.res:
+			assert.Equal(t, monitor.SeverityWarning, monitorResult.Severity)
+			assert.Equal(t, "LargeEnvironment", monitorResult.Reason)
+		}
+	})
+
+	t.Run("LargeEnvironmentDisabled", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		mon := &KernelMonitor{}
+		mon.SetEventConfig(config.EventConfig{DisabledEvents: []string{"LargeEnvironment"}})
+		mockManager := &mockManager{obs: newMockObserver(), res: make(chan monitor.Condition, 5)}
+		mon.Register(ctx, mockManager)
+		var envs []byte
+		for i := range 1001 {
+			envs = append(envs, []byte(fmt.Sprintf("%d\x00", i))...)
+		}
+		if err := mon.checkEnvironment(envs, 0); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, 0, len(mockManager.res))
+	})
+
+	t.Run("LargeEnvironmentCustomThreshold", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		mon := &KernelMonitor{}
+		mon.SetEventConfig(config.EventConfig{EventThresholds: map[string]int{"LargeEnvironment": 2000}})
+		mockManager := &mockManager{obs: newMockObserver(), res: make(chan monitor.Condition, 5)}
+		mon.Register(ctx, mockManager)
+		var envs []byte
+		for i := range 1500 {
+			envs = append(envs, []byte(fmt.Sprintf("%d\x00", i))...)
+		}
+		if err := mon.checkEnvironment(envs, 0); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, 0, len(mockManager.res))
+
+		for i := 1500; i < 2001; i++ {
 			envs = append(envs, []byte(fmt.Sprintf("%d\x00", i))...)
 		}
 		if err := mon.checkEnvironment(envs, 0); err != nil {

--- a/pkg/config/monitor.go
+++ b/pkg/config/monitor.go
@@ -19,6 +19,34 @@ type MonitorSettings struct {
 	AllowedIPTablesChains []string `yaml:"allowedIPTablesChains,omitempty" json:"allowedIPTablesChains,omitempty"`
 }
 
+// EventConfig holds agent-level event configuration.
+type EventConfig struct {
+	DisabledEvents  []string       `yaml:"disabledEvents,omitempty" json:"disabledEvents,omitempty"`
+	EventThresholds map[string]int `yaml:"eventThresholds,omitempty" json:"eventThresholds,omitempty"`
+}
+
+// IsEventDisabled returns true when an event has been disabled by name.
+func (ec EventConfig) IsEventDisabled(eventName string) bool {
+	return slices.Contains(ec.DisabledEvents, eventName)
+}
+
+// EventThreshold returns a configured event threshold, or the provided default.
+func (ec EventConfig) EventThreshold(eventName string, defaultThreshold int) int {
+	if ec.EventThresholds == nil {
+		return defaultThreshold
+	}
+	threshold, exists := ec.EventThresholds[eventName]
+	if !exists {
+		return defaultThreshold
+	}
+	return threshold
+}
+
+// IsZero returns true when no event configuration is set.
+func (ec EventConfig) IsZero() bool {
+	return len(ec.DisabledEvents) == 0 && len(ec.EventThresholds) == 0
+}
+
 // IsEnabled returns true if the monitor is enabled.
 func (ms MonitorSettings) IsEnabled() bool {
 	// Defaults to true when Enabled is nil (not explicitly set).
@@ -31,7 +59,9 @@ func (ms MonitorSettings) IsEnabled() bool {
 
 // MonitorConfig is the top-level configuration structure.
 type MonitorConfig struct {
-	Monitors map[string]MonitorSettings `yaml:"monitors,omitempty" json:"monitors,omitempty"`
+	Monitors        map[string]MonitorSettings `yaml:"monitors,omitempty" json:"monitors,omitempty"`
+	DisabledEvents  []string                   `yaml:"disabledEvents,omitempty" json:"disabledEvents,omitempty"`
+	EventThresholds map[string]int             `yaml:"eventThresholds,omitempty" json:"eventThresholds,omitempty"`
 }
 
 // IsMonitorEnabled checks if a given plugin is enabled.
@@ -60,6 +90,17 @@ func (mc *MonitorConfig) GetAllowedIPTablesChains() []string {
 	return settings.AllowedIPTablesChains
 }
 
+// GetEventConfig returns the agent-level event configuration.
+func (mc *MonitorConfig) GetEventConfig() EventConfig {
+	if mc == nil {
+		return EventConfig{}
+	}
+	return EventConfig{
+		DisabledEvents:  mc.DisabledEvents,
+		EventThresholds: mc.EventThresholds,
+	}
+}
+
 // KnownPluginNames is the set of valid plugin names for validation.
 var KnownPluginNames = []string{
 	"kernel-monitor",
@@ -70,10 +111,18 @@ var KnownPluginNames = []string{
 	"runtime",
 }
 
+// KnownEventNames is the set of valid agent event names for validation.
+var KnownEventNames = []string{
+	"LargeEnvironment",
+}
+
 // Validate checks that all keys in Monitors are known plugin names.
 func (mc *MonitorConfig) Validate() error {
-	if mc == nil || mc.Monitors == nil {
+	if mc == nil {
 		return nil
+	}
+	if mc.Monitors == nil {
+		return mc.GetEventConfig().Validate()
 	}
 	var unknown []string
 	for name := range mc.Monitors {
@@ -100,6 +149,40 @@ func (mc *MonitorConfig) Validate() error {
 				}
 			}
 		}
+	}
+	if err := mc.GetEventConfig().Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate checks that event configuration values are well-formed.
+func (ec EventConfig) Validate() error {
+	for _, eventName := range ec.DisabledEvents {
+		if err := validateEventName("disabledEvents", eventName); err != nil {
+			return err
+		}
+	}
+	for eventName, threshold := range ec.EventThresholds {
+		if err := validateEventName("eventThresholds", eventName); err != nil {
+			return err
+		}
+		if threshold <= 0 {
+			return fmt.Errorf("eventThresholds entry %q must be positive", eventName)
+		}
+	}
+	return nil
+}
+
+func validateEventName(fieldName, eventName string) error {
+	if strings.TrimSpace(eventName) != eventName {
+		return fmt.Errorf("%s event name %q must not have leading or trailing whitespace", fieldName, eventName)
+	}
+	if eventName == "" {
+		return fmt.Errorf("%s event name must not be empty", fieldName)
+	}
+	if !slices.Contains(KnownEventNames, eventName) {
+		return fmt.Errorf("%s event name %q is not supported", fieldName, eventName)
 	}
 	return nil
 }

--- a/pkg/config/monitor_test.go
+++ b/pkg/config/monitor_test.go
@@ -179,6 +179,120 @@ func TestGetAllowedIPTablesChains(t *testing.T) {
 	})
 }
 
+func TestGetEventConfig(t *testing.T) {
+	t.Run("NilConfig", func(t *testing.T) {
+		var cfg *config.MonitorConfig
+		assert.Equal(t, config.EventConfig{}, cfg.GetEventConfig())
+	})
+	t.Run("WithEventConfig", func(t *testing.T) {
+		cfg := &config.MonitorConfig{
+			DisabledEvents:  []string{"LargeEnvironment"},
+			EventThresholds: map[string]int{"LargeEnvironment": 2000},
+		}
+		assert.Equal(t, config.EventConfig{
+			DisabledEvents:  []string{"LargeEnvironment"},
+			EventThresholds: map[string]int{"LargeEnvironment": 2000},
+		}, cfg.GetEventConfig())
+	})
+}
+
+func TestLoadMonitorConfig_EventConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`disabledEvents:
+  - LargeEnvironment
+eventThresholds:
+  LargeEnvironment: 2000
+monitors:
+  kernel-monitor:
+    enabled: true
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.True(t, found)
+	assert.Equal(t, []string{"LargeEnvironment"}, cfg.DisabledEvents)
+	assert.Equal(t, map[string]int{"LargeEnvironment": 2000}, cfg.EventThresholds)
+}
+
+func TestLoadMonitorConfig_EventNameWithWhitespaceRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`disabledEvents:
+  - " LargeEnvironment "
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "must not have leading or trailing whitespace")
+}
+
+func TestLoadMonitorConfig_EmptyEventNameRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`disabledEvents:
+  - ""
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestLoadMonitorConfig_NonPositiveEventThresholdRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`eventThresholds:
+  LargeEnvironment: 0
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "must be positive")
+}
+
+func TestLoadMonitorConfig_UnsupportedEventNameRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`disabledEvents:
+  - TypoEvent
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "is not supported")
+}
+
+func TestLoadMonitorConfig_EventThresholdNameWithWhitespaceRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`eventThresholds:
+  " LargeEnvironment ": 2000
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "must not have leading or trailing whitespace")
+}
+
 func TestLoadMonitorConfig_AllowedIPTablesChains(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
**Issue #, if available**: Fixes https://github.com/aws/eks-node-monitoring-agent/issues/108

**Description of changes**:
Adds agent-level event configuration through `disabledEvents` and `eventThresholds` in `/etc/nma/config.yaml` and the Helm chart values. The settings are validated against supported event names and positive thresholds, then injected into monitors that implement `SetEventConfig`.

This initially wires the configuration to the kernel monitor's `LargeEnvironment` event, preserving the existing default behavior of reporting only when the environment variable count is greater than 1000. Users can now suppress that event or raise/lower its threshold without disabling the entire kernel monitor.

**Testing Done**:
- `go test ./pkg/config ./monitors/kernel`
- `git diff --check`
- `make helm-lint`
- `make helm-template HELM_FLAGS='--set nodeAgent.disabledEvents[0]=LargeEnvironment --set nodeAgent.eventThresholds.LargeEnvironment=2000'`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
