### PR TITLE
Clear NetworkingReady once IPAMD's API server error stops recurring

### DIFF
--- a/api/monitor/interface.go
+++ b/api/monitor/interface.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor/resource"
 )
@@ -44,6 +45,20 @@ type Condition struct {
 	// MinOccurrence is the minimal time the failure could occur before we export the condition.
 	// default is 0 if not assigned
 	MinOccurrences int64
+	// TTL is how long a Fatal condition remains valid without being re-observed.
+	// Conditions derived from a log line are latched: the monitor sees the failure
+	// once and has no corresponding "recovered" line to clear it, so the condition
+	// sticks until the node is replaced. Setting a TTL lets the exporter return the
+	// condition to its ready state once the underlying failure stops being observed.
+	//
+	// Only meaningful for SeverityFatal. Zero means the condition never expires,
+	// which preserves the previous latching behavior for issues that genuinely
+	// require external repair (e.g. uncorrectable GPU memory errors).
+	//
+	// A TTL is only appropriate for a failure that keeps being re-observed for as
+	// long as it is real. Set it to a comfortable multiple of that re-observation
+	// interval so a persistent problem never expires between observations.
+	TTL time.Duration
 }
 
 // A gauge for how severe the issue is, and whether actions need to be taken

--- a/monitors/networking/monitor.go
+++ b/monitors/networking/monitor.go
@@ -52,6 +52,16 @@ const (
 	// on the handleIPAMD interval (currently 5m), so this should ideally be kept longer than that
 	// TODO: should preferably use a concept of a minimum rate for a condition in node exporter
 	ipamdNotRunningConsistencyDuration = 15 * time.Minute
+
+	// how long an "Unable to reach API Server" observation keeps NetworkingReady
+	// down. IPAMD polls the API server every 2s while it is unreachable and logs
+	// on each failure, so a node that is genuinely cut off re-arms this
+	// continuously. A single log line, by contrast, is usually just the boot race
+	// between IPAMD starting and kube-proxy programming the service ClusterIP;
+	// that resolves in seconds but used to latch the condition until the node was
+	// replaced. 15m is far longer than the 2s re-log interval, so a real outage
+	// never lapses between observations.
+	ipamdAPIServerUnreachableTTL = 15 * time.Minute
 )
 
 type criIPDetails struct {
@@ -273,6 +283,7 @@ func (m *NetworkingMonitor) handleIPAMDLogs(line string) error {
 			reasons.IPAMDNotReady.
 				Builder().
 				Message("IPAM-D has failed to connect to API Server which could be an issue with IPTable rules or any other network configuration.").
+				TTL(ipamdAPIServerUnreachableTTL).
 				Build(),
 		)
 	} else if strings.Contains(line, "Starting L-IPAMD") {

--- a/monitors/networking/monitor_test.go
+++ b/monitors/networking/monitor_test.go
@@ -74,12 +74,15 @@ func TestNetworkingMonitor(t *testing.T) {
 		log    string
 		reason string
 		monitor.Severity
+		ttl time.Duration
 	}{
-		{"Failed to check API server connectivity: invalid configuration: no configuration has been provided", "IPAMDNotReady", monitor.SeverityFatal},
-		{"Unable to reach API Server", "IPAMDNotReady", monitor.SeverityFatal},
-		{"Failed to check API server connectivity", "IPAMDNotReady", monitor.SeverityFatal},
-		{"Starting L-IPAMD", "IPAMDRepeatedlyRestart", monitor.SeverityWarning},
-		{"InsufficientFreeAddressesInSubnet", "IPAMDNoIPs", monitor.SeverityWarning},
+		{"Failed to check API server connectivity: invalid configuration: no configuration has been provided", "IPAMDNotReady", monitor.SeverityFatal, 0},
+		// the unreachable-API-Server cases self-clear: IPAMD re-logs them every 2s
+		// while the failure is real, so a lone line is a transient boot race.
+		{"Unable to reach API Server", "IPAMDNotReady", monitor.SeverityFatal, ipamdAPIServerUnreachableTTL},
+		{"Failed to check API server connectivity", "IPAMDNotReady", monitor.SeverityFatal, ipamdAPIServerUnreachableTTL},
+		{"Starting L-IPAMD", "IPAMDRepeatedlyRestart", monitor.SeverityWarning, 0},
+		{"InsufficientFreeAddressesInSubnet", "IPAMDNoIPs", monitor.SeverityWarning, 0},
 	} {
 		t.Run(testCase.log, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -97,6 +100,7 @@ func TestNetworkingMonitor(t *testing.T) {
 			case monitorResult := <-mockManager.res:
 				assert.Equal(t, testCase.Severity, monitorResult.Severity)
 				assert.Equal(t, testCase.reason, monitorResult.Reason)
+				assert.Equal(t, testCase.ttl, monitorResult.TTL)
 			}
 		})
 	}

--- a/pkg/manager/node_exporter.go
+++ b/pkg/manager/node_exporter.go
@@ -46,7 +46,9 @@ func NewNodeExporter(
 		nodeKey:                client.ObjectKeyFromObject(node),
 		kubeClient:             kubeClient,
 		recorder:               recorder,
+		conditionConfigs:       managedConditionConfigs,
 		managedConditions:      initializeManagedConditions(managedConditionConfigs),
+		expiries:               make(map[corev1.NodeConditionType]map[string]time.Time),
 		managedConditionsDirty: true,
 	}
 }
@@ -89,9 +91,16 @@ type nodeExporter struct {
 	nodeRef    *corev1.ObjectReference
 	nodeKey    client.ObjectKey
 
+	conditionConfigs       map[corev1.NodeConditionType]NodeConditionConfig
 	managedConditions      map[corev1.NodeConditionType]corev1.NodeCondition
 	managedConditionsDirty bool
 	managedConditionsLock  sync.Mutex
+
+	// expiries tracks, per condition type, the deadline by which each contributing
+	// reason must be re-observed to stay latched. Reasons reported without a TTL
+	// are absent here and therefore never expire. Keyed by reason so that a
+	// condition aggregating several failures only clears once all of them lapse.
+	expiries map[corev1.NodeConditionType]map[string]time.Time
 }
 
 // Info records an event for the specified condition.
@@ -119,6 +128,16 @@ func (e *nodeExporter) Fatal(ctx context.Context, monitorCondition monitor.Condi
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: now,
 		LastHeartbeatTime:  now,
+	}
+	if monitorCondition.TTL > 0 {
+		if e.expiries[conditionType] == nil {
+			e.expiries[conditionType] = make(map[string]time.Time)
+		}
+		e.expiries[conditionType][monitorCondition.Reason] = now.Add(monitorCondition.TTL)
+	} else {
+		// a reason reported without a TTL latches the condition, so drop any
+		// expiry previously recorded for it.
+		delete(e.expiries[conditionType], monitorCondition.Reason)
 	}
 	if oldCondition, ok := e.managedConditions[conditionType]; ok {
 		// if the status has not changed, use the old transition time
@@ -158,12 +177,60 @@ func (e *nodeExporter) RunWithTickers(ctx context.Context, heartbeatTicker <-cha
 		case <-heartbeatTicker:
 			e.updateHeartbeatTimes()
 		case <-reportTicker:
+			e.expireConditions(ctx)
 			if err := e.reportManagedConditions(ctx); err != nil {
 				log.FromContext(ctx).Error(err, "failed to report managed conditions")
 			}
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+// expireConditions returns any Fatal condition whose contributing reasons have all
+// passed their TTL back to its configured ready state. A condition with at least one
+// un-expired or non-expiring reason is left alone.
+func (e *nodeExporter) expireConditions(ctx context.Context) {
+	e.managedConditionsLock.Lock()
+	defer e.managedConditionsLock.Unlock()
+	now := metav1.Now()
+	for conditionType, reasonExpiries := range e.expiries {
+		condition, ok := e.managedConditions[conditionType]
+		if !ok || condition.Status != corev1.ConditionFalse {
+			continue
+		}
+		// only clear when every reason holding this condition down has lapsed,
+		// otherwise a still-failing reason would be silently dropped.
+		for reason, expiry := range reasonExpiries {
+			if now.Time.Before(expiry) {
+				continue
+			}
+			delete(reasonExpiries, reason)
+		}
+		if len(reasonExpiries) > 0 {
+			continue
+		}
+		conditionConfig, ok := e.conditionConfigs[conditionType]
+		if !ok {
+			// without a ready reason/message there is nothing sane to revert to.
+			continue
+		}
+		delete(e.expiries, conditionType)
+		log.FromContext(ctx).Info("clearing expired condition",
+			"conditionType", conditionType,
+			"previousReason", condition.Reason,
+		)
+		e.recorder.Event(e.nodeRef, corev1.EventTypeNormal, string(conditionType),
+			fmt.Sprintf("%s: condition cleared, %s was not re-observed", conditionConfig.ReadyReason, condition.Reason))
+		e.managedConditions[conditionType] = corev1.NodeCondition{
+			Type:               conditionType,
+			Reason:             conditionConfig.ReadyReason,
+			Message:            conditionConfig.ReadyMessage,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: now,
+			LastHeartbeatTime:  now,
+		}
+		e.managedConditionsDirty = true
 	}
 }
 

--- a/pkg/manager/node_exporter_test.go
+++ b/pkg/manager/node_exporter_test.go
@@ -342,3 +342,194 @@ func TestNodeExporter_LastTransitionTimeFlapping(t *testing.T) {
 		t.Errorf("Message was incorrectly updated with duplicates or cleared. expected: MessageA; MessageB, got: %s", latestMessage)
 	}
 }
+
+// A condition reported with a TTL should return to its ready state once the
+// failure stops being re-observed, rather than latching until node replacement.
+func TestNodeExporter_ExpiredConditionCleared(t *testing.T) {
+	ctx := context.TODO()
+	fakeClient := fake.NewFakeClient()
+	nodeName := "test-node"
+	initialNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	if err := fakeClient.Create(ctx, &initialNode); err != nil {
+		t.Fatalf("failed to create initial node: %v", err)
+	}
+
+	conditionType := corev1.NodeConditionType("NetworkingReady")
+	var recorder fakeEventRecorder
+	nodeExporter := manager.NewNodeExporter(
+		&initialNode,
+		fakeClient,
+		&recorder,
+		map[corev1.NodeConditionType]manager.NodeConditionConfig{
+			conditionType: {
+				ReadyReason:  "NetworkingIsReady",
+				ReadyMessage: "Monitoring for the Networking system is active",
+			},
+		},
+	)
+
+	reportChan := make(chan time.Time)
+	go nodeExporter.RunWithTickers(ctx, make(chan time.Time), reportChan)
+
+	// a very short TTL so the condition lapses within the test
+	fatal := monitor.Condition{
+		Reason:   "IPAMDNotReady",
+		Message:  "IPAM-D has failed to connect to API Server",
+		Severity: monitor.SeverityFatal,
+		TTL:      50 * time.Millisecond,
+	}
+	if err := nodeExporter.Fatal(ctx, fatal, conditionType); err != nil {
+		t.Fatal(err)
+	}
+
+	reportChan <- time.Now()
+	nodeKey := client.ObjectKeyFromObject(&initialNode)
+	unhealthy := corev1.NodeCondition{
+		Type:    conditionType,
+		Reason:  fatal.Reason,
+		Message: fatal.Message,
+		Status:  corev1.ConditionFalse,
+	}
+	if err := waitForCondition(ctx, fakeClient, nodeKey, unhealthy); err != nil {
+		t.Fatalf("condition was never reported as unhealthy: %v", err)
+	}
+
+	// once the TTL lapses, the next report tick should restore the ready state
+	time.Sleep(100 * time.Millisecond)
+	reportChan <- time.Now()
+
+	ready := corev1.NodeCondition{
+		Type:    conditionType,
+		Reason:  "NetworkingIsReady",
+		Message: "Monitoring for the Networking system is active",
+		Status:  corev1.ConditionTrue,
+	}
+	if err := waitForCondition(ctx, fakeClient, nodeKey, ready); err != nil {
+		t.Fatalf("expired condition was not cleared: %v", err)
+	}
+}
+
+// A condition reported without a TTL must keep latching, since it represents an
+// issue that only external repair can resolve.
+func TestNodeExporter_ConditionWithoutTTLNeverExpires(t *testing.T) {
+	ctx := context.TODO()
+	fakeClient := fake.NewFakeClient()
+	initialNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	if err := fakeClient.Create(ctx, &initialNode); err != nil {
+		t.Fatalf("failed to create initial node: %v", err)
+	}
+
+	conditionType := corev1.NodeConditionType("NetworkingReady")
+	var recorder fakeEventRecorder
+	nodeExporter := manager.NewNodeExporter(
+		&initialNode,
+		fakeClient,
+		&recorder,
+		map[corev1.NodeConditionType]manager.NodeConditionConfig{
+			conditionType: {ReadyReason: "NetworkingIsReady", ReadyMessage: "ok"},
+		},
+	)
+
+	reportChan := make(chan time.Time)
+	go nodeExporter.RunWithTickers(ctx, make(chan time.Time), reportChan)
+
+	fatal := monitor.Condition{
+		Reason:   "InterfaceNotUp",
+		Message:  "an interface is down",
+		Severity: monitor.SeverityFatal,
+	}
+	if err := nodeExporter.Fatal(ctx, fatal, conditionType); err != nil {
+		t.Fatal(err)
+	}
+
+	nodeKey := client.ObjectKeyFromObject(&initialNode)
+	unhealthy := corev1.NodeCondition{
+		Type:    conditionType,
+		Reason:  fatal.Reason,
+		Message: fatal.Message,
+		Status:  corev1.ConditionFalse,
+	}
+	reportChan <- time.Now()
+	if err := waitForCondition(ctx, fakeClient, nodeKey, unhealthy); err != nil {
+		t.Fatalf("condition was never reported as unhealthy: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	reportChan <- time.Now()
+	time.Sleep(100 * time.Millisecond)
+
+	var node corev1.Node
+	if err := fakeClient.Get(ctx, nodeKey, &node); err != nil {
+		t.Fatal(err)
+	}
+	if !nodeHasCondition(node, unhealthy) {
+		t.Fatalf("condition without a TTL was cleared: %+v", node.Status.Conditions)
+	}
+}
+
+// A condition held down by several reasons must stay down until all of them lapse,
+// otherwise a still-failing reason would be silently dropped.
+func TestNodeExporter_ConditionHeldByUnexpiredReason(t *testing.T) {
+	ctx := context.TODO()
+	fakeClient := fake.NewFakeClient()
+	initialNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	if err := fakeClient.Create(ctx, &initialNode); err != nil {
+		t.Fatalf("failed to create initial node: %v", err)
+	}
+
+	conditionType := corev1.NodeConditionType("NetworkingReady")
+	var recorder fakeEventRecorder
+	nodeExporter := manager.NewNodeExporter(
+		&initialNode,
+		fakeClient,
+		&recorder,
+		map[corev1.NodeConditionType]manager.NodeConditionConfig{
+			conditionType: {ReadyReason: "NetworkingIsReady", ReadyMessage: "ok"},
+		},
+	)
+
+	reportChan := make(chan time.Time)
+	go nodeExporter.RunWithTickers(ctx, make(chan time.Time), reportChan)
+
+	// one reason lapses almost immediately, the other is good for the whole test
+	if err := nodeExporter.Fatal(ctx, monitor.Condition{
+		Reason:   "IPAMDNotReady",
+		Message:  "transient",
+		Severity: monitor.SeverityFatal,
+		TTL:      50 * time.Millisecond,
+	}, conditionType); err != nil {
+		t.Fatal(err)
+	}
+	if err := nodeExporter.Fatal(ctx, monitor.Condition{
+		Reason:   "IPAMDNoIPs",
+		Message:  "persistent",
+		Severity: monitor.SeverityFatal,
+		TTL:      time.Hour,
+	}, conditionType); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	reportChan <- time.Now()
+	time.Sleep(100 * time.Millisecond)
+
+	var node corev1.Node
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(&initialNode), &node); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range node.Status.Conditions {
+		if c.Type == conditionType && c.Status != corev1.ConditionFalse {
+			t.Fatalf("condition cleared while a reason was still un-expired: %+v", c)
+		}
+	}
+}
+
+func waitForCondition(ctx context.Context, c client.Client, key client.ObjectKey, expected corev1.NodeCondition) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		var node corev1.Node
+		if err := c.Get(ctx, key, &node); err != nil {
+			return false, err
+		}
+		return nodeHasCondition(node, expected), nil
+	})
+}

--- a/pkg/reasons/meta.go
+++ b/pkg/reasons/meta.go
@@ -4,6 +4,7 @@ package reasons
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 )
@@ -36,6 +37,13 @@ func (r ConditionBuilder) Severity(sev monitor.Severity) ConditionBuilder {
 
 func (r ConditionBuilder) MinOccurrences(minOccurrences int64) ConditionBuilder {
 	r.Condition.MinOccurrences = minOccurrences
+	return r
+}
+
+// TTL marks the condition as self-clearing: if it is not re-observed within the
+// given duration, the exporter returns the node condition to its ready state.
+func (r ConditionBuilder) TTL(ttl time.Duration) ConditionBuilder {
+	r.Condition.TTL = ttl
 	return r
 }
 


### PR DESCRIPTION
The networking monitor sets NetworkingReady=False from a single ipamd log line, with Fatal severity and MinOccurrences 0. There is no corresponding recovery pattern, so the condition latches for the lifetime of the node.

In practice the common trigger is a boot race: ipamd starts before kube-proxy has programmed iptables for the kubernetes service ClusterIP, its 5s /version probe times out once, and it logs "Unable to reach API Server". It then retries and connects. The node is healthy, pods get IPs, and every other networking check passes, but NetworkingReady stays False for days, which hides genuine networking failures on the same node.

Give Condition an optional TTL. The node exporter records a deadline per contributing reason and, when every reason for a condition has lapsed, returns that condition to the ready state from its NodeConditionConfig and emits an event. Reasons reported without a TTL keep the previous latching behavior, so issues that genuinely need external repair are unaffected.

Apply a 15m TTL to the unreachable-API-Server reasons only. ipamd polls every 2s and logs on each failure while the outage is real, so a node that is actually cut off re-arms the condition continuously and never expires between observations.

with karpenter only shutting down NetworkReady=False nodes after 30m that should work with a 15m TTL

**Issue #, if available**:

**Description of changes**:

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
