### PR TITLE
Fix auto mode diagnostics fd leaks

### DIFF
--- a/pkg/diagnostic/logger.go
+++ b/pkg/diagnostic/logger.go
@@ -34,6 +34,14 @@ type diagnosticLogger struct {
 
 const (
 	sectionMarker = "NMA::LOG"
+	// maxTailReadBytes bounds how much of a large file is read into memory.
+	// It is generously larger than any per-section console budget, so the
+	// tail-trimmed output is unchanged while memory stays bounded.
+	maxTailReadBytes = 256 * 1024
+	// journalMaxLines bounds journalctl output; without a limit the entire
+	// unit journal is buffered into memory each cycle and grows unbounded
+	// over the node's lifetime. Chosen to comfortably exceed the section budget.
+	journalMaxLines = "2000"
 )
 
 func NewDiagnosticLogger(writer io.Writer, settings Settings) diagnosticLogger {
@@ -122,7 +130,10 @@ func systemdStatus(services ...string) []byte {
 }
 
 func journalctl(unit string) []byte {
-	if out, err := exec.Command("journalctl", "-o", "short-iso-precise", "--unit", unit).Output(); err != nil {
+	// Bound the journal read with --lines: without it the entire unit journal
+	// is buffered into memory each cycle and grows unbounded over the node's
+	// lifetime. The output is tail-trimmed to the section budget anyway.
+	if out, err := exec.Command("journalctl", "-o", "short-iso-precise", "--unit", unit, "--lines", journalMaxLines).Output(); err != nil {
 		return []byte(fmt.Sprintf("failed to call journalctl due to: %s", err))
 	} else {
 		return out
@@ -183,11 +194,34 @@ func dmesg() []byte {
 }
 
 func ipamd() []byte {
-	if out, err := os.ReadFile("/var/log/aws-routed-eni/ipamd.log"); err != nil {
-		return []byte(fmt.Sprintf("failed to read ipamd.log due to: %s", err))
-	} else {
-		return out
+	return readFileTail("/var/log/aws-routed-eni/ipamd.log", maxTailReadBytes)
+}
+
+// readFileTail returns up to the last n bytes of the file at path without
+// reading the whole file into memory. Large logs (which grow over the node's
+// lifetime) would otherwise be fully buffered on every cycle; the caller still
+// trims the result to the section budget via tailx, so the emitted output is
+// unchanged.
+func readFileTail(path string, n int64) []byte {
+	f, err := os.Open(path)
+	if err != nil {
+		return []byte(fmt.Sprintf("failed to read %s due to: %s", path, err))
 	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return []byte(fmt.Sprintf("failed to stat %s due to: %s", path, err))
+	}
+	if info.Size() > n {
+		if _, err := f.Seek(info.Size()-n, io.SeekStart); err != nil {
+			return []byte(fmt.Sprintf("failed to seek %s due to: %s", path, err))
+		}
+	}
+	buf, err := io.ReadAll(io.LimitReader(f, n))
+	if err != nil {
+		return []byte(fmt.Sprintf("failed to read %s due to: %s", path, err))
+	}
+	return buf
 }
 
 func testAPIServerEndpoint(host string) []byte {

--- a/pkg/diagnostic/logger_test.go
+++ b/pkg/diagnostic/logger_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ContextStopsLogger(t *testing.T) {
@@ -35,5 +38,34 @@ func TestUtils(t *testing.T) {
 		assert.Equal(t, "World", string(tailx([]byte("Hello,\nWorld"), 7)))
 		assert.Equal(t, "World\nAgain!", string(tailx([]byte("Hello,\nWorld\nAgain!"), 15)))
 		assert.Equal(t, "Hello,\nWorld\nAgain!", string(tailx([]byte("Hello,\nWorld\nAgain!"), 99)))
+	})
+}
+
+func TestReadFileTail(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("SmallerThanLimit_ReturnsWholeFile", func(t *testing.T) {
+		p := filepath.Join(dir, "small.log")
+		content := []byte("line1\nline2\nline3\n")
+		require.NoError(t, os.WriteFile(p, content, 0o644))
+		assert.Equal(t, content, readFileTail(p, 1024))
+	})
+
+	t.Run("LargerThanLimit_ReturnsBoundedTail", func(t *testing.T) {
+		p := filepath.Join(dir, "big.log")
+		// 1 MiB of filler followed by a known 4 KiB tail; reading with a 4 KiB
+		// limit must return exactly the tail and never the whole file.
+		filler := bytes.Repeat([]byte("A"), 1<<20)
+		tail := bytes.Repeat([]byte("B"), 4096)
+		require.NoError(t, os.WriteFile(p, append(filler, tail...), 0o644))
+
+		got := readFileTail(p, 4096)
+		assert.Len(t, got, 4096, "must not read more than the limit")
+		assert.Equal(t, tail, got, "must return the last n bytes")
+	})
+
+	t.Run("MissingFile_ReturnsErrorMessage", func(t *testing.T) {
+		got := readFileTail(filepath.Join(dir, "does-not-exist.log"), 1024)
+		assert.Contains(t, string(got), "failed to read")
 	})
 }

--- a/pkg/observer/journald.go
+++ b/pkg/observer/journald.go
@@ -32,6 +32,18 @@ func init() {
 
 var journalPaths = []string{"/var/log/journal", "/run/log/journal"}
 
+const (
+	// journalRefreshInterval bounds a single sd_journal handle's lifetime.
+	// sd_journal keeps an FD and mmap window per file in the journal dir, times
+	// two observers, so a long-lived handle accumulates FDs as journald rotates.
+	// We only tail forward, so periodically reopening bounds the open set to the
+	// files currently on disk.
+	journalRefreshInterval = 5 * time.Minute
+	// journalWaitTimeout bounds journal.Wait so the loop wakes to check the
+	// refresh timer even when the journal is idle.
+	journalWaitTimeout = 5 * time.Second
+)
+
 type journalObserver struct {
 	BaseObserver
 	journalBasePath string
@@ -43,37 +55,71 @@ func (o *journalObserver) Identifier() string {
 }
 
 func (o *journalObserver) Init(ctx context.Context) error {
+	journal, err := o.openJournal()
+	if err != nil {
+		return err
+	}
+	return o.watchLoop(ctx, journal)
+}
+
+// openJournal opens a journal handle for this observer's service, positioned at
+// "now" so that only new entries are tailed. The caller owns the returned
+// handle and must Close it.
+func (o *journalObserver) openJournal() (*sdjournal.Journal, error) {
 	journalPath := filepath.Join(config.HostRoot(), o.journalBasePath)
 
 	journal, err := sdjournal.NewJournalFromDir(journalPath)
 	if err != nil {
-		return fmt.Errorf("failed to create journal client from path %q: %w", journalPath, err)
+		return nil, fmt.Errorf("failed to create journal client from path %q: %w", journalPath, err)
 	}
 	startTime := time.Now()
-	if err = journal.SeekRealtimeUsec(util.TimeToJournalTimestamp(startTime)); err != nil {
-		return fmt.Errorf("failed to seek journal at %v: %w", startTime, err)
+	if err := journal.SeekRealtimeUsec(util.TimeToJournalTimestamp(startTime)); err != nil {
+		journal.Close()
+		return nil, fmt.Errorf("failed to seek journal at %v: %w", startTime, err)
 	}
 	match := sdjournal.Match{
 		Field: sdjournal.SD_JOURNAL_FIELD_SYSLOG_IDENTIFIER,
 		Value: o.serviceName,
 	}
 	if err := journal.AddMatch(match.String()); err != nil {
-		return fmt.Errorf("failed to add journal filter for service %q due to: %s", o.serviceName, err)
+		journal.Close()
+		return nil, fmt.Errorf("failed to add journal filter for service %q due to: %s", o.serviceName, err)
 	}
-	return o.watchLoop(ctx, journal)
+	return journal, nil
 }
 
 func (o *journalObserver) watchLoop(ctx context.Context, journal *sdjournal.Journal) error {
 	logger := log.FromContext(ctx)
+	// Close whichever handle is current when the loop exits. A closure is used
+	// so it observes reassignments of journal made during refresh below.
+	defer func() { journal.Close() }()
+
+	lastRefresh := time.Now()
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		// Refresh the handle to release FDs/mmaps for rotated or vacuumed files.
+		// Safe on this single goroutine (sd_journal isn't thread-safe); reseeking
+		// to "now" loses at most the window between close and reopen.
+		if time.Since(lastRefresh) >= journalRefreshInterval {
+			if refreshed, err := o.openJournal(); err != nil {
+				logger.Error(err, "failed to refresh journal handle; keeping existing handle")
+			} else {
+				journal.Close()
+				journal = refreshed
+			}
+			// Advance the timer even on failure, so a failing refresh retries
+			// once per interval rather than on every loop iteration.
+			lastRefresh = time.Now()
+		}
+
 		n, err := journal.Next()
 		if err != nil {
 			logger.Error(err, "failed to get next journal entry")
 			return
 		}
 		if n == 0 {
-			// Sleep until something happens on the journal
-			journal.Wait(sdjournal.IndefiniteWait)
+			// Wait (bounded) so the loop wakes to re-check the refresh timer
+			// even when no new entries arrive.
+			journal.Wait(journalWaitTimeout)
 			return
 		}
 		entry, err := journal.GetEntry()


### PR DESCRIPTION
**Issue #, if available**:
#194 

**Description of changes**:

This addresses two independent leaks that surface on EKS Auto Mode under sustained pod churn, kept as two commits so either can be reverted on its own.

The first commit bounds the console diagnostics logger. It read several sources in full every five minutes and kept only a short tail, so the ipamd log and the kubelet and containerd journals, which grow with churn, were each buffered whole on every cycle. The ipamd producer now seeks to the last 256 KiB instead of reading the whole file, and the journalctl producers pass --lines so journald caps its own output. The emitted console output is unchanged, since each section was already tail-trimmed; only the wasted read is removed.

The second commit refreshes the journald observers. Each observer opens the whole journal directory through sd_journal, which keeps a file descriptor and an mmap window on every file in that directory, and the agent runs one observer per unit, so a handle that is opened once and never refreshed accumulates descriptors as journald rotates. Because the observers only tail forward from now, the handle is now periodically closed, reopened, and reseeked, which releases descriptors and mmap windows for rotated or vacuumed files and bounds the open set to the files currently on disk. The watch loop uses a bounded wait so it wakes to check the timer when idle, and the seek and match error paths now close the handle instead of leaking it.

**Testing Done**:
Unit tests pass, including a new test covering the bounded tail read and the existing journald observer suite, and the full build (vet, fmt, compile) is clean. The journald fix was validated on a running test node by deploying the build, forcing repeated journald rotations followed by an aggressive vacuum that deleted archived journals, and confirming the agent's open file descriptors tracked the on-disk journal file count with no leaked descriptors to deleted files, while the agent stayed healthy with zero restarts through the churn. The console diagnostics change is covered by the unit test, since that logger only runs when the agent is started with --console-diagnostics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
