### PR TITLE
read ca cert from kubectl config

### DIFF
--- a/cmd/eks-node-monitoring-agent/restconfig.go
+++ b/cmd/eks-node-monitoring-agent/restconfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -47,15 +48,22 @@ func (rcp *podRestConfigProvider) Provide() (*rest.Config, error) {
 	if kubeconfigPath == "" {
 		return nil, fmt.Errorf("could not locate host kubeconfig in expected paths")
 	}
-	caCertPath := pathlib.ResolveCACertPath(config.HostRoot())
-	if caCertPath == "" {
-		return nil, fmt.Errorf("could not locate host CA Certificates in expected paths")
+
+	// the CA the cluster is configured with is the source of truth. it may be
+	// embedded in the kubeconfig (certificate-authority-data) or referenced as a
+	// host file path (certificate-authority); fall back to the well-known host
+	// location only when the kubeconfig specifies neither.
+	overrides := &clientcmd.ConfigOverrides{}
+	if caCertPath, err := rcp.resolveCACertPath(kubeconfigPath); err != nil {
+		return nil, err
+	} else if caCertPath != "" {
+		overrides.ClusterInfo = clientcmdapi.Cluster{CertificateAuthority: caCertPath}
 	}
 
 	// attempt to pick up kubelet's cluster config from the node.
 	restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
-		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{CertificateAuthority: caCertPath}},
+		overrides,
 	).ClientConfig()
 	if err != nil {
 		return nil, err
@@ -84,6 +92,57 @@ func rewriteExecProvider(restConfig *rest.Config, m chrootMapper) error {
 		restConfig.ExecProvider.Args...,
 	)
 	return err
+}
+
+// resolveCACertPath determines the CA certificate the host kubeconfig expects.
+// It returns an empty path (no override needed) when the kubeconfig already
+// embeds certificate-authority-data, the host-root-prefixed path when the
+// kubeconfig references a CA file, and the well-known default location as a
+// last resort.
+func (rcp *podRestConfigProvider) resolveCACertPath(kubeconfigPath string) (string, error) {
+	hostRoot := config.HostRoot()
+
+	kubeconfig, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to load kubeconfig %q: %w", kubeconfigPath, err)
+	}
+
+	cluster := clusterForCurrentContext(kubeconfig)
+	if cluster != nil {
+		// embedded CA data is self-contained; let clientcmd use it as-is.
+		if len(cluster.CertificateAuthorityData) > 0 {
+			return "", nil
+		}
+		// a referenced CA file path is relative to the host, so prefix it with
+		// the host root unless it already points inside the mount.
+		if caCertPath := cluster.CertificateAuthority; caCertPath != "" {
+			if hostRoot != "/" && !strings.HasPrefix(caCertPath, hostRoot) {
+				caCertPath = filepath.Join(hostRoot, caCertPath)
+			}
+			return caCertPath, nil
+		}
+	}
+
+	if caCertPath := pathlib.ResolveCACertPath(hostRoot); caCertPath != "" {
+		return caCertPath, nil
+	}
+	return "", fmt.Errorf("could not locate host CA Certificates in expected paths")
+}
+
+// clusterForCurrentContext returns the cluster referenced by the kubeconfig's
+// current context, falling back to the sole cluster when unambiguous.
+func clusterForCurrentContext(kubeconfig *clientcmdapi.Config) *clientcmdapi.Cluster {
+	if ctx, ok := kubeconfig.Contexts[kubeconfig.CurrentContext]; ok {
+		if cluster, ok := kubeconfig.Clusters[ctx.Cluster]; ok {
+			return cluster
+		}
+	}
+	if len(kubeconfig.Clusters) == 1 {
+		for _, cluster := range kubeconfig.Clusters {
+			return cluster
+		}
+	}
+	return nil
 }
 
 type chrootMapper struct{}

--- a/cmd/eks-node-monitoring-agent/restconfig.go
+++ b/cmd/eks-node-monitoring-agent/restconfig.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -94,55 +93,14 @@ func rewriteExecProvider(restConfig *rest.Config, m chrootMapper) error {
 	return err
 }
 
-// resolveCACertPath determines the CA certificate the host kubeconfig expects.
-// It returns an empty path (no override needed) when the kubeconfig already
-// embeds certificate-authority-data, the host-root-prefixed path when the
-// kubeconfig references a CA file, and the well-known default location as a
-// last resort.
+// resolveCACertPath determines the CA certificate the host kubeconfig expects
+// for the cluster of its current context.
 func (rcp *podRestConfigProvider) resolveCACertPath(kubeconfigPath string) (string, error) {
-	hostRoot := config.HostRoot()
-
 	kubeconfig, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to load kubeconfig %q: %w", kubeconfigPath, err)
 	}
-
-	cluster := clusterForCurrentContext(kubeconfig)
-	if cluster != nil {
-		// embedded CA data is self-contained; let clientcmd use it as-is.
-		if len(cluster.CertificateAuthorityData) > 0 {
-			return "", nil
-		}
-		// a referenced CA file path is relative to the host, so prefix it with
-		// the host root unless it already points inside the mount.
-		if caCertPath := cluster.CertificateAuthority; caCertPath != "" {
-			if hostRoot != "/" && !strings.HasPrefix(caCertPath, hostRoot) {
-				caCertPath = filepath.Join(hostRoot, caCertPath)
-			}
-			return caCertPath, nil
-		}
-	}
-
-	if caCertPath := pathlib.ResolveCACertPath(hostRoot); caCertPath != "" {
-		return caCertPath, nil
-	}
-	return "", fmt.Errorf("could not locate host CA Certificates in expected paths")
-}
-
-// clusterForCurrentContext returns the cluster referenced by the kubeconfig's
-// current context, falling back to the sole cluster when unambiguous.
-func clusterForCurrentContext(kubeconfig *clientcmdapi.Config) *clientcmdapi.Cluster {
-	if ctx, ok := kubeconfig.Contexts[kubeconfig.CurrentContext]; ok {
-		if cluster, ok := kubeconfig.Clusters[ctx.Cluster]; ok {
-			return cluster
-		}
-	}
-	if len(kubeconfig.Clusters) == 1 {
-		for _, cluster := range kubeconfig.Clusters {
-			return cluster
-		}
-	}
-	return nil
+	return pathlib.ResolveClusterCACert(config.HostRoot(), pathlib.ClusterForCurrentContext(kubeconfig))
 }
 
 type chrootMapper struct{}

--- a/cmd/eks-node-monitoring-agent/restconfig_test.go
+++ b/cmd/eks-node-monitoring-agent/restconfig_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 )
 
 func TestRewriteExecProvider(t *testing.T) {
@@ -36,4 +40,147 @@ func TestRewriteExecProvider(t *testing.T) {
 			t.Fatalf("original command not preserved in args: %v", cfg.ExecProvider.Args)
 		}
 	})
+}
+
+func TestResolveCACertPath(t *testing.T) {
+	t.Run("embedded CA data needs no override", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{
+			CertificateAuthorityData: []byte("---embedded ca---"),
+		})
+
+		caCertPath, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if caCertPath != "" {
+			t.Fatalf("expected empty path for embedded CA data, got %q", caCertPath)
+		}
+	})
+
+	t.Run("referenced CA file is prefixed with the host root", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{
+			CertificateAuthority: "/etc/kubernetes/pki/ca.crt",
+		})
+
+		caCertPath, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := filepath.Join(hostRoot, "/etc/kubernetes/pki/ca.crt"); caCertPath != want {
+			t.Fatalf("expected %q, got %q", want, caCertPath)
+		}
+	})
+
+	t.Run("referenced CA file already inside the host root is left as-is", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		caCertPath := filepath.Join(hostRoot, "/etc/kubernetes/pki/ca.crt")
+		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{
+			CertificateAuthority: caCertPath,
+		})
+
+		got, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != caCertPath {
+			t.Fatalf("expected %q unchanged, got %q", caCertPath, got)
+		}
+	})
+
+	t.Run("falls back to the well-known host location", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		wellKnown := filepath.Join(hostRoot, "/etc/kubernetes/pki/ca.crt")
+		if err := os.MkdirAll(filepath.Dir(wellKnown), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(wellKnown, []byte("---ca---"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{})
+
+		got, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != wellKnown {
+			t.Fatalf("expected %q, got %q", wellKnown, got)
+		}
+	})
+
+	t.Run("errors when no CA can be located", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{})
+
+		if _, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath); err == nil {
+			t.Fatal("expected an error when no CA can be located")
+		}
+	})
+
+	t.Run("errors when the kubeconfig cannot be loaded", func(t *testing.T) {
+		if _, err := (&podRestConfigProvider{}).resolveCACertPath("/does/not/exist"); err == nil {
+			t.Fatal("expected an error for a missing kubeconfig")
+		}
+	})
+}
+
+func TestClusterForCurrentContext(t *testing.T) {
+	t.Run("resolves the cluster referenced by the current context", func(t *testing.T) {
+		want := &clientcmdapi.Cluster{Server: "https://current"}
+		kubeconfig := &clientcmdapi.Config{
+			CurrentContext: "ctx",
+			Contexts:       map[string]*clientcmdapi.Context{"ctx": {Cluster: "wanted"}},
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"wanted": want,
+				"other":  {Server: "https://other"},
+			},
+		}
+		if got := clusterForCurrentContext(kubeconfig); got != want {
+			t.Fatalf("expected %+v, got %+v", want, got)
+		}
+	})
+
+	t.Run("falls back to the sole cluster when the context is missing", func(t *testing.T) {
+		want := &clientcmdapi.Cluster{Server: "https://only"}
+		kubeconfig := &clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{"only": want},
+		}
+		if got := clusterForCurrentContext(kubeconfig); got != want {
+			t.Fatalf("expected the sole cluster, got %+v", got)
+		}
+	})
+
+	t.Run("returns nil when the context is missing and clusters are ambiguous", func(t *testing.T) {
+		kubeconfig := &clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"a": {Server: "https://a"},
+				"b": {Server: "https://b"},
+			},
+		}
+		if got := clusterForCurrentContext(kubeconfig); got != nil {
+			t.Fatalf("expected nil for ambiguous clusters, got %+v", got)
+		}
+	})
+}
+
+// writeKubeconfig writes a minimal kubeconfig with a single "test" cluster/context
+// under hostRoot and returns its path.
+func writeKubeconfig(t *testing.T, hostRoot string, cluster *clientcmdapi.Cluster) string {
+	t.Helper()
+	kubeconfig := clientcmdapi.Config{
+		CurrentContext: "test",
+		Contexts:       map[string]*clientcmdapi.Context{"test": {Cluster: "test"}},
+		Clusters:       map[string]*clientcmdapi.Cluster{"test": cluster},
+	}
+	kubeconfigPath := filepath.Join(hostRoot, "kubeconfig")
+	if err := clientcmd.WriteToFile(kubeconfig, kubeconfigPath); err != nil {
+		t.Fatal(err)
+	}
+	return kubeconfigPath
 }

--- a/cmd/eks-node-monitoring-agent/restconfig_test.go
+++ b/cmd/eks-node-monitoring-agent/restconfig_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -43,23 +42,7 @@ func TestRewriteExecProvider(t *testing.T) {
 }
 
 func TestResolveCACertPath(t *testing.T) {
-	t.Run("embedded CA data needs no override", func(t *testing.T) {
-		hostRoot := t.TempDir()
-		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
-		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{
-			CertificateAuthorityData: []byte("---embedded ca---"),
-		})
-
-		caCertPath, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if caCertPath != "" {
-			t.Fatalf("expected empty path for embedded CA data, got %q", caCertPath)
-		}
-	})
-
-	t.Run("referenced CA file is prefixed with the host root", func(t *testing.T) {
+	t.Run("resolves the CA of the kubeconfig's current context", func(t *testing.T) {
 		hostRoot := t.TempDir()
 		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
 		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{
@@ -75,96 +58,9 @@ func TestResolveCACertPath(t *testing.T) {
 		}
 	})
 
-	t.Run("referenced CA file already inside the host root is left as-is", func(t *testing.T) {
-		hostRoot := t.TempDir()
-		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
-		caCertPath := filepath.Join(hostRoot, "/etc/kubernetes/pki/ca.crt")
-		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{
-			CertificateAuthority: caCertPath,
-		})
-
-		got, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != caCertPath {
-			t.Fatalf("expected %q unchanged, got %q", caCertPath, got)
-		}
-	})
-
-	t.Run("falls back to the well-known host location", func(t *testing.T) {
-		hostRoot := t.TempDir()
-		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
-		wellKnown := filepath.Join(hostRoot, "/etc/kubernetes/pki/ca.crt")
-		if err := os.MkdirAll(filepath.Dir(wellKnown), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(wellKnown, []byte("---ca---"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{})
-
-		got, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != wellKnown {
-			t.Fatalf("expected %q, got %q", wellKnown, got)
-		}
-	})
-
-	t.Run("errors when no CA can be located", func(t *testing.T) {
-		hostRoot := t.TempDir()
-		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
-		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{})
-
-		if _, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath); err == nil {
-			t.Fatal("expected an error when no CA can be located")
-		}
-	})
-
 	t.Run("errors when the kubeconfig cannot be loaded", func(t *testing.T) {
 		if _, err := (&podRestConfigProvider{}).resolveCACertPath("/does/not/exist"); err == nil {
 			t.Fatal("expected an error for a missing kubeconfig")
-		}
-	})
-}
-
-func TestClusterForCurrentContext(t *testing.T) {
-	t.Run("resolves the cluster referenced by the current context", func(t *testing.T) {
-		want := &clientcmdapi.Cluster{Server: "https://current"}
-		kubeconfig := &clientcmdapi.Config{
-			CurrentContext: "ctx",
-			Contexts:       map[string]*clientcmdapi.Context{"ctx": {Cluster: "wanted"}},
-			Clusters: map[string]*clientcmdapi.Cluster{
-				"wanted": want,
-				"other":  {Server: "https://other"},
-			},
-		}
-		if got := clusterForCurrentContext(kubeconfig); got != want {
-			t.Fatalf("expected %+v, got %+v", want, got)
-		}
-	})
-
-	t.Run("falls back to the sole cluster when the context is missing", func(t *testing.T) {
-		want := &clientcmdapi.Cluster{Server: "https://only"}
-		kubeconfig := &clientcmdapi.Config{
-			Clusters: map[string]*clientcmdapi.Cluster{"only": want},
-		}
-		if got := clusterForCurrentContext(kubeconfig); got != want {
-			t.Fatalf("expected the sole cluster, got %+v", got)
-		}
-	})
-
-	t.Run("returns nil when the context is missing and clusters are ambiguous", func(t *testing.T) {
-		kubeconfig := &clientcmdapi.Config{
-			Clusters: map[string]*clientcmdapi.Cluster{
-				"a": {Server: "https://a"},
-				"b": {Server: "https://b"},
-			},
-		}
-		if got := clusterForCurrentContext(kubeconfig); got != nil {
-			t.Fatalf("expected nil for ambiguous clusters, got %+v", got)
 		}
 	})
 }

--- a/pkg/log_collector/collect/networking.go
+++ b/pkg/log_collector/collect/networking.go
@@ -162,10 +162,9 @@ func apiServerConnectivity(acc *Accessor) error {
 		}
 		caData := cluster.CertificateAuthorityData
 		if len(caData) == 0 {
-			caCertPath := cluster.CertificateAuthority
-			// fixup the path if it comes from the host machine
-			if acc.cfg.Root != "/" && !strings.HasPrefix(caCertPath, acc.cfg.Root) {
-				caCertPath = filepath.Join(acc.cfg.Root, caCertPath)
+			caCertPath, err := pathlib.ResolveClusterCACert(acc.cfg.Root, cluster)
+			if err != nil {
+				return err
 			}
 			caBytes, err := os.ReadFile(caCertPath)
 			if err != nil {

--- a/pkg/pathlib/kubelet.go
+++ b/pkg/pathlib/kubelet.go
@@ -1,14 +1,60 @@
 package pathlib
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const DefaultCACertPath = "/etc/kubernetes/pki/ca.crt"
 
 func ResolveCACertPath(hostRoot string) string {
 	return ResolvePathOption(hostRoot, filepath.Join(hostRoot, DefaultCACertPath))
+}
+
+// ResolveClusterCACert determines the CA certificate a kubeconfig cluster expects.
+// It returns an empty path when the cluster embeds certificate-authority-data
+// (which is self-contained and needs no file), the host-root-prefixed path when
+// the cluster references a CA file, and the well-known host location as a last
+// resort.
+func ResolveClusterCACert(hostRoot string, cluster *clientcmdapi.Cluster) (string, error) {
+	if cluster != nil {
+		if len(cluster.CertificateAuthorityData) > 0 {
+			return "", nil
+		}
+		// a referenced CA file path is relative to the host, so prefix it with
+		// the host root unless it already points inside the mount.
+		if caCertPath := cluster.CertificateAuthority; caCertPath != "" {
+			if hostRoot != "/" && !strings.HasPrefix(caCertPath, hostRoot) {
+				caCertPath = filepath.Join(hostRoot, caCertPath)
+			}
+			return caCertPath, nil
+		}
+	}
+
+	if caCertPath := ResolveCACertPath(hostRoot); caCertPath != "" {
+		return caCertPath, nil
+	}
+	return "", fmt.Errorf("could not locate host CA Certificates in expected paths")
+}
+
+// ClusterForCurrentContext returns the cluster referenced by the kubeconfig's
+// current context, falling back to the sole cluster when unambiguous.
+func ClusterForCurrentContext(kubeconfig *clientcmdapi.Config) *clientcmdapi.Cluster {
+	if ctx, ok := kubeconfig.Contexts[kubeconfig.CurrentContext]; ok {
+		if cluster, ok := kubeconfig.Clusters[ctx.Cluster]; ok {
+			return cluster
+		}
+	}
+	if len(kubeconfig.Clusters) == 1 {
+		for _, cluster := range kubeconfig.Clusters {
+			return cluster
+		}
+	}
+	return nil
 }
 
 func ResolveKubeletConfigDropIn(hostRoot string) string {

--- a/pkg/pathlib/kubelet_test.go
+++ b/pkg/pathlib/kubelet_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestResolvePath(t *testing.T) {
@@ -66,6 +67,81 @@ func TestResolvePath(t *testing.T) {
 			assert.Empty(t, test.resolver(root))
 		})
 	}
+}
+
+func TestResolveClusterCACert(t *testing.T) {
+	t.Run("embedded CA data needs no path", func(t *testing.T) {
+		caCertPath, err := ResolveClusterCACert(t.TempDir(), &clientcmdapi.Cluster{
+			CertificateAuthorityData: []byte("---embedded ca---"),
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, caCertPath)
+	})
+
+	t.Run("referenced CA file is prefixed with the host root", func(t *testing.T) {
+		root := t.TempDir()
+		caCertPath, err := ResolveClusterCACert(root, &clientcmdapi.Cluster{
+			CertificateAuthority: DefaultCACertPath,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(root, DefaultCACertPath), caCertPath)
+	})
+
+	t.Run("referenced CA file already inside the host root is left as-is", func(t *testing.T) {
+		root := t.TempDir()
+		want := filepath.Join(root, DefaultCACertPath)
+		caCertPath, err := ResolveClusterCACert(root, &clientcmdapi.Cluster{CertificateAuthority: want})
+		assert.NoError(t, err)
+		assert.Equal(t, want, caCertPath)
+	})
+
+	t.Run("falls back to the well-known host location", func(t *testing.T) {
+		root := t.TempDir()
+		SetupFile(t, root, DefaultCACertPath)
+		caCertPath, err := ResolveClusterCACert(root, &clientcmdapi.Cluster{})
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(root, DefaultCACertPath), caCertPath)
+	})
+
+	t.Run("errors when no CA can be located", func(t *testing.T) {
+		_, err := ResolveClusterCACert(t.TempDir(), &clientcmdapi.Cluster{})
+		assert.Error(t, err)
+	})
+
+	t.Run("errors for a nil cluster without a well-known CA", func(t *testing.T) {
+		_, err := ResolveClusterCACert(t.TempDir(), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestClusterForCurrentContext(t *testing.T) {
+	t.Run("resolves the cluster referenced by the current context", func(t *testing.T) {
+		want := &clientcmdapi.Cluster{Server: "https://current"}
+		assert.Same(t, want, ClusterForCurrentContext(&clientcmdapi.Config{
+			CurrentContext: "ctx",
+			Contexts:       map[string]*clientcmdapi.Context{"ctx": {Cluster: "wanted"}},
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"wanted": want,
+				"other":  {Server: "https://other"},
+			},
+		}))
+	})
+
+	t.Run("falls back to the sole cluster when the context is missing", func(t *testing.T) {
+		want := &clientcmdapi.Cluster{Server: "https://only"}
+		assert.Same(t, want, ClusterForCurrentContext(&clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{"only": want},
+		}))
+	})
+
+	t.Run("returns nil when the context is missing and clusters are ambiguous", func(t *testing.T) {
+		assert.Nil(t, ClusterForCurrentContext(&clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"a": {Server: "https://a"},
+				"b": {Server: "https://b"},
+			},
+		}))
+	})
 }
 
 func SetupFile(t *testing.T, root, file string) {


### PR DESCRIPTION
**Description of changes**:
atm /etc/kubernetes/pki/ca.crt is hardcoded
user can't override it and the kubectl config that has a field for it is not read

... so let's read it from the kubeclt config

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.