### PR TITLE
feat: add regex based interface filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For each category, the agent applies a dedicated `NodeCondition` to worker nodes
 
 ## Installation
 
-It is recommended to install the EKS Node Health Monitoring Agent as an EKS add-on. For Helm installation instructions, see [charts/eks-node-monitoring-agent/README.md](./charts/eks-node-monitoring-agent/README.md). 
+It is recommended to install the EKS Node Health Monitoring Agent as an EKS add-on. For Helm installation instructions, see [charts/eks-node-monitoring-agent/README.md](./charts/eks-node-monitoring-agent/README.md).
 
 For detailed configuration options and usage documentation, refer to the [Amazon EKS Node Health documentation](https://docs.aws.amazon.com/eks/latest/userguide/node-health.html).
 
@@ -63,6 +63,17 @@ nodeAgent:
         - "filter/MY-CUSTOM-CHAIN"
 ```
 
+The networking monitor also supports `excludedInterfaceNameRegexps` to suppress `InterfaceNotUp` / `InterfaceNotRunning` findings for interfaces that are not part of Kubernetes node networking. This is useful on accelerated instance types (e.g. P6) that expose host-visible Mellanox/NVIDIA IPoIB interfaces such as `ibp115s0f0`, which may legitimately remain down. Each entry is a Go regular expression matched against the interface name; invalid regexps fail fast at startup:
+
+```yaml
+nodeAgent:
+  monitors:
+    networking:
+      excludedInterfaceNameRegexps:
+        - "^ibp[0-9]+s[0-9]+f[0-9]+$"
+        - "^ib[0-9]+$"
+```
+
 ### Config File Format
 
 The agent reads a YAML config file mounted at `/etc/nma/config.yaml`. Omitted monitors default to enabled.
@@ -86,6 +97,7 @@ monitors:
 Valid plugin names: `kernel-monitor`, `networking`, `storage-monitor`, `nvidia`, `neuron`, `runtime`.
 
 When a monitor is disabled:
+
 - Its health checks are not executed.
 - The corresponding `NodeCondition` (e.g., `NetworkingReady`) is not set on the node, avoiding false-positive healthy status for unmonitored subsystems.
 

--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -219,6 +219,14 @@
                         "type": "string",
                         "pattern": "^[^/]+/[^/]+$"
                     }
+                },
+                "excludedInterfaceNameRegexps": {
+                    "type": "array",
+                    "description": "List of regular expressions matching interface names that should be excluded from InterfaceNotUp / InterfaceNotRunning checks. Use this to suppress false positives from known non-node-networking interfaces (e.g. Mellanox/NVIDIA IPoIB interfaces such as \"^ibp[0-9]+s[0-9]+f[0-9]+$\"). Defaults to excluding IPoIB interfaces; set to an empty list to disable the default exclusion.",
+                    "default": ["^ibp[0-9]+s[0-9]+f[0-9]+$"],
+                    "items": {
+                      "type": "string"
+                    }
                 }
             }
         },

--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -233,6 +233,21 @@ func run() error {
 		}
 	}
 
+	if exprs := monitorConfig.GetExcludedInterfaceNameRegexps(); len(exprs) > 0 {
+		for _, mon := range enabledMonitors {
+			type interfaceExcludable interface {
+				SetExcludedInterfaceNameRegexps([]string) error
+			}
+			if c, ok := mon.(interfaceExcludable); ok {
+				if err := c.SetExcludedInterfaceNameRegexps(exprs); err != nil {
+					logger.Error(err, "failed to configure excluded interface name regexps", "monitor", mon.Name())
+					return err
+				}
+				logger.Info("configured excluded interface name regexps", "monitor", mon.Name(), "regexps", exprs)
+			}
+		}
+	}
+
 	if len(enabledMonitors) == 0 {
 		logger.Info("all monitors are disabled by configuration, NMA will not perform any monitoring")
 	} else {

--- a/docs/node-health-issues.adoc
+++ b/docs/node-health-issues.adoc
@@ -265,11 +265,11 @@ The monitoring condition is `NetworkingReady` for issues in the following table 
 
 |InterfaceNotRunning
 |Condition
-|This interface appears to not be running or there are network issues.
+|This interface appears to not be running or there are network issues. To suppress this for known non-node-networking interfaces (e.g. IPoIB interfaces such as `ibp115s0f0`), set `excludedInterfaceNameRegexps` under `nodeAgent.monitors.networking` in the Helm values or under `monitors.networking` in the config file at `/etc/nma/config.yaml`.
 
 |InterfaceNotUp
 |Condition
-|This interface appears to not be up or there are network issues.
+|This interface appears to not be up or there are network issues. To suppress this for known non-node-networking interfaces (e.g. IPoIB interfaces such as `ibp115s0f0`), set `excludedInterfaceNameRegexps` under `nodeAgent.monitors.networking` in the Helm values or under `monitors.networking` in the config file at `/etc/nma/config.yaml`.
 
 |KubeProxyNotReady
 |Event

--- a/monitors/networking/monitor.go
+++ b/monitors/networking/monitor.go
@@ -72,6 +72,10 @@ type NetworkingMonitor struct {
 	exec                  osext.Exec
 	runtimeContext        *config.RuntimeContext
 	allowedIPTablesChains []string
+	// excludedInterfaceNameRegexps holds compiled regexps. Interfaces whose
+	// name matches any of these are skipped during InterfaceNotUp /
+	// InterfaceNotRunning checks.
+	excludedInterfaceNameRegexps []*regexp.Regexp
 }
 
 func (m *NetworkingMonitor) Name() string {
@@ -114,6 +118,33 @@ func WithRuntimeService(svc cri.RuntimeService) Option {
 
 func (m *NetworkingMonitor) SetAllowedIPTablesChains(chains []string) {
 	m.allowedIPTablesChains = chains
+}
+
+// SetExcludedInterfaceNameRegexps compiles the provided regexps and stores them
+// for use during interface checks. An error is returned if any regexp is
+// invalid, allowing the caller to fail fast on misconfiguration.
+func (m *NetworkingMonitor) SetExcludedInterfaceNameRegexps(exprs []string) error {
+	compiled := make([]*regexp.Regexp, 0, len(exprs))
+	for _, expr := range exprs {
+		re, err := regexp.Compile(expr)
+		if err != nil {
+			return fmt.Errorf("invalid excludedInterfaceNameRegexps entry %q: %w", expr, err)
+		}
+		compiled = append(compiled, re)
+	}
+	m.excludedInterfaceNameRegexps = compiled
+	return nil
+}
+
+// isInterfaceExcluded reports whether the given interface name matches any of
+// the configured exclusion regexps.
+func (m *NetworkingMonitor) isInterfaceExcluded(name string) bool {
+	for _, re := range m.excludedInterfaceNameRegexps {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
 }
 
 func NewNetworkingMonitor(options ...Option) *NetworkingMonitor {
@@ -427,6 +458,7 @@ func (m *NetworkingMonitor) handleInterfaces() error {
 func (m *NetworkingMonitor) checkInterfaces(interfaces []net.Interface) error {
 	hasLoopback := false
 	for _, intf := range interfaces {
+		m.log.Info("Checking interface", "interface", intf.Name)
 		// ignores things like docker0 for now.
 		// NetworkingReady         False   Tue, 11 Mar 2025 14:47:30 +0000   Fri, 07 Mar 2025 21:27:30 +0000   InterfaceNotRunning          Interface "docker0" is not running
 		if strings.HasPrefix(intf.Name, "docker") {
@@ -437,6 +469,15 @@ func (m *NetworkingMonitor) checkInterfaces(interfaces []net.Interface) error {
 		} else if net.FlagMulticast&intf.Flags == 0 || net.FlagBroadcast&intf.Flags == 0 {
 			// Intended as a catch-all for dummy interfaces based on a pattern observed with
 			// nodelocaldns and kube-proxy when using IPVS mode, but not a hard rule
+			continue
+		}
+
+		// Operators can configure regexps to exclude known non-node-networking
+		// interfaces (e.g. Mellanox/NVIDIA IPoIB interfaces such as ibp115s0f0)
+		// that may legitimately remain down or lack an IP address. Skip the
+		// InterfaceNotUp / InterfaceNotRunning checks for these.
+		if m.isInterfaceExcluded(intf.Name) {
+			m.log.V(1).Info("skipping interface checks due to excludedInterfaceNameRegexps configuration", "interface", intf.Name)
 			continue
 		}
 

--- a/monitors/networking/monitor_test.go
+++ b/monitors/networking/monitor_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/cache"
 	cri "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -156,6 +157,68 @@ func TestNetworkingPeriodic(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("ExcludedInterfaceSkipped", func(t *testing.T) {
+		mon := NewNetworkingMonitor()
+		mockManager := &mockManager{
+			obs: observer.BaseObserver{},
+			res: make(chan monitor.Condition, 5),
+		}
+		mon.Register(context.TODO(), mockManager)
+		require.NoError(t, mon.SetExcludedInterfaceNameRegexps([]string{`^ibp[0-9]+s[0-9]+f[0-9]+$`}))
+
+		// A healthy loopback avoids the MissingLoopbackInterface notification. The
+		// IPoIB interface is down/not-running but matches the exclusion regexp, so
+		// it should never trigger InterfaceNotUp / InterfaceNotRunning.
+		interfaces := []net.Interface{
+			{Name: "lo", Flags: net.FlagUp | net.FlagRunning | net.FlagLoopback},
+			{Name: "ibp115s0f0", Flags: net.FlagMulticast | net.FlagBroadcast},
+		}
+
+		for i := 0; i < 2; i++ {
+			if err := mon.checkInterfaces(interfaces); err != nil {
+				t.Fatal(err)
+			}
+		}
+		select {
+		case monitorResult := <-mockManager.res:
+			t.Fatalf("unexpected notification for excluded interface: %v", monitorResult)
+		default:
+		}
+	})
+
+	t.Run("NonExcludedInterfaceStillReported", func(t *testing.T) {
+		mon := NewNetworkingMonitor()
+		mockManager := &mockManager{
+			obs: observer.BaseObserver{},
+			res: make(chan monitor.Condition, 5),
+		}
+		mon.Register(context.TODO(), mockManager)
+		require.NoError(t, mon.SetExcludedInterfaceNameRegexps([]string{`^ibp[0-9]+s[0-9]+f[0-9]+$`}))
+
+		// eth0 does not match the exclusion regexp, so it must still be reported.
+		interfaces := []net.Interface{
+			{Name: "lo", Flags: net.FlagUp | net.FlagRunning | net.FlagLoopback},
+			{Name: "eth0", Flags: net.FlagMulticast | net.FlagBroadcast},
+		}
+
+		for i := 0; i < 2; i++ {
+			if err := mon.checkInterfaces(interfaces); err != nil {
+				t.Fatal(err)
+			}
+		}
+		select {
+		case monitorResult := <-mockManager.res:
+			assert.Equal(t, "InterfaceNotUp", monitorResult.Reason)
+		default:
+			t.Fatalf("missing notification for non-excluded interface")
+		}
+	})
+
+	t.Run("InvalidRegexpReturnsError", func(t *testing.T) {
+		mon := NewNetworkingMonitor()
+		assert.Error(t, mon.SetExcludedInterfaceNameRegexps([]string{`^ibp[0-9+$`}))
+	})
 
 	t.Run("PortConflict", func(t *testing.T) {
 		rule, err := iptables.ParseIPTablesRule(`-A CNI-DN-08cb4d05ff8daf230ce42 -p tcp -m tcp --dport 10250 -j DNAT --to-destination 172.31.106.34:10250`)

--- a/pkg/config/monitor.go
+++ b/pkg/config/monitor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -15,8 +16,9 @@ const DefaultConfigPath = "/etc/nma/config.yaml"
 
 // MonitorSettings holds per-monitor configuration.
 type MonitorSettings struct {
-	Enabled               *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	AllowedIPTablesChains []string `yaml:"allowedIPTablesChains,omitempty" json:"allowedIPTablesChains,omitempty"`
+	Enabled                      *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	AllowedIPTablesChains        []string `yaml:"allowedIPTablesChains,omitempty" json:"allowedIPTablesChains,omitempty"`
+	ExcludedInterfaceNameRegexps []string `yaml:"excludedInterfaceNameRegexps,omitempty" json:"excludedInterfaceNameRegexps,omitempty"`
 }
 
 // IsEnabled returns true if the monitor is enabled.
@@ -60,6 +62,28 @@ func (mc *MonitorConfig) GetAllowedIPTablesChains() []string {
 	return settings.AllowedIPTablesChains
 }
 
+// DefaultExcludedInterfaceNameRegexps are the interface-name exclusion regexps
+// applied when the networking monitor has none explicitly configured. It
+// excludes Mellanox/NVIDIA IPoIB interfaces (e.g. "ibp115s0f0") by default,
+// which are not node-networking interfaces and would otherwise cause false
+// positive InterfaceNotUp / InterfaceNotRunning notifications.
+var DefaultExcludedInterfaceNameRegexps = []string{`^ibp[0-9]+s[0-9]+f[0-9]+$`}
+
+// GetExcludedInterfaceNameRegexps returns the interface-name exclusion regexps
+// configured for the networking monitor. When the networking monitor has no
+// excludedInterfaceNameRegexps explicitly set, DefaultExcludedInterfaceNameRegexps
+// is returned. An explicitly configured empty list disables the default.
+func (mc *MonitorConfig) GetExcludedInterfaceNameRegexps() []string {
+	if mc == nil || mc.Monitors == nil {
+		return DefaultExcludedInterfaceNameRegexps
+	}
+	settings, exists := mc.Monitors["networking"]
+	if !exists || settings.ExcludedInterfaceNameRegexps == nil {
+		return DefaultExcludedInterfaceNameRegexps
+	}
+	return settings.ExcludedInterfaceNameRegexps
+}
+
 // KnownPluginNames is the set of valid plugin names for validation.
 var KnownPluginNames = []string{
 	"kernel-monitor",
@@ -97,6 +121,19 @@ func (mc *MonitorConfig) Validate() error {
 				table, chainName, ok := strings.Cut(chain, "/")
 				if !ok || strings.Count(chain, "/") != 1 || strings.TrimSpace(table) == "" || strings.TrimSpace(chainName) == "" {
 					return fmt.Errorf("allowedIPTablesChains entry %q must use \"table/chain\" format with non-empty table and chain (e.g. \"filter/MY-CUSTOM-CHAIN\")", chain)
+				}
+			}
+		}
+		if len(settings.ExcludedInterfaceNameRegexps) > 0 {
+			if name != "networking" {
+				return fmt.Errorf("excludedInterfaceNameRegexps is only supported by the networking monitor, not %q", name)
+			}
+			for _, expr := range settings.ExcludedInterfaceNameRegexps {
+				if strings.TrimSpace(expr) == "" {
+					return fmt.Errorf("excludedInterfaceNameRegexps entry must not be empty or whitespace-only")
+				}
+				if _, err := regexp.Compile(expr); err != nil {
+					return fmt.Errorf("excludedInterfaceNameRegexps entry %q is not a valid regular expression: %w", expr, err)
 				}
 			}
 		}

--- a/pkg/config/monitor_test.go
+++ b/pkg/config/monitor_test.go
@@ -302,6 +302,123 @@ func TestLoadMonitorConfig_AllowedIPTablesChainsOnNonNetworkingMonitorRejected(t
 	assert.Contains(t, err.Error(), "kernel-monitor")
 }
 
+func TestGetExcludedInterfaceNameRegexps(t *testing.T) {
+	t.Run("NilConfig", func(t *testing.T) {
+		var cfg *config.MonitorConfig
+		assert.Equal(t, config.DefaultExcludedInterfaceNameRegexps, cfg.GetExcludedInterfaceNameRegexps())
+	})
+	t.Run("EmptyMap", func(t *testing.T) {
+		cfg := &config.MonitorConfig{}
+		assert.Equal(t, config.DefaultExcludedInterfaceNameRegexps, cfg.GetExcludedInterfaceNameRegexps())
+	})
+	t.Run("NoNetworkingEntry", func(t *testing.T) {
+		cfg := &config.MonitorConfig{
+			Monitors: map[string]config.MonitorSettings{
+				"kernel-monitor": {Enabled: boolPtr(true)},
+			},
+		}
+		assert.Equal(t, config.DefaultExcludedInterfaceNameRegexps, cfg.GetExcludedInterfaceNameRegexps())
+	})
+	t.Run("NetworkingEntryWithoutRegexps", func(t *testing.T) {
+		cfg := &config.MonitorConfig{
+			Monitors: map[string]config.MonitorSettings{
+				"networking": {Enabled: boolPtr(true)},
+			},
+		}
+		assert.Equal(t, config.DefaultExcludedInterfaceNameRegexps, cfg.GetExcludedInterfaceNameRegexps())
+	})
+	t.Run("ExplicitEmptyListDisablesDefault", func(t *testing.T) {
+		cfg := &config.MonitorConfig{
+			Monitors: map[string]config.MonitorSettings{
+				"networking": {ExcludedInterfaceNameRegexps: []string{}},
+			},
+		}
+		assert.Empty(t, cfg.GetExcludedInterfaceNameRegexps())
+	})
+	t.Run("WithRegexps", func(t *testing.T) {
+		cfg := &config.MonitorConfig{
+			Monitors: map[string]config.MonitorSettings{
+				"networking": {
+					ExcludedInterfaceNameRegexps: []string{`^ibp[0-9]+s[0-9]+f[0-9]+$`, `^ib[0-9]+$`},
+				},
+			},
+		}
+		assert.Equal(t, []string{`^ibp[0-9]+s[0-9]+f[0-9]+$`, `^ib[0-9]+$`}, cfg.GetExcludedInterfaceNameRegexps())
+	})
+}
+
+func TestLoadMonitorConfig_ExcludedInterfaceNameRegexps(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`monitors:
+  networking:
+    enabled: true
+    excludedInterfaceNameRegexps:
+      - '^ibp[0-9]+s[0-9]+f[0-9]+$'
+      - '^ib[0-9]+$'
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.True(t, found)
+	assert.Equal(t, []string{`^ibp[0-9]+s[0-9]+f[0-9]+$`, `^ib[0-9]+$`}, cfg.GetExcludedInterfaceNameRegexps())
+}
+
+func TestLoadMonitorConfig_InvalidRegexpRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`monitors:
+  networking:
+    excludedInterfaceNameRegexps:
+      - '^ibp[0-9+$'
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "is not a valid regular expression")
+}
+
+func TestLoadMonitorConfig_EmptyRegexpRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`monitors:
+  networking:
+    excludedInterfaceNameRegexps:
+      - "   "
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestLoadMonitorConfig_ExcludedInterfaceNameRegexpsOnNonNetworkingMonitorRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`monitors:
+  kernel-monitor:
+    excludedInterfaceNameRegexps:
+      - '^ib[0-9]+$'
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "excludedInterfaceNameRegexps is only supported by the networking monitor")
+	assert.Contains(t, err.Error(), "kernel-monitor")
+}
+
 func TestLoadMonitorConfig_StrictUnmarshalRejectsUnknownFields(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")

--- a/pkg/reasons/reasons.yaml
+++ b/pkg/reasons/reasons.yaml
@@ -240,12 +240,20 @@ NetworkingReady:
     Template: 'InterfaceNotRunning'
     DefaultSeverity: 'Fatal'
     Description: >-
-      This interface appears to not be running or there are network issues.
+      This interface appears to not be running or there are network issues. To
+      suppress this for known non-node-networking interfaces (e.g. IPoIB
+      interfaces such as `ibp115s0f0`), set `excludedInterfaceNameRegexps`
+      under `nodeAgent.monitors.networking` in the Helm values or under
+      `monitors.networking` in the config file at `/etc/nma/config.yaml`.
   InterfaceNotUp:
     Template: 'InterfaceNotUp'
     DefaultSeverity: 'Fatal'
     Description: >-
-      This interface appears to not be up or there are network issues.
+      This interface appears to not be up or there are network issues. To
+      suppress this for known non-node-networking interfaces (e.g. IPoIB
+      interfaces such as `ibp115s0f0`), set `excludedInterfaceNameRegexps`
+      under `nodeAgent.monitors.networking` in the Helm values or under
+      `monitors.networking` in the config file at `/etc/nma/config.yaml`.
   NPARepeatedlyRestart:
     Template: 'NPARepeatedlyRestart'
     DefaultSeverity: 'Warning'


### PR DESCRIPTION
**Issue #, if available**:

https://github.com/aws/eks-node-monitoring-agent/issues/155

**Description of changes**:

Adds exactly what the issue is looking for, the ability to turn off interface monitoring using a list regexps.

**Testing Done**:

Validated in my own cluster that I can configure regxps and ignore specific interfaces from monitoring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
