### PR TITLE
fix: resolve kubeconfig client certificate paths against the host mount

### DIFF
--- a/cmd/eks-node-monitoring-agent/restconfig.go
+++ b/cmd/eks-node-monitoring-agent/restconfig.go
@@ -91,9 +91,9 @@ func rewriteExecProvider(restConfig *rest.Config, m chrootMapper) error {
 }
 
 // hostPathOverrides builds clientcmd overrides that resolve the file paths the
-// host kubeconfig references (CA certificate, client certificate, client key)
-// against the host filesystem mount. Credentials embedded as *-data are
-// self-contained and left untouched.
+// host kubeconfig references (CA certificate, client certificate, client key,
+// token file) against the host filesystem mount. Credentials embedded in the
+// kubeconfig are self-contained and left untouched.
 func (rcp *podRestConfigProvider) hostPathOverrides(kubeconfigPath string) (*clientcmd.ConfigOverrides, error) {
 	hostRoot := config.HostRoot()
 
@@ -117,13 +117,19 @@ func (rcp *podRestConfigProvider) hostPathOverrides(kubeconfigPath string) (*cli
 	}
 
 	// kubeconfigs that authenticate with a client certificate (e.g. on
-	// kops-provisioned nodes) reference the certificate and key by host path too.
+	// kops-provisioned nodes) reference the certificate and key by host path too,
+	// as does a token read from a file (tokenFile).
 	if authInfo := pathlib.AuthInfoForCurrentContext(kubeconfig); authInfo != nil {
 		if len(authInfo.ClientCertificateData) == 0 {
 			overrides.AuthInfo.ClientCertificate = pathlib.HostPath(hostRoot, authInfo.ClientCertificate)
 		}
 		if len(authInfo.ClientKeyData) == 0 {
 			overrides.AuthInfo.ClientKey = pathlib.HostPath(hostRoot, authInfo.ClientKey)
+		}
+		// an inline token takes precedence over tokenFile, so only the latter
+		// needs a path.
+		if len(authInfo.Token) == 0 {
+			overrides.AuthInfo.TokenFile = pathlib.HostPath(hostRoot, authInfo.TokenFile)
 		}
 	}
 

--- a/cmd/eks-node-monitoring-agent/restconfig.go
+++ b/cmd/eks-node-monitoring-agent/restconfig.go
@@ -48,15 +48,12 @@ func (rcp *podRestConfigProvider) Provide() (*rest.Config, error) {
 		return nil, fmt.Errorf("could not locate host kubeconfig in expected paths")
 	}
 
-	// the CA the cluster is configured with is the source of truth. it may be
-	// embedded in the kubeconfig (certificate-authority-data) or referenced as a
-	// host file path (certificate-authority); fall back to the well-known host
-	// location only when the kubeconfig specifies neither.
-	overrides := &clientcmd.ConfigOverrides{}
-	if caCertPath, err := rcp.resolveCACertPath(kubeconfigPath); err != nil {
+	// the kubeconfig references its TLS material by path relative to the host,
+	// but the agent reads the host filesystem through a mount, so build
+	// overrides that resolve those paths against it.
+	overrides, err := rcp.hostPathOverrides(kubeconfigPath)
+	if err != nil {
 		return nil, err
-	} else if caCertPath != "" {
-		overrides.ClusterInfo = clientcmdapi.Cluster{CertificateAuthority: caCertPath}
 	}
 
 	// attempt to pick up kubelet's cluster config from the node.
@@ -93,14 +90,44 @@ func rewriteExecProvider(restConfig *rest.Config, m chrootMapper) error {
 	return err
 }
 
-// resolveCACertPath determines the CA certificate the host kubeconfig expects
-// for the cluster of its current context.
-func (rcp *podRestConfigProvider) resolveCACertPath(kubeconfigPath string) (string, error) {
+// hostPathOverrides builds clientcmd overrides that resolve the file paths the
+// host kubeconfig references (CA certificate, client certificate, client key)
+// against the host filesystem mount. Credentials embedded as *-data are
+// self-contained and left untouched.
+func (rcp *podRestConfigProvider) hostPathOverrides(kubeconfigPath string) (*clientcmd.ConfigOverrides, error) {
+	hostRoot := config.HostRoot()
+
 	kubeconfig, err := clientcmd.LoadFromFile(kubeconfigPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to load kubeconfig %q: %w", kubeconfigPath, err)
+		return nil, fmt.Errorf("failed to load kubeconfig %q: %w", kubeconfigPath, err)
 	}
-	return pathlib.ResolveClusterCACert(config.HostRoot(), pathlib.ClusterForCurrentContext(kubeconfig))
+
+	overrides := &clientcmd.ConfigOverrides{}
+
+	// the CA the cluster is configured with is the source of truth. it may be
+	// embedded in the kubeconfig (certificate-authority-data) or referenced as a
+	// host file path (certificate-authority); fall back to the well-known host
+	// location only when the kubeconfig specifies neither.
+	caCertPath, err := pathlib.ResolveClusterCACert(hostRoot, pathlib.ClusterForCurrentContext(kubeconfig))
+	if err != nil {
+		return nil, err
+	}
+	if caCertPath != "" {
+		overrides.ClusterInfo = clientcmdapi.Cluster{CertificateAuthority: caCertPath}
+	}
+
+	// kubeconfigs that authenticate with a client certificate (e.g. on
+	// kops-provisioned nodes) reference the certificate and key by host path too.
+	if authInfo := pathlib.AuthInfoForCurrentContext(kubeconfig); authInfo != nil {
+		if len(authInfo.ClientCertificateData) == 0 {
+			overrides.AuthInfo.ClientCertificate = pathlib.HostPath(hostRoot, authInfo.ClientCertificate)
+		}
+		if len(authInfo.ClientKeyData) == 0 {
+			overrides.AuthInfo.ClientKey = pathlib.HostPath(hostRoot, authInfo.ClientKey)
+		}
+	}
+
+	return overrides, nil
 }
 
 type chrootMapper struct{}

--- a/cmd/eks-node-monitoring-agent/restconfig_test.go
+++ b/cmd/eks-node-monitoring-agent/restconfig_test.go
@@ -41,38 +41,88 @@ func TestRewriteExecProvider(t *testing.T) {
 	})
 }
 
-func TestResolveCACertPath(t *testing.T) {
+func TestHostPathOverrides(t *testing.T) {
 	t.Run("resolves the CA of the kubeconfig's current context", func(t *testing.T) {
 		hostRoot := t.TempDir()
 		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
 		kubeconfigPath := writeKubeconfig(t, hostRoot, &clientcmdapi.Cluster{
 			CertificateAuthority: "/etc/kubernetes/pki/ca.crt",
-		})
+		}, nil)
 
-		caCertPath, err := (&podRestConfigProvider{}).resolveCACertPath(kubeconfigPath)
+		overrides, err := (&podRestConfigProvider{}).hostPathOverrides(kubeconfigPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if want := filepath.Join(hostRoot, "/etc/kubernetes/pki/ca.crt"); caCertPath != want {
-			t.Fatalf("expected %q, got %q", want, caCertPath)
+		if want := filepath.Join(hostRoot, "/etc/kubernetes/pki/ca.crt"); overrides.ClusterInfo.CertificateAuthority != want {
+			t.Fatalf("expected %q, got %q", want, overrides.ClusterInfo.CertificateAuthority)
+		}
+	})
+
+	t.Run("resolves client certificate and key paths against the host root", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		kubeconfigPath := writeKubeconfig(t, hostRoot,
+			&clientcmdapi.Cluster{CertificateAuthority: "/srv/kubernetes/api-server-ca-bundle.crt"},
+			&clientcmdapi.AuthInfo{
+				ClientCertificate: "/srv/kubernetes/kubelet.crt",
+				ClientKey:         "/srv/kubernetes/kubelet.key",
+			},
+		)
+
+		overrides, err := (&podRestConfigProvider{}).hostPathOverrides(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := filepath.Join(hostRoot, "/srv/kubernetes/kubelet.crt"); overrides.AuthInfo.ClientCertificate != want {
+			t.Fatalf("expected client certificate %q, got %q", want, overrides.AuthInfo.ClientCertificate)
+		}
+		if want := filepath.Join(hostRoot, "/srv/kubernetes/kubelet.key"); overrides.AuthInfo.ClientKey != want {
+			t.Fatalf("expected client key %q, got %q", want, overrides.AuthInfo.ClientKey)
+		}
+	})
+
+	t.Run("leaves embedded credentials untouched", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		kubeconfigPath := writeKubeconfig(t, hostRoot,
+			&clientcmdapi.Cluster{CertificateAuthorityData: []byte("ca")},
+			&clientcmdapi.AuthInfo{
+				ClientCertificateData: []byte("cert"),
+				ClientKeyData:         []byte("key"),
+			},
+		)
+
+		overrides, err := (&podRestConfigProvider{}).hostPathOverrides(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if overrides.ClusterInfo.CertificateAuthority != "" {
+			t.Fatalf("expected no CA override, got %q", overrides.ClusterInfo.CertificateAuthority)
+		}
+		if overrides.AuthInfo.ClientCertificate != "" || overrides.AuthInfo.ClientKey != "" {
+			t.Fatalf("expected no client credential overrides, got %q / %q",
+				overrides.AuthInfo.ClientCertificate, overrides.AuthInfo.ClientKey)
 		}
 	})
 
 	t.Run("errors when the kubeconfig cannot be loaded", func(t *testing.T) {
-		if _, err := (&podRestConfigProvider{}).resolveCACertPath("/does/not/exist"); err == nil {
+		if _, err := (&podRestConfigProvider{}).hostPathOverrides("/does/not/exist"); err == nil {
 			t.Fatal("expected an error for a missing kubeconfig")
 		}
 	})
 }
 
-// writeKubeconfig writes a minimal kubeconfig with a single "test" cluster/context
-// under hostRoot and returns its path.
-func writeKubeconfig(t *testing.T, hostRoot string, cluster *clientcmdapi.Cluster) string {
+// writeKubeconfig writes a minimal kubeconfig with a single "test"
+// cluster/user/context under hostRoot and returns its path.
+func writeKubeconfig(t *testing.T, hostRoot string, cluster *clientcmdapi.Cluster, authInfo *clientcmdapi.AuthInfo) string {
 	t.Helper()
 	kubeconfig := clientcmdapi.Config{
 		CurrentContext: "test",
-		Contexts:       map[string]*clientcmdapi.Context{"test": {Cluster: "test"}},
+		Contexts:       map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
 		Clusters:       map[string]*clientcmdapi.Cluster{"test": cluster},
+	}
+	if authInfo != nil {
+		kubeconfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{"test": authInfo}
 	}
 	kubeconfigPath := filepath.Join(hostRoot, "kubeconfig")
 	if err := clientcmd.WriteToFile(kubeconfig, kubeconfigPath); err != nil {

--- a/cmd/eks-node-monitoring-agent/restconfig_test.go
+++ b/cmd/eks-node-monitoring-agent/restconfig_test.go
@@ -81,6 +81,40 @@ func TestHostPathOverrides(t *testing.T) {
 		}
 	})
 
+	t.Run("resolves the token file against the host root", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		kubeconfigPath := writeKubeconfig(t, hostRoot,
+			&clientcmdapi.Cluster{CertificateAuthorityData: []byte("ca")},
+			&clientcmdapi.AuthInfo{TokenFile: "/var/lib/kubelet/token"},
+		)
+
+		overrides, err := (&podRestConfigProvider{}).hostPathOverrides(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := filepath.Join(hostRoot, "/var/lib/kubelet/token"); overrides.AuthInfo.TokenFile != want {
+			t.Fatalf("expected token file %q, got %q", want, overrides.AuthInfo.TokenFile)
+		}
+	})
+
+	t.Run("leaves the token file untouched when an inline token takes precedence", func(t *testing.T) {
+		hostRoot := t.TempDir()
+		t.Setenv(config.HOST_ROOT_ENV, hostRoot)
+		kubeconfigPath := writeKubeconfig(t, hostRoot,
+			&clientcmdapi.Cluster{CertificateAuthorityData: []byte("ca")},
+			&clientcmdapi.AuthInfo{Token: "inline", TokenFile: "/var/lib/kubelet/token"},
+		)
+
+		overrides, err := (&podRestConfigProvider{}).hostPathOverrides(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if overrides.AuthInfo.TokenFile != "" {
+			t.Fatalf("expected no token file override, got %q", overrides.AuthInfo.TokenFile)
+		}
+	})
+
 	t.Run("leaves embedded credentials untouched", func(t *testing.T) {
 		hostRoot := t.TempDir()
 		t.Setenv(config.HOST_ROOT_ENV, hostRoot)

--- a/pkg/pathlib/kubelet.go
+++ b/pkg/pathlib/kubelet.go
@@ -38,9 +38,13 @@ func ResolveClusterCACert(hostRoot string, cluster *clientcmdapi.Cluster) (strin
 
 // HostPath prefixes a host-absolute path with the host root mount, so a path a
 // kubeconfig references can be opened from inside the container. Empty paths and
-// paths already pointing inside the mount are returned unchanged.
+// paths already pointing inside the mount are returned unchanged. The
+// inside-the-mount check compares whole path components, so a sibling like
+// /hostname/pki/ca.crt is still prefixed when the mount is /host.
 func HostPath(hostRoot, path string) string {
-	if path == "" || hostRoot == "/" || strings.HasPrefix(path, hostRoot) {
+	hostRoot = filepath.Clean(hostRoot)
+	insideHostRoot := path == hostRoot || strings.HasPrefix(path, hostRoot+"/")
+	if path == "" || hostRoot == "/" || insideHostRoot {
 		return path
 	}
 	return filepath.Join(hostRoot, path)

--- a/pkg/pathlib/kubelet.go
+++ b/pkg/pathlib/kubelet.go
@@ -25,13 +25,8 @@ func ResolveClusterCACert(hostRoot string, cluster *clientcmdapi.Cluster) (strin
 		if len(cluster.CertificateAuthorityData) > 0 {
 			return "", nil
 		}
-		// a referenced CA file path is relative to the host, so prefix it with
-		// the host root unless it already points inside the mount.
 		if caCertPath := cluster.CertificateAuthority; caCertPath != "" {
-			if hostRoot != "/" && !strings.HasPrefix(caCertPath, hostRoot) {
-				caCertPath = filepath.Join(hostRoot, caCertPath)
-			}
-			return caCertPath, nil
+			return HostPath(hostRoot, caCertPath), nil
 		}
 	}
 
@@ -39,6 +34,32 @@ func ResolveClusterCACert(hostRoot string, cluster *clientcmdapi.Cluster) (strin
 		return caCertPath, nil
 	}
 	return "", fmt.Errorf("could not locate host CA Certificates in expected paths")
+}
+
+// HostPath prefixes a host-absolute path with the host root mount, so a path a
+// kubeconfig references can be opened from inside the container. Empty paths and
+// paths already pointing inside the mount are returned unchanged.
+func HostPath(hostRoot, path string) string {
+	if path == "" || hostRoot == "/" || strings.HasPrefix(path, hostRoot) {
+		return path
+	}
+	return filepath.Join(hostRoot, path)
+}
+
+// AuthInfoForCurrentContext returns the user referenced by the kubeconfig's
+// current context, falling back to the sole user when unambiguous.
+func AuthInfoForCurrentContext(kubeconfig *clientcmdapi.Config) *clientcmdapi.AuthInfo {
+	if ctx, ok := kubeconfig.Contexts[kubeconfig.CurrentContext]; ok {
+		if authInfo, ok := kubeconfig.AuthInfos[ctx.AuthInfo]; ok {
+			return authInfo
+		}
+	}
+	if len(kubeconfig.AuthInfos) == 1 {
+		for _, authInfo := range kubeconfig.AuthInfos {
+			return authInfo
+		}
+	}
+	return nil
 }
 
 // ClusterForCurrentContext returns the cluster referenced by the kubeconfig's

--- a/pkg/pathlib/kubelet_test.go
+++ b/pkg/pathlib/kubelet_test.go
@@ -114,6 +114,32 @@ func TestResolveClusterCACert(t *testing.T) {
 	})
 }
 
+func TestHostPath(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		hostRoot string
+		path     string
+		want     string
+	}{
+		{name: "prefixes a host path", hostRoot: "/host", path: "/srv/kubernetes/kubelet.key",
+			want: "/host/srv/kubernetes/kubelet.key"},
+		{name: "keeps an empty path", hostRoot: "/host", path: "", want: ""},
+		{name: "keeps every path when the host root is /", hostRoot: "/", path: "/etc/kubernetes/pki/ca.crt",
+			want: "/etc/kubernetes/pki/ca.crt"},
+		{name: "keeps a path already inside the host root", hostRoot: "/host", path: "/host/etc/ca.crt",
+			want: "/host/etc/ca.crt"},
+		{name: "keeps the host root itself", hostRoot: "/host", path: "/host", want: "/host"},
+		{name: "prefixes a path that only shares a prefix with the host root", hostRoot: "/host",
+			path: "/hostname/pki/ca.crt", want: "/host/hostname/pki/ca.crt"},
+		{name: "ignores a trailing slash on the host root", hostRoot: "/host/", path: "/host/etc/ca.crt",
+			want: "/host/etc/ca.crt"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, HostPath(test.hostRoot, test.path))
+		})
+	}
+}
+
 func TestClusterForCurrentContext(t *testing.T) {
 	t.Run("resolves the cluster referenced by the current context", func(t *testing.T) {
 		want := &clientcmdapi.Cluster{Server: "https://current"}


### PR DESCRIPTION
The pod rest config provider reads the node's kubeconfig to talk to the API server. The cluster CA is now resolved against the host root mount (#189), but the client credentials the kubeconfig references are still opened at their host-absolute paths.

On nodes whose kubeconfig authenticates with a client certificate (e.g. those provisioned by kops) that material is referenced by absolute host path:

    certificate-authority: /srv/kubernetes/api-server-ca-bundle.crt
    client-certificate:    /srv/kubernetes/kubelet.crt
    client-key:            /srv/kubernetes/kubelet.key

The agent reads the host filesystem through a mount, so clientcmd looks for the certificate and key at the wrong location and the provider fails with:

    invalid configuration: [unable to read client-cert /srv/kubernetes/kubelet.crt for kubelet due to open /srv/kubernetes/kubelet.crt: no such file or directory, unable to read client-key /srv/kubernetes/kubelet.key for kubelet due to open /srv/kubernetes/kubelet.key: no such file or directory]

This is not fatal (`main.go` logs it and falls back to the in-cluster ServiceAccount), so it silently loses the host-kubeconfig auth this provider exists to set up.

Resolve the client certificate and key against the host root as well, reusing the prefixing #189 introduced for the CA (extracted as `pathlib.HostPath`). Credentials embedded as `*-data` are self-contained and left untouched, so exec-based EKS kubeconfigs are unaffected.

Rebased onto main now that #189 and #190 have merged: the CA rewriting and the nil-`ExecProvider` guard that this PR originally also carried are upstream, so this is now only the client certificate/key half.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

