### PR TITLE
feat: allow configuring the name of the cni daemonset

### DIFF
--- a/monitors/networking/monitor.go
+++ b/monitors/networking/monitor.go
@@ -1007,7 +1007,7 @@ func (m *NetworkingMonitor) isVPCCNIInstalled() (string, bool, error) {
 	}
 	for _, path := range dirs {
 		// this is only a first filter as it may match other pods, e.g. the aws-node-termination-handler
-		if strings.Contains(path.Name(), "_aws-node-") {
+		if strings.Contains(path.Name(), config.VPCCNIPodPrefix()) {
 			if path.Name() == m.vpcCNIPodID {
 				return path.Name(), true, nil
 			}

--- a/pkg/config/hostpath.go
+++ b/pkg/config/hostpath.go
@@ -7,6 +7,8 @@ import (
 
 const HOST_ROOT_ENV = "HOST_ROOT"
 
+const VPC_CNI_POD_PREFIX_ENV = "VPC_CNI_POD_PREFIX"
+
 // HostRoot returns the root path for accessing host filesystem
 // Defaults to "/" if HOST_ROOT environment variable is not set
 func HostRoot() string {
@@ -14,6 +16,16 @@ func HostRoot() string {
 		return root
 	}
 	return "/"
+}
+
+// VPCCNIPodPrefix returns the substring used to match VPC CNI pod log directories
+// in /var/log/pods/. Defaults to the upstream "aws-node" DaemonSet name; override
+// via the VPC_CNI_POD_PREFIX environment variable for installs with a custom name.
+func VPCCNIPodPrefix() string {
+	if prefix, exists := os.LookupEnv(VPC_CNI_POD_PREFIX_ENV); exists {
+		return prefix
+	}
+	return "_aws-node-"
 }
 
 // ToHostPath joins the host root with the given path


### PR DESCRIPTION
**Description of changes**:

got this error but we have cni ... but it's named `aws-cni`
```
{"level":"info","ts":"2026-06-27T17:33:52Z","msg":"Skipping MAC address policy check - VPC CNI is not installed","hostname":"ip-172-16-112-103.us-west-2.compute.internal","monitor":"networking"}
```

renaming it would be a pain (risk of downtime when we delete so need to slowly migrate with nodeselector hackery)
would this env var be acceptable ?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
