### PR TITLE
fix: expose nodeSelector and priorityClassName in config schema

### DIFF
--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -49,6 +49,16 @@
                     "description": "Labels applied to the eks node monitoring agent pod. These labels are merged with any global pod labels, with component specific labels taking precedence in the case of a conflict.",
                     "default": {}
                 },
+                "nodeSelector": {
+                    "$ref": "#/definitions/StringMap",
+                    "description": "Node labels that a node must have for the eks node monitoring agent pod to be scheduled on it.",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Name of an existing PriorityClass assigned to the eks node monitoring agent pod.",
+                    "default": "system-node-critical"
+                },
                 "probePort": {
                     "type": "integer",
                     "description": "Health probe port for the eks node monitoring agent. Used for both the --probe-address arg and the liveness probe.",
@@ -108,6 +118,16 @@
                     "$ref": "#/definitions/StringMap",
                     "description": "Labels applied to the eks node monitoring agent pod. These labels are merged with any global pod labels, with component specific labels taking precedence in the case of a conflict.",
                     "default": {}
+                },
+                "nodeSelector": {
+                    "$ref": "#/definitions/StringMap",
+                    "description": "Node labels that a node must have for the dcgm-exporter pod to be scheduled on it. ",
+                    "default": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Name of an existing PriorityClass assigned to the dcgm-exporter pod.",
+                    "default": "system-node-critical"
                 },
                 "resources": {
                     "$ref": "#/definitions/Resources"

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -64,8 +64,10 @@ The following table lists the configurable parameters for this chart and their d
 | dcgmAgent.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy for the dcgm-server DaemonSet |
 | dcgmAgent.image.region | string | `"us-west-2"` | ECR repository region for the dcgm-exporter. Only used when a tag is set. |
 | dcgmAgent.image.tag | string | `""` | Image tag that pins the dcgm-server DaemonSet back to a standalone eks/observability/dcgm-exporter image. Empty by default, so the DaemonSet runs the nv-hostengine bundled in the eks-node-monitoring-agent image. See the "DCGM host engine" section of the chart README before setting this. |
+| dcgmAgent.nodeSelector | object | `{}` | Node labels required for the dcgm exporter to be scheduled on a node. |
 | dcgmAgent.podAnnotations | object | `{}` | Pod annotations applied to the dcgm exporter |
 | dcgmAgent.podLabels | object | `{}` | Pod labels applied to the dcgm exporter |
+| dcgmAgent.priorityClassName | string | `"system-node-critical"` | PriorityClass for the dcgm exporter. |
 | dcgmAgent.resizePolicy | list | `[]` | Container resize policy for in-place pod vertical scaling (requires Kubernetes 1.33+) |
 | dcgmAgent.resources | object | `{}` | Container resources for the dcgm deployment |
 | dcgmAgent.tolerations | list | `[]` | Deployment tolerations for the dcgm |
@@ -86,8 +88,10 @@ The following table lists the configurable parameters for this chart and their d
 | nodeAgent.image.region | string | `"us-west-2"` | ECR repository region for the eks-node-monitoring-agent |
 | nodeAgent.image.tag | string | `"v1.6.7-eksbuild.1"` | Image tag for the eks-node-monitoring-agent |
 | nodeAgent.monitors | object | `{}` | Per-monitor configuration keyed by plugin name. See the main README for details. |
+| nodeAgent.nodeSelector | object | `{}` | Node labels required for the eks-node-monitoring-agent to be scheduled on a node. |
 | nodeAgent.podAnnotations | object | `{}` | Pod annotations applied to the eks-node-monitoring-agent |
 | nodeAgent.podLabels | object | `{}` | Pod labels applied to the eks-node-monitoring-agent |
+| nodeAgent.priorityClassName | string | `"system-node-critical"` | PriorityClass for the eks-node-monitoring-agent. |
 | nodeAgent.probePort | int | `8002` | Health probe port for the eks-node-monitoring-agent. Used for both the --probe-address arg and the liveness probe. |
 | nodeAgent.resizePolicy | list | `[]` | Container resize policy for in-place pod vertical scaling (requires Kubernetes 1.33+) |
 | nodeAgent.resources | object | `{"limits":{"cpu":"250m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"30Mi"}}` | Container resources for the eks-node-monitoring-agent |

--- a/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
         {{- with .Values.dcgmAgent.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      priorityClassName: {{ .Values.priorityClassName | default "system-node-critical" }}
+      priorityClassName: {{ .Values.dcgmAgent.priorityClassName | default "system-node-critical" }}
       containers:
         - name: {{ .Chart.Name }}-dcgm
           image: {{ template "dcgm-server.image" . }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -95,6 +95,10 @@ nodeAgent:
     - operator: Exists
   # -- Pod labels applied to the eks-node-monitoring-agent
   podLabels: {}
+  # -- Node labels required for the eks-node-monitoring-agent to be scheduled on a node.
+  nodeSelector: {}
+  # -- PriorityClass for the eks-node-monitoring-agent.
+  priorityClassName: system-node-critical
   # -- Per-monitor configuration keyed by plugin name. See the main README for details.
   monitors: {}
   # -- Pod annotations applied to the eks-node-monitoring-agent
@@ -154,6 +158,10 @@ dcgmAgent:
   tolerations: []
   # -- Pod labels applied to the dcgm exporter
   podLabels: {}
+  # -- Node labels required for the dcgm exporter to be scheduled on a node.
+  nodeSelector: {}
+  # -- PriorityClass for the dcgm exporter.
+  priorityClassName: system-node-critical
   # -- Pod annotations applied to the dcgm exporter
   podAnnotations: {}  
 


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

Declare `nodeSelector` and `priorityClassName` in `configuration.schema.json` for both the node agent and dcgm exporter. The templates already rendered them, but `additionalProperties: false` rejected them before the chart was rendered, making them unusable for managed add-on installs.

Also fixes `dcgm-daemonset.yaml` reading `.Values.priorityClassName` instead of `.Values.dcgmAgent.priorityClassName`, which meant the value could never be set. Defaults are unchanged.

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
