### PR TITLE
feat(dcgm): Run nv-hostengine from the agent image

### DIFF
--- a/.github/workflows/bump-dcgm-exporter.yaml
+++ b/.github/workflows/bump-dcgm-exporter.yaml
@@ -1,5 +1,11 @@
 name: "Bump DCGM Exporter Image"
 
+# Only applies when charts/eks-node-monitoring-agent/values.yaml pins
+# dcgmAgent.image.tag to a standalone eks/observability/dcgm-exporter image,
+# which is the break-glass configuration. By default DCGM ships in the
+# eks-node-monitoring-agent image and its version is the DCGM_VERSION build arg
+# in the Dockerfile, so this workflow no-ops.
+
 on:
   workflow_dispatch:
   schedule:
@@ -49,10 +55,16 @@ jobs:
           # Parse current dcgmAgent image tag from values.yaml
           # The tag sits under dcgmAgent.image.tag — grab the first 'tag:' line after 'dcgmAgent:'
           VALUES_FILE="charts/eks-node-monitoring-agent/values.yaml"
-          CURRENT_TAG=$(awk '/^dcgmAgent:/{found=1} found && /tag:/{print $2; exit}' "$VALUES_FILE")
+          CURRENT_TAG=$(awk '/^dcgmAgent:/{found=1} found && /tag:/{print $2; exit}' "$VALUES_FILE" | tr -d "\"'")
           if [ -z "$CURRENT_TAG" ]; then
-            echo "::error::Failed to parse current DCGM tag from ${VALUES_FILE}"
-            exit 1
+            # No standalone DCGM image is pinned, which is the default: the
+            # dcgm-server DaemonSet runs nv-hostengine from the
+            # eks-node-monitoring-agent image. That DCGM version comes from the
+            # DCGM_VERSION build arg in the Dockerfile, not from an image tag,
+            # so there is nothing for this workflow to bump.
+            echo "dcgmAgent.image.tag is empty; DCGM ships in the agent image (Dockerfile DCGM_VERSION). Nothing to bump."
+            echo "new_version_available=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "Current DCGM exporter tag: ${CURRENT_TAG}"
           echo "current_tag=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,38 @@ RUN dnf install -y systemd-devel && \
     dnf clean all
 
 # =============================================================================
-# Stage 2: DCGM builder for GPU monitoring libraries
+# Stage 2: DCGM builder for GPU monitoring libraries and the DCGM host engine
 # =============================================================================
+# NOTE: do not add --platform to this stage. The repository below is selected
+# from `uname -m`, so building on the build platform instead of the target
+# platform would silently place amd64 binaries in the arm64 image.
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS dcgm-builder
 
-# Install DCGM from NVIDIA repository for GPU monitoring support
-# This is optional - the agent works without it on non-GPU nodes
+# DCGM version served to GPU nodes. Pinned for reproducibility: this determines
+# the nv-hostengine version the agent talks to, not just a client library.
+ARG DCGM_VERSION=4.6.1-1
+
+# Install DCGM from the NVIDIA repository for GPU monitoring support.
+# This is optional - the agent works without it on non-GPU nodes.
+#   -core:        libdcgm client, DCGM modules, nv-hostengine, dcgmi, nvvs
+#   -proprietary: plugins/cudaless/libEud.so, for DCGM diagnostics
+# The CUDA plugin tiers (-cudaXX, -proprietary-cudaXX) are deliberately not
+# installed: they add >1GB and the dcgm-exporter image previously used here did
+# not ship them either, so DCGM diagnostics keep the same cudaless-only scope.
 RUN dnf install -y dnf-plugins-core && \
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-rhel9.repo && \
-    dnf install -y datacenter-gpu-manager-4-core && \
+    dnf install -y \
+        datacenter-gpu-manager-4-core-1:${DCGM_VERSION} \
+        datacenter-gpu-manager-4-proprietary-1:${DCGM_VERSION} && \
     dnf clean all
+
+# Stage the runtime payload into a single tree. `cp -a` preserves the
+# libfoo.so.4 -> libfoo.so.4.x.y symlinks; copying the globs directly would
+# dereference them and store every library twice.
+RUN mkdir -p /staging/usr/lib64 /staging/usr/bin /staging/usr/libexec && \
+    cp -a /usr/lib64/libdcgm.so* /usr/lib64/libdcgmmodule*.so* /staging/usr/lib64/ && \
+    cp -a /usr/bin/nv-hostengine /usr/bin/dcgmi /staging/usr/bin/ && \
+    cp -a /usr/libexec/datacenter-gpu-manager-4 /staging/usr/libexec/
 
 # =============================================================================
 # Stage 3: Go builder to compile the application
@@ -78,8 +100,12 @@ COPY --from=systemd-builder /usr/lib64/libgcrypt.so* /usr/lib64/
 COPY --from=systemd-builder /usr/lib64/libgpg-error.so* /usr/lib64/
 COPY --from=systemd-builder /usr/lib64/libcap.so* /usr/lib64/
 
-# Copy DCGM client library for GPU monitoring (optional - only used on GPU nodes)
-COPY --from=dcgm-builder /usr/lib64/libdcgm.so* /usr/lib64/
+# Copy the DCGM client library, DCGM modules, nv-hostengine, dcgmi and nvvs.
+# The agent itself only needs libdcgm (and only on GPU nodes), but the chart's
+# dcgm-server DaemonSet runs nv-hostengine out of this same image, which is why
+# the host engine and its modules ship here instead of in a separate image.
+# Kept above the binary copies below so agent code changes do not invalidate it.
+COPY --from=dcgm-builder /staging/ /
 
 # Copy the built binaries
 COPY --from=go-builder /workspace/bin/eks-node-monitoring-agent /opt/bin/eks-node-monitoring-agent

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -30,6 +30,25 @@ To uninstall:
 helm uninstall eks-node-monitoring-agent --namespace kube-system
 ```
 
+## DCGM host engine
+
+On NVIDIA GPU nodes the agent collects GPU health from DCGM. It connects as a
+DCGM client in standalone mode, so an `nv-hostengine` process must be reachable
+on the node (`localhost:5555` by default). The chart provides one via the
+`dcgm-server` DaemonSet.
+
+`nv-hostengine`, `dcgmi` and the DCGM modules ship inside the
+`eks-node-monitoring-agent` image, so `dcgm-server` runs the same image as the
+node agent and no separate DCGM image is pulled. Previously this DaemonSet ran
+`eks/observability/dcgm-exporter`, which bundled an Ubuntu userland and the
+`dcgm-exporter` binary that the agent never used.
+
+If you need to pin the DaemonSet back to a standalone DCGM image, set
+`dcgmAgent.image.tag` (resolved against `eks/observability/dcgm-exporter`) or
+`dcgmAgent.image.override` for a full image reference. Note that the
+`dcgm-exporter` images carry the CVEs of their base OS and of the exporter
+binary, so treat this as a temporary break-glass measure.
+
 ## Configuration
 
 The following table lists the configurable parameters for this chart and their default values.
@@ -37,13 +56,14 @@ The following table lists the configurable parameters for this chart and their d
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | dcgmAgent.affinity | object | see [`values.yaml`](./values.yaml) | Map of dcgm pod affinities |
-| dcgmAgent.image.account | string | `"602401143452"` | ECR repository account number for the dcgm-exporter |
-| dcgmAgent.image.containerRegistry | string | `""` | Full container registry URL override (e.g., 602401143452.dkr.ecr.us-west-2.amazonaws.com). When set, this takes precedence over account/endpoint/region/domain fields. |
-| dcgmAgent.image.domain | string | `"amazonaws.com"` | ECR repository domain for the dcgm-exporter |
-| dcgmAgent.image.endpoint | string | `"ecr"` | ECR repository endpoint for the dcgm-exporter |
-| dcgmAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy for the dcgm-exporter |
-| dcgmAgent.image.region | string | `"us-west-2"` | ECR repository region for the dcgm-exporter |
-| dcgmAgent.image.tag | string | `"4.5.2-4.8.1-ubuntu22.04"` | Image tag for the dcgm-exporter |
+| dcgmAgent.image.account | string | `"602401143452"` | ECR repository account number for the dcgm-exporter. Only used when a tag is set. |
+| dcgmAgent.image.containerRegistry | string | `""` | Full container registry URL override (e.g., 602401143452.dkr.ecr.us-west-2.amazonaws.com). When set, this takes precedence over account/endpoint/region/domain fields. Only used when a tag is set. |
+| dcgmAgent.image.domain | string | `"amazonaws.com"` | ECR repository domain for the dcgm-exporter. Only used when a tag is set. |
+| dcgmAgent.image.endpoint | string | `"ecr"` | ECR repository endpoint for the dcgm-exporter. Only used when a tag is set. |
+| dcgmAgent.image.override | string | `""` | Full image override (registry/repository:tag) for the dcgm-server DaemonSet. Takes precedence over all other fields. |
+| dcgmAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy for the dcgm-server DaemonSet |
+| dcgmAgent.image.region | string | `"us-west-2"` | ECR repository region for the dcgm-exporter. Only used when a tag is set. |
+| dcgmAgent.image.tag | string | `""` | Image tag that pins the dcgm-server DaemonSet back to a standalone eks/observability/dcgm-exporter image. Empty by default, so the DaemonSet runs the nv-hostengine bundled in the eks-node-monitoring-agent image. See the "DCGM host engine" section of the chart README before setting this. |
 | dcgmAgent.podAnnotations | object | `{}` | Pod annotations applied to the dcgm exporter |
 | dcgmAgent.podLabels | object | `{}` | Pod labels applied to the dcgm exporter |
 | dcgmAgent.resizePolicy | list | `[]` | Container resize policy for in-place pod vertical scaling (requires Kubernetes 1.33+) |

--- a/charts/eks-node-monitoring-agent/README.md.gotmpl
+++ b/charts/eks-node-monitoring-agent/README.md.gotmpl
@@ -30,6 +30,25 @@ To uninstall:
 helm uninstall eks-node-monitoring-agent --namespace kube-system
 ```
 
+## DCGM host engine
+
+On NVIDIA GPU nodes the agent collects GPU health from DCGM. It connects as a
+DCGM client in standalone mode, so an `nv-hostengine` process must be reachable
+on the node (`localhost:5555` by default). The chart provides one via the
+`dcgm-server` DaemonSet.
+
+`nv-hostengine`, `dcgmi` and the DCGM modules ship inside the
+`eks-node-monitoring-agent` image, so `dcgm-server` runs the same image as the
+node agent and no separate DCGM image is pulled. Previously this DaemonSet ran
+`eks/observability/dcgm-exporter`, which bundled an Ubuntu userland and the
+`dcgm-exporter` binary that the agent never used.
+
+If you need to pin the DaemonSet back to a standalone DCGM image, set
+`dcgmAgent.image.tag` (resolved against `eks/observability/dcgm-exporter`) or
+`dcgmAgent.image.override` for a full image reference. Note that the
+`dcgm-exporter` images carry the CVEs of their base OS and of the exporter
+binary, so treat this as a temporary break-glass measure.
+
 ## Configuration
 
 The following table lists the configurable parameters for this chart and their default values.

--- a/charts/eks-node-monitoring-agent/templates/_helpers.tpl
+++ b/charts/eks-node-monitoring-agent/templates/_helpers.tpl
@@ -64,16 +64,25 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Get the current dcgm-exporter image for a region.
-We use the dcgm-exporter image from the eks/observability.
+Get the image that runs the bundled DCGM host engine (nv-hostengine).
+
+The engine ships in the eks-node-monitoring-agent image itself, so by default
+this resolves to the same image as the node agent. The dcgmAgent.image.* fields
+remain supported as a break-glass path: setting `override`, or a `tag` for the
+eks/observability/dcgm-exporter repository, pins the DaemonSet back to a
+standalone DCGM image.
 */}}
-{{- define "dcgm-exporter.image" -}}
+{{- define "dcgm-server.image" -}}
 {{- if .Values.dcgmAgent.image.override }}
 {{- .Values.dcgmAgent.image.override }}
-{{- else if .Values.dcgmAgent.image.containerRegistry }}
+{{- else if .Values.dcgmAgent.image.tag }}
+{{- if .Values.dcgmAgent.image.containerRegistry }}
 {{- printf "%s/eks/observability/dcgm-exporter:%s" .Values.dcgmAgent.image.containerRegistry .Values.dcgmAgent.image.tag -}}
 {{- else }}
 {{- printf "%s.dkr.%s.%s.%s/eks/observability/dcgm-exporter:%s" .Values.dcgmAgent.image.account .Values.dcgmAgent.image.endpoint .Values.dcgmAgent.image.region .Values.dcgmAgent.image.domain .Values.dcgmAgent.image.tag -}}
+{{- end -}}
+{{- else }}
+{{- include "eks-node-monitoring-agent.image" . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
@@ -42,10 +42,25 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | default "system-node-critical" }}
       containers:
         - name: {{ .Chart.Name }}-dcgm
-          image: {{ template "dcgm-exporter.image" . }}
+          image: {{ template "dcgm-server.image" . }}
           imagePullPolicy: {{ .Values.dcgmAgent.image.pullPolicy }}
-          command: ["/bin/sh"]
-          args: ["-c", "nv-hostengine -n -b ALL || true; sleep infinity"]
+          command: ["/usr/bin/nv-hostengine"]
+          args: ["-n", "-b", "ALL"]
+          {{- /*
+          NVIDIA_* are required for the NVIDIA container runtime to expose the
+          GPUs and inject the host driver libraries (libnvidia-ml.so) that
+          nv-hostengine needs. Without them the host engine still starts and
+          serves port 5555, but reports zero GPUs, which silently disables all
+          GPU health detection. The dcgm-exporter image used previously carried
+          these in its image config; they must be set explicitly now.
+          */}}
+          env:
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: compute,utility,compat32
+            - name: NVIDIA_DISABLE_REQUIRE
+              value: "true"
           {{- with .Values.dcgmAgent.resizePolicy }}
           resizePolicy:
             {{- toYaml . | nindent 12 }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -102,20 +102,21 @@ nodeAgent:
 
 dcgmAgent:
   image:
-    # -- Image tag for the dcgm-exporter
-    tag: 4.5.2-4.8.1-ubuntu22.04
-    # -- Full container registry URL override (e.g., 602401143452.dkr.ecr.us-west-2.amazonaws.com).
-    # When set, this takes precedence over account/endpoint/region/domain fields.
+    # -- Image tag that pins the dcgm-server DaemonSet back to a standalone eks/observability/dcgm-exporter image. Empty by default, so the DaemonSet runs the nv-hostengine bundled in the eks-node-monitoring-agent image. See the "DCGM host engine" section of the chart README before setting this.
+    tag: ""
+    # -- Full image override (registry/repository:tag) for the dcgm-server DaemonSet. Takes precedence over all other fields.
+    override: ""
+    # -- Full container registry URL override (e.g., 602401143452.dkr.ecr.us-west-2.amazonaws.com). When set, this takes precedence over account/endpoint/region/domain fields. Only used when a tag is set.
     containerRegistry: ""
-    # -- ECR repository domain for the dcgm-exporter
+    # -- ECR repository domain for the dcgm-exporter. Only used when a tag is set.
     domain: amazonaws.com
-    # -- ECR repository region for the dcgm-exporter
+    # -- ECR repository region for the dcgm-exporter. Only used when a tag is set.
     region: us-west-2
-    # -- ECR repository endpoint for the dcgm-exporter
+    # -- ECR repository endpoint for the dcgm-exporter. Only used when a tag is set.
     endpoint: ecr
-    # -- ECR repository account number for the dcgm-exporter
+    # -- ECR repository account number for the dcgm-exporter. Only used when a tag is set.
     account: "602401143452"
-    # -- Container pull policy for the dcgm-exporter
+    # -- Container pull policy for the dcgm-server DaemonSet
     pullPolicy: IfNotPresent
   # -- Map of dcgm pod affinities
   # @default -- see [`values.yaml`](./values.yaml)

--- a/e2e/setup/manifests/agent.tpl.yaml
+++ b/e2e/setup/manifests/agent.tpl.yaml
@@ -541,10 +541,17 @@ spec:
       priorityClassName: system-node-critical
       containers:
         - name: eks-node-monitoring-agent-dcgm
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/observability/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04
+          image: {{ .Image }}
           imagePullPolicy: IfNotPresent
-          command: ["/bin/sh"]
-          args: ["-c", "nv-hostengine -n -b ALL || true; sleep infinity"]
+          command: ["/usr/bin/nv-hostengine"]
+          args: ["-n", "-b", "ALL"]
+          env:
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: compute,utility,compat32
+            - name: NVIDIA_DISABLE_REQUIRE
+              value: "true"
           ports:
           - containerPort: 5555
             hostPort: 5555


### PR DESCRIPTION
**Issue #, if available**:
Slightly related to #82 

**Description of changes**:

The dcgm-server DaemonSet ran nv-hostengine out of eks/observability/dcgm-exporter, which puts an Ubuntu userland and the 77MB dcgm-exporter binary on every GPU node even though the agent only needs the DCGM host engine. Both are scanned surface the agent never executes: the Ubuntu OS packages and the Go dependencies linked into dcgm-exporter.

Ship nv-hostengine, dcgmi, the DCGM modules and nvvs in the eks-node-monitoring-agent image instead, and point dcgm-server at that image. The host engine moves 4.5.2 -> 4.6.1, which also removes an existing skew: the agent's libdcgm client and its go-dcgm bindings are already 4.6.1 while the engine it talked to was 4.5.2.

Rebasing dcgm-exporter onto its distroless variant is not an alternative. That image ships only the exporter binary; it contains no nv-hostengine, so the DaemonSet cannot run at all.

- Dockerfile: install datacenter-gpu-manager-4-core and -proprietary at a pinned DCGM_VERSION, stage the payload with cp -a so the .so symlinks survive (a glob COPY dereferences them and stores every library twice), and copy it as one layer above the Go binaries so agent changes do not invalidate it. The CUDA plugin tiers are left out; the dcgm-exporter image did not carry them either, so diagnostics keep the same scope.
- dcgm-daemonset: exec /usr/bin/nv-hostengine directly instead of wrapping it in a shell with `|| true; sleep infinity`, which kept the container alive around a dead engine. Set the NVIDIA_* variables the exporter image previously carried in its image config; without them the container gets no driver injection and the engine reports zero GPUs.
- values: dcgmAgent.image.tag now defaults to empty, so no dcgm-exporter image is referenced. Setting it, or image.override, pins dcgm-server back to a standalone DCGM image as a break-glass path.
- bump-dcgm-exporter: no-op when no tag is pinned rather than failing. DCGM upgrades now happen through DCGM_VERSION in the Dockerfile.

**Testing Done**:

Verified against the built image: nv-hostengine 4.6.1 starts and serves port 5555, dcgmi connects to it, the Health and Introspection modules load on demand, and the module list matches
Compared it against dcgm-exporter:4.5.2-4.8.1-ubuntu22.04 run on the same host. Default helm rendering changes only this container and contains no dcgm-exporter reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
