### PR TITLE
fix: bound collector execution so a blocked collector cannot stop diagnostics

### DIFF
--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -65,6 +65,10 @@ var (
 
 const (
 	envNodeName = "MY_NODE_NAME"
+
+	// consoleFlushTimeout bounds the final diagnostic cycle written on exit, so
+	// that a collector blocked on host I/O cannot hold up the process teardown.
+	consoleFlushTimeout = 30 * time.Second
 )
 
 func init() {
@@ -84,8 +88,13 @@ func main() {
 			f, _ := openDevConsole()
 			defer f.Close()
 			// ensures that at least one run of the diagnostic is always
-			// completed and written to console before exiting.
-			diagnostic.NewDiagnosticLogger(f, diagnostic.Settings{}).Start(context.Background())
+			// completed and written to console before exiting. RunOnce emits a
+			// single cycle and returns; Start would block on its ticker and keep
+			// a crashing agent from ever exiting. The bound keeps a collector
+			// that is wedged on host I/O from delaying the exit indefinitely.
+			flushCtx, cancelFlush := context.WithTimeout(context.Background(), consoleFlushTimeout)
+			defer cancelFlush()
+			diagnostic.NewDiagnosticLogger(f, diagnostic.Settings{}).RunOnce(flushCtx)
 
 			// increase visibility on errors/panics propagated from main.
 			if r := recover(); r != nil {

--- a/pkg/controllers/nodediagnostic.go
+++ b/pkg/controllers/nodediagnostic.go
@@ -57,6 +57,16 @@ type nodeDiagnosticController struct {
 	// logCaptureTimeout overrides LogCaptureTimeout. Zero means the default; it
 	// is only set in tests, which cannot wait out the real bound.
 	logCaptureTimeout time.Duration
+
+	// captureRunning reports whether a previous log collection has not returned
+	// yet. A collector blocked on unresponsive host I/O never returns, so
+	// without this every later NodeDiagnostic would start a fresh collection and
+	// leak both a goroutine and the temp directory that collection is writing
+	// into, for the life of the node.
+	captureRunning atomic.Bool
+	// captureStartedAt is the unix nano timestamp of the outstanding collection,
+	// and is only meaningful while captureRunning is true.
+	captureStartedAt atomic.Int64
 }
 
 func NewNodeDiagnosticController(kubeClient client.Client, nodeName string, runtimeContext *config.RuntimeContext) *nodeDiagnosticController {
@@ -579,11 +589,41 @@ const LogCaptureTimeout = 20 * time.Minute
 // collection is deliberately not archived — it writes into the temp directory
 // that collectLogs removes on return, and archiving a directory with a live
 // writer in it would race the archiver against a growing file.
+//
+// Abandoning is only safe because of captureRunning. An abandoned collection
+// still holds its goroutine and its temp directory: collectLogs removes that
+// directory with a deferred call which does not run until the blocked read
+// returns, and on a wedged mount it never does. While a collection is
+// outstanding this reports the block instead of starting another one, so a
+// permanently wedged collector costs one goroutine and one temp directory
+// rather than a fresh pair for every NodeDiagnostic.
 func (c *nodeDiagnosticController) collectLogsBounded(ctx context.Context, categories []v1alpha1.LogCategory) (io.Reader, int, error) {
 	timeout := c.logCaptureTimeout
 	if timeout <= 0 {
 		timeout = LogCaptureTimeout
 	}
+
+	if !c.captureRunning.CompareAndSwap(false, true) {
+		// zero means the winning caller has claimed the slot but has not stored its
+		// start time yet, so there is no duration to report. Reporting one anyway
+		// would measure from the epoch.
+		if startedAt := c.captureStartedAt.Load(); startedAt == 0 {
+			return nil, 0, fmt.Errorf(
+				"log collection from a previous NodeDiagnostic has not returned and is still blocked on host I/O; " +
+					"not starting another until it does")
+		} else {
+			blocked := time.Since(time.Unix(0, startedAt)).Truncate(time.Second)
+			return nil, 0, fmt.Errorf(
+				"log collection from a previous NodeDiagnostic has not returned after %s and is still blocked on host I/O; "+
+					"not starting another until it does", blocked)
+		}
+	}
+	// stored by the caller that claimed the slot, so the timestamp belongs to the
+	// outstanding collection. Storing it before the claim would let every refused
+	// caller overwrite it with the time of its own attempt, which reads back as
+	// zero elapsed; the refusal path above handles the not-yet-stored case instead.
+	c.captureStartedAt.Store(time.Now().UnixNano())
+
 	// not named "collect": that would shadow the log collector package.
 	collectFn := c.collectFunc
 	if collectFn == nil {
@@ -602,6 +642,9 @@ func (c *nodeDiagnosticController) collectLogsBounded(ctx context.Context, categ
 	done := make(chan result, 1)
 	go func() {
 		archive, issueCount, err := collectFn(collectCtx, categories)
+		// released before publishing, so that a caller which receives the result
+		// always observes the collection as free again.
+		c.captureRunning.Store(false)
 		done <- result{archive, issueCount, err}
 	}()
 

--- a/pkg/controllers/nodediagnostic.go
+++ b/pkg/controllers/nodediagnostic.go
@@ -49,6 +49,14 @@ type nodeDiagnosticController struct {
 	// captureFunc is the function called to execute the packet capture. It defaults to
 	// captureAndUploadPackets but can be overridden in tests to avoid running tcpdump.
 	captureFunc func(ctx context.Context, nd *v1alpha1.NodeDiagnostic, captureID string) ([]error, error)
+
+	// collectFunc is the function called to collect logs. It defaults to
+	// collectLogs but can be overridden in tests to avoid reading host state.
+	collectFunc func(ctx context.Context, categories []v1alpha1.LogCategory) (io.Reader, int, error)
+
+	// logCaptureTimeout overrides LogCaptureTimeout. Zero means the default; it
+	// is only set in tests, which cannot wait out the real bound.
+	logCaptureTimeout time.Duration
 }
 
 func NewNodeDiagnosticController(kubeClient client.Client, nodeName string, runtimeContext *config.RuntimeContext) *nodeDiagnosticController {
@@ -58,6 +66,7 @@ func NewNodeDiagnosticController(kubeClient client.Client, nodeName string, runt
 		runtimeContext: runtimeContext,
 	}
 	c.captureFunc = c.captureAndUploadPackets
+	c.collectFunc = c.collectLogs
 	return c
 }
 
@@ -159,13 +168,13 @@ func (c *nodeDiagnosticController) handleLogCapture(ctx context.Context, nodeDia
 	}
 
 	log.Info("beginning log collection")
-	archiveReader, issueCount, err := c.collectLogs(ctx, nodeDiagnostic.Spec.Categories)
+	archiveReader, issueCount, err := c.collectLogsBounded(ctx, nodeDiagnostic.Spec.Categories)
 	if err != nil {
 		log.Error(err, "failed to collect logs")
 		captureStatus.State = v1alpha1.CaptureState{
 			Completed: &v1alpha1.CaptureStateCompleted{
 				Reason:     v1alpha1.CaptureStateFailure,
-				Message:    fmt.Sprint("fatal error during log collection process", err),
+				Message:    fmt.Sprintf("fatal error during log collection process: %s", err),
 				StartedAt:  captureStatus.State.Running.StartedAt,
 				FinishedAt: metav1.Now(),
 			},
@@ -553,6 +562,60 @@ func (c *nodeDiagnosticController) captureAndUploadPackets(ctx context.Context, 
 	return uploadErrors, nil
 }
 
+// LogCaptureTimeout bounds a whole LogCapture. Individual commands are bounded
+// by collect.DefaultCommandTimeout, so this is the backstop for a collector that
+// blocks outside of a subprocess, such as reading a file on an unresponsive
+// mount. Without it a blocked collector leaves CaptureState in Running forever,
+// which is indistinguishable from a slow capture and, with
+// MaxConcurrentReconciles of 1, also stops every later NodeDiagnostic.
+const LogCaptureTimeout = 20 * time.Minute
+
+// collectLogsBounded runs the log collection under LogCaptureTimeout.
+//
+// On timeout the collection goroutine is abandoned rather than waited on, for
+// the same reason the command level bound abandons its child: a collector stuck
+// on unresponsive host I/O cannot be interrupted, and waiting for it is what
+// leaves the capture stuck in Running. The partial output of an abandoned
+// collection is deliberately not archived — it writes into the temp directory
+// that collectLogs removes on return, and archiving a directory with a live
+// writer in it would race the archiver against a growing file.
+func (c *nodeDiagnosticController) collectLogsBounded(ctx context.Context, categories []v1alpha1.LogCategory) (io.Reader, int, error) {
+	timeout := c.logCaptureTimeout
+	if timeout <= 0 {
+		timeout = LogCaptureTimeout
+	}
+	// not named "collect": that would shadow the log collector package.
+	collectFn := c.collectFunc
+	if collectFn == nil {
+		collectFn = c.collectLogs
+	}
+
+	collectCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type result struct {
+		archive    io.Reader
+		issueCount int
+		err        error
+	}
+	// buffered so an abandoned collection can still publish and exit.
+	done := make(chan result, 1)
+	go func() {
+		archive, issueCount, err := collectFn(collectCtx, categories)
+		done <- result{archive, issueCount, err}
+	}()
+
+	select {
+	case r := <-done:
+		return r.archive, r.issueCount, r.err
+	case <-collectCtx.Done():
+		if err := ctx.Err(); err != nil {
+			return nil, 0, fmt.Errorf("log collection stopped: %w", err)
+		}
+		return nil, 0, fmt.Errorf("log collection timed out after %s, a collector is blocked on host I/O", timeout)
+	}
+}
+
 // collectLogs is a small abstraction over the log collector that helps keep the
 // controller code brief.
 //
@@ -577,7 +640,7 @@ func (c *nodeDiagnosticController) collectLogs(ctx context.Context, categories [
 		),
 	}
 
-	acc, err := collect.NewAccessor(cfg)
+	acc, err := collect.NewAccessor(ctx, cfg)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to create accessor: %s", err)
 	}

--- a/pkg/controllers/nodediagnostic_test.go
+++ b/pkg/controllers/nodediagnostic_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -397,6 +398,92 @@ func TestCollectLogsBounded_ParentCancellation(t *testing.T) {
 
 // TestHandleDelete_ActiveCapture_CancelCalled verifies that when a
 // NodeDiagnostic is deleted while a capture is active, the cancel func is called.
+func TestCollectLogsBounded_OutstandingRunIsNotRestarted(t *testing.T) {
+	release := make(chan struct{})
+	var starts atomic.Int32
+
+	c := &nodeDiagnosticController{
+		logCaptureTimeout: 50 * time.Millisecond,
+		collectFunc: func(ctx context.Context, _ []v1alpha1.LogCategory) (io.Reader, int, error) {
+			starts.Add(1)
+			// blocks past the bound and ignores cancellation, standing in for a
+			// collector stuck on an unresponsive mount.
+			<-release
+			return strings.NewReader("archive"), 0, nil
+		},
+	}
+
+	// first attempt gives up on the bound and abandons the collection.
+	_, _, err := c.collectLogsBounded(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+
+	// second attempt must report the outstanding run rather than start another.
+	_, _, err = c.collectLogsBounded(context.Background(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has not returned")
+	assert.Contains(t, err.Error(), "not starting another")
+	assert.NotContains(t, err.Error(), "timed out",
+		"the skip must be reported as a skip, not as a fresh timeout")
+	assert.Equal(t, int32(1), starts.Load(),
+		"a second collection must not be started while the first is outstanding")
+
+	// once the abandoned collection returns, the next attempt runs normally.
+	close(release)
+	require.Eventually(t, func() bool { return !c.captureRunning.Load() },
+		time.Second, 10*time.Millisecond, "the slot must be released when the collection returns")
+
+	archive, _, err := c.collectLogsBounded(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), starts.Load())
+	body, err := io.ReadAll(archive)
+	require.NoError(t, err)
+	assert.Equal(t, "archive", string(body))
+}
+
+func TestCollectLogsBounded_SkipReportsRealBlockDuration(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+
+	c := &nodeDiagnosticController{
+		logCaptureTimeout: 20 * time.Millisecond,
+		collectFunc: func(ctx context.Context, _ []v1alpha1.LogCategory) (io.Reader, int, error) {
+			<-release
+			return nil, 0, nil
+		},
+	}
+
+	_, _, err := c.collectLogsBounded(context.Background(), nil)
+	require.Error(t, err)
+
+	// long enough that a correct implementation must round to a whole second.
+	time.Sleep(1100 * time.Millisecond)
+
+	_, _, err = c.collectLogsBounded(context.Background(), nil)
+	require.Error(t, err)
+	// the timestamp belongs to the outstanding collection. If a refused caller
+	// could overwrite it, this would measure the gap between two adjacent
+	// statements and report 0s.
+	assert.NotContains(t, err.Error(), "after 0s",
+		"the duration must be measured from the outstanding collection, not from this attempt")
+	assert.Regexp(t, `has not returned after [1-9][0-9]*s`, err.Error(),
+		"a collection blocked for over a second must report at least 1s")
+}
+
+func TestCollectLogsBounded_SlotReleasedOnSuccess(t *testing.T) {
+	c := &nodeDiagnosticController{
+		logCaptureTimeout: time.Second,
+		collectFunc: func(ctx context.Context, _ []v1alpha1.LogCategory) (io.Reader, int, error) {
+			return strings.NewReader("archive"), 0, nil
+		},
+	}
+
+	for i := range 3 {
+		_, _, err := c.collectLogsBounded(context.Background(), nil)
+		require.NoErrorf(t, err, "attempt %d must not be skipped: a completed collection frees the slot", i+1)
+	}
+}
+
 func TestHandleDelete_ActiveCapture_CancelCalled(t *testing.T) {
 	c := &nodeDiagnosticController{nodeName: "test-node"}
 

--- a/pkg/controllers/nodediagnostic_test.go
+++ b/pkg/controllers/nodediagnostic_test.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -301,6 +303,96 @@ func TestHandlePacketCapture_CancelledDuringCapture(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("handlePacketCapture did not return within timeout")
 	}
+}
+
+// Regression test for issue #219: a blocked collector must not leave the capture
+// in Running forever. handleLogCapture has to complete the status with a failure
+// naming the timeout, so that a hung capture is distinguishable from a slow one.
+func TestHandleLogCapture_BlockedCollectorCompletesWithTimeout(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.SchemeBuilder.AddToScheme(scheme))
+
+	nd := &v1alpha1.NodeDiagnostic{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node", Generation: 1},
+		Spec: v1alpha1.NodeDiagnosticSpec{
+			LogCapture: &v1alpha1.LogCapture{
+				UploadDestination: "node",
+				Categories:        []v1alpha1.LogCategory{v1alpha1.LogCategoryAll},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(nd).
+		WithStatusSubresource(&v1alpha1.NodeDiagnostic{}).
+		Build()
+
+	collectorEntered := make(chan struct{})
+	c := &nodeDiagnosticController{
+		kubeClient:        fakeClient,
+		nodeName:          "test-node",
+		logCaptureTimeout: 100 * time.Millisecond,
+		// stands in for a collector wedged on unresponsive host I/O: it ignores
+		// cancellation, exactly as a process in uninterruptible sleep does.
+		collectFunc: func(ctx context.Context, _ []v1alpha1.LogCategory) (io.Reader, int, error) {
+			close(collectorEntered)
+			<-make(chan struct{})
+			return nil, 0, nil
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- c.handleLogCapture(context.Background(), nd) }()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "the status patch itself should succeed")
+	case <-time.After(30 * time.Second):
+		t.Fatal("handleLogCapture did not return, a blocked collector still hangs the capture")
+	}
+
+	<-collectorEntered
+	status := nd.Status.GetCaptureStatus(v1alpha1.CaptureTypeLog)
+	require.NotNil(t, status)
+	require.NotNil(t, status.State.Completed, "capture must not be left in Running")
+	assert.Nil(t, status.State.Running)
+	assert.Equal(t, v1alpha1.CaptureStateFailure, status.State.Completed.Reason)
+	assert.Contains(t, status.State.Completed.Message, "timed out after 100ms")
+}
+
+// A collection that finishes inside the bound is unaffected.
+func TestCollectLogsBounded_CompletesWithinTimeout(t *testing.T) {
+	c := &nodeDiagnosticController{
+		logCaptureTimeout: 30 * time.Second,
+		collectFunc: func(ctx context.Context, _ []v1alpha1.LogCategory) (io.Reader, int, error) {
+			return strings.NewReader("archive"), 2, nil
+		},
+	}
+
+	archive, issueCount, err := c.collectLogsBounded(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, issueCount, "the failed task count must be passed through")
+	body, err := io.ReadAll(archive)
+	require.NoError(t, err)
+	assert.Equal(t, "archive", string(body))
+}
+
+// Shutdown is reported as cancellation rather than as a capture timeout.
+func TestCollectLogsBounded_ParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := &nodeDiagnosticController{
+		collectFunc: func(ctx context.Context, _ []v1alpha1.LogCategory) (io.Reader, int, error) {
+			<-ctx.Done()
+			return nil, 0, ctx.Err()
+		},
+	}
+
+	_, _, err := c.collectLogsBounded(ctx, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NotContains(t, err.Error(), "timed out")
 }
 
 // TestHandleDelete_ActiveCapture_CancelCalled verifies that when a

--- a/pkg/diagnostic/logger.go
+++ b/pkg/diagnostic/logger.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -20,6 +21,11 @@ import (
 type Settings struct {
 	LogInterval       time.Duration
 	ApiServerEndpoint string
+	// CollectorTimeout bounds how long a single collector may take before its
+	// section is emitted as a timeout notice and the cycle moves on. It should
+	// stay comfortably below LogInterval so that a slow collector does not
+	// consume the whole cycle. Defaults to defaultCollectorTimeout.
+	CollectorTimeout time.Duration
 }
 
 // NOTE: the functions in this logger don't check the host root path, which is
@@ -30,10 +36,35 @@ type Settings struct {
 type diagnosticLogger struct {
 	settings Settings
 	writer   io.Writer
+	// producers are built once and reused for every cycle so that they can
+	// track whether a previous run of themselves is still outstanding.
+	producers []*producer
+	// sectionBytes is the per section budget for the console buffer.
+	sectionBytes int
+}
+
+// producer emits the body of one console section.
+type producer struct {
+	name string
+	fn   func(context.Context) []byte
+
+	// running reports whether a previous cycle's run of this producer has not
+	// returned yet. A collector blocked in uninterruptible sleep never returns,
+	// so without this the loop would start a fresh copy every cycle and
+	// accumulate stuck processes and goroutines for the life of the node.
+	running atomic.Bool
+	// startedAt is the unix nano timestamp of the outstanding run, and is only
+	// meaningful while running is true.
+	startedAt atomic.Int64
 }
 
 const (
 	sectionMarker = "NMA::LOG"
+	// defaultCollectorTimeout bounds a single collector. Collectors read host
+	// state that can block indefinitely (a 'df' on an unresponsive NFS or EFS
+	// mount is enough), and the cycle is sequential, so an unbounded collector
+	// silently stops every later section as well.
+	defaultCollectorTimeout = 30 * time.Second
 	// maxTailReadBytes bounds how much of a large file is read into memory.
 	// It is generously larger than any per-section console budget, so the
 	// tail-trimmed output is unchanged while memory stays bounded.
@@ -51,6 +82,9 @@ func NewDiagnosticLogger(writer io.Writer, settings Settings) diagnosticLogger {
 	if settings.LogInterval <= 0 {
 		settings.LogInterval = 5 * time.Minute
 	}
+	if settings.CollectorTimeout <= 0 {
+		settings.CollectorTimeout = defaultCollectorTimeout
+	}
 	if settings.ApiServerEndpoint == "" {
 		config, err := clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
 		if err == nil {
@@ -58,27 +92,17 @@ func NewDiagnosticLogger(writer io.Writer, settings Settings) diagnosticLogger {
 		}
 	}
 
-	return diagnosticLogger{
-		settings: settings,
-		writer:   writer,
-	}
-}
-
-func (l diagnosticLogger) Start(ctx context.Context) error {
-	var producers = []struct {
-		name string
-		fn   func() []byte
-	}{
+	producers := []*producer{
 		{name: "cpu", fn: cpuUsage},
 		{name: "memory", fn: memoryUsage},
 		{name: "disk", fn: diskUsage},
 		{name: "interfaces", fn: listNetworkInterfaces},
-		{name: "ipamd", fn: func() []byte { return tailx(ipamd(), 5000) }},
-		{name: "apiserver", fn: func() []byte { return testAPIServerEndpoint(l.settings.ApiServerEndpoint) }},
-		{name: "dmesg", fn: func() []byte { return dmesg() }},
-		{name: "systemd", fn: func() []byte { return systemdStatus("containerd", "kubelet") }},
-		{name: "kubelet", fn: func() []byte { return journalctl("kubelet") }},
-		{name: "containerd", fn: func() []byte { return journalctl("containerd") }},
+		{name: "ipamd", fn: func(context.Context) []byte { return tailx(ipamd(), 5000) }},
+		{name: "apiserver", fn: func(context.Context) []byte { return testAPIServerEndpoint(settings.ApiServerEndpoint) }},
+		{name: "dmesg", fn: dmesg},
+		{name: "systemd", fn: func(ctx context.Context) []byte { return systemdStatus(ctx, "containerd", "kubelet") }},
+		{name: "kubelet", fn: func(ctx context.Context) []byte { return journalctl(ctx, "kubelet") }},
+		{name: "containerd", fn: func(ctx context.Context) []byte { return journalctl(ctx, "containerd") }},
 	}
 
 	// to calculate the sections size that would best fit in the 68K buffer, we
@@ -97,20 +121,21 @@ func (l diagnosticLogger) Start(ctx context.Context) error {
 		constSectionBytes += length
 	}
 	freeBytes := bufferLength - (constSectionBytes + (len(producers) * headerBytes))
-	sectionBytes := freeBytes / (len(producers) - len(constLengthSections))
 
+	return diagnosticLogger{
+		settings:     settings,
+		writer:       writer,
+		producers:    producers,
+		sectionBytes: freeBytes / (len(producers) - len(constLengthSections)),
+	}
+}
+
+func (l diagnosticLogger) Start(ctx context.Context) error {
 	ticker := time.NewTicker(l.settings.LogInterval)
 	defer ticker.Stop()
 
 	for {
-		for _, producer := range producers {
-			timestamp := time.Now().UTC().Format(time.RFC3339)
-			header := strings.Join([]string{sectionMarker, timestamp, producer.name}, "|")
-			data := tailx(producer.fn(), sectionBytes)
-			if _, err := fmt.Fprintf(l.writer, "%s\n%s\n", header, data); err != nil {
-				log.FromContext(ctx).Error(err, "error logging to writer")
-			}
-		}
+		l.RunOnce(ctx)
 		select {
 		case <-ticker.C:
 		case <-ctx.Done():
@@ -120,43 +145,110 @@ func (l diagnosticLogger) Start(ctx context.Context) error {
 	}
 }
 
-func systemdStatus(services ...string) []byte {
-	args := []string{"status", "--all", "-n", "0"}
-	if out, err := exec.Command("systemctl", append(args, services...)...).Output(); err != nil {
-		return []byte(fmt.Sprintf("failed to call systemctl due to: %s", err))
+// RunOnce writes exactly one cycle of diagnostic sections and returns. Every
+// section is emitted, whether or not its collector produced anything, and the
+// cycle is bounded by CollectorTimeout per collector.
+func (l diagnosticLogger) RunOnce(ctx context.Context) {
+	for _, producer := range l.producers {
+		timestamp := time.Now().UTC().Format(time.RFC3339)
+		header := strings.Join([]string{sectionMarker, timestamp, producer.name}, "|")
+		data := tailx(l.collect(ctx, producer), l.sectionBytes)
+		if _, err := fmt.Fprintf(l.writer, "%s\n%s\n", header, data); err != nil {
+			log.FromContext(ctx).Error(err, "error logging to writer")
+		}
+	}
+}
+
+// collect returns the producer's output, or a notice to emit in its place when
+// the producer does not finish in time. It never blocks for longer than
+// CollectorTimeout, which is what keeps the cycle — and therefore every later
+// section — making progress when a collector wedges.
+//
+// The collector runs on its own goroutine, which is abandoned rather than waited
+// on once the bound is hit. The context handed to the collector is cancelled at
+// the same deadline, so a killable child is terminated; a child in
+// uninterruptible sleep is not, and its goroutine stays outstanding. That is
+// what the running flag is for: while a run is outstanding the producer is
+// skipped instead of started again, so a single permanently wedged collector
+// costs one goroutine and one process rather than a fresh pair every cycle.
+func (l diagnosticLogger) collect(ctx context.Context, p *producer) []byte {
+	if !p.running.CompareAndSwap(false, true) {
+		blocked := time.Since(time.Unix(0, p.startedAt.Load())).Truncate(time.Second)
+		return []byte(fmt.Sprintf(
+			"collector %q has not returned after %s and is skipped until it does", p.name, blocked))
+	}
+	p.startedAt.Store(time.Now().UnixNano())
+
+	collectCtx, cancel := context.WithTimeout(ctx, l.settings.CollectorTimeout)
+	// cancelled here rather than by the collector goroutine. Cancelling from the
+	// goroutine would make collectCtx.Done ready as soon as the collector
+	// finished, so the select below would pick between a real result and a
+	// spurious timeout at random.
+	defer cancel()
+
+	// buffered so that an abandoned collector can still publish and exit.
+	done := make(chan []byte, 1)
+	go func() {
+		data := p.fn(collectCtx)
+		// released before publishing, so that a caller which receives the result
+		// always observes the producer as free again.
+		p.running.Store(false)
+		done <- data
+	}()
+
+	select {
+	case data := <-done:
+		return data
+	case <-collectCtx.Done():
+		if err := ctx.Err(); err != nil {
+			return []byte(fmt.Sprintf("collector %q did not finish before shutdown", p.name))
+		}
+		return []byte(fmt.Sprintf("collector %q timed out after %s", p.name, l.settings.CollectorTimeout))
+	}
+}
+
+// commandOutput runs a command bound to ctx and returns its standard output, or
+// the failure as the section body, matching the convention of reporting a
+// collector's problem as its content rather than dropping the section.
+//
+// The command is run in the foreground and is deliberately not wrapped in
+// osext.Output: the caller (diagnosticLogger.collect) already bounds this
+// collector, and it needs the collector to stay outstanding for as long as its
+// child does. Returning early here instead would let the next cycle start
+// another copy of a command that can never be killed.
+func commandOutput(ctx context.Context, name string, arg ...string) []byte {
+	cmd := exec.CommandContext(ctx, name, arg...)
+	// bound the wait for the child's pipes to close after it is killed, so that
+	// a grandchild holding stdout open cannot keep this collector outstanding.
+	cmd.WaitDelay = 5 * time.Second
+	if out, err := cmd.Output(); err != nil {
+		return []byte(fmt.Sprintf("failed to call %s due to: %s", name, err))
 	} else {
 		return out
 	}
 }
 
-func journalctl(unit string) []byte {
+func systemdStatus(ctx context.Context, services ...string) []byte {
+	args := []string{"status", "--all", "-n", "0"}
+	return commandOutput(ctx, "systemctl", append(args, services...)...)
+}
+
+func journalctl(ctx context.Context, unit string) []byte {
 	// Bound the journal read with --lines: without it the entire unit journal
 	// is buffered into memory each cycle and grows unbounded over the node's
 	// lifetime. The output is tail-trimmed to the section budget anyway.
-	if out, err := exec.Command("journalctl", "-o", "short-iso-precise", "--unit", unit, "--lines", journalMaxLines).Output(); err != nil {
-		return []byte(fmt.Sprintf("failed to call journalctl due to: %s", err))
-	} else {
-		return out
-	}
+	return commandOutput(ctx, "journalctl", "-o", "short-iso-precise", "--unit", unit, "--lines", journalMaxLines)
 }
 
-func cpuUsage() []byte {
-	if out, err := exec.Command("ps", "aux").Output(); err != nil {
-		return []byte(fmt.Sprintf("failed to call ps due to: %s", err))
-	} else {
-		return out
-	}
+func cpuUsage(ctx context.Context) []byte {
+	return commandOutput(ctx, "ps", "aux")
 }
 
-func diskUsage() []byte {
-	if out, err := exec.Command("df", "-T").Output(); err != nil {
-		return []byte(fmt.Sprintf("failed to call df due to: %s", err))
-	} else {
-		return out
-	}
+func diskUsage(ctx context.Context) []byte {
+	return commandOutput(ctx, "df", "-T")
 }
 
-func memoryUsage() []byte {
+func memoryUsage(context.Context) []byte {
 	if out, err := os.ReadFile("/proc/meminfo"); err != nil {
 		return []byte(fmt.Sprintf("failed to read /pro/meminfo due to: %s", err))
 	} else {
@@ -164,7 +256,7 @@ func memoryUsage() []byte {
 	}
 }
 
-func listNetworkInterfaces() []byte {
+func listNetworkInterfaces(context.Context) []byte {
 	interfaces, err := net.Interfaces()
 	if err != nil {
 		return []byte(fmt.Sprintf("failed to get network interfaces due to: %s", err))
@@ -185,12 +277,8 @@ func listNetworkInterfaces() []byte {
 	return out.Bytes()
 }
 
-func dmesg() []byte {
-	if out, err := exec.Command("dmesg").Output(); err != nil {
-		return []byte(fmt.Sprintf("failed to call dmesg due to: %s", err))
-	} else {
-		return out
-	}
+func dmesg(ctx context.Context) []byte {
+	return commandOutput(ctx, "dmesg")
 }
 
 func ipamd() []byte {

--- a/pkg/diagnostic/logger.go
+++ b/pkg/diagnostic/logger.go
@@ -173,10 +173,21 @@ func (l diagnosticLogger) RunOnce(ctx context.Context) {
 // costs one goroutine and one process rather than a fresh pair every cycle.
 func (l diagnosticLogger) collect(ctx context.Context, p *producer) []byte {
 	if !p.running.CompareAndSwap(false, true) {
-		blocked := time.Since(time.Unix(0, p.startedAt.Load())).Truncate(time.Second)
-		return []byte(fmt.Sprintf(
-			"collector %q has not returned after %s and is skipped until it does", p.name, blocked))
+		// zero means the winning caller has claimed the slot but has not stored its
+		// start time yet, so there is no duration to report. Reporting one anyway
+		// would measure from the epoch.
+		if startedAt := p.startedAt.Load(); startedAt == 0 {
+			return []byte(fmt.Sprintf("collector %q has not returned and is skipped until it does", p.name))
+		} else {
+			blocked := time.Since(time.Unix(0, startedAt)).Truncate(time.Second)
+			return []byte(fmt.Sprintf(
+				"collector %q has not returned after %s and is skipped until it does", p.name, blocked))
+		}
 	}
+	// stored by the caller that claimed the slot, so the timestamp belongs to the
+	// outstanding run. Storing it before the claim would let every skipped caller
+	// overwrite it with the time of its own attempt, which reads back as zero
+	// elapsed; the skip path above handles the not-yet-stored case instead.
 	p.startedAt.Store(time.Now().UnixNano())
 
 	collectCtx, cancel := context.WithTimeout(ctx, l.settings.CollectorTimeout)
@@ -191,7 +202,10 @@ func (l diagnosticLogger) collect(ctx context.Context, p *producer) []byte {
 	go func() {
 		data := p.fn(collectCtx)
 		// released before publishing, so that a caller which receives the result
-		// always observes the producer as free again.
+		// always observes the producer as free again. Only the goroutine that
+		// claimed the slot ever releases it, and only once, so an abandoned
+		// collector cannot free a later run's claim: while it is outstanding the
+		// flag stays set and every other caller is skipped without claiming.
 		p.running.Store(false)
 		done <- data
 	}()

--- a/pkg/diagnostic/logger_test.go
+++ b/pkg/diagnostic/logger_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -68,6 +70,162 @@ func TestAPIServerEndpointUnreachable(t *testing.T) {
 	// response and therefore no body to close.
 	body := testAPIServerEndpoint("https://127.0.0.1:1")
 	assert.Contains(t, string(body), "failed to make request endpoint")
+}
+
+// newTestLogger builds a logger over an explicit producer set, bypassing the
+// host collectors so that blocking behaviour can be exercised directly.
+func newTestLogger(w io.Writer, timeout time.Duration, producers ...*producer) diagnosticLogger {
+	return diagnosticLogger{
+		settings:     Settings{LogInterval: time.Hour, CollectorTimeout: timeout},
+		writer:       w,
+		producers:    producers,
+		sectionBytes: 4096,
+	}
+}
+
+// blockingProducer never returns, standing in for a collector stuck on
+// unresponsive host I/O (a 'df' against a wedged NFS mount, for example).
+func blockingProducer(name string, entered chan<- struct{}) *producer {
+	return &producer{name: name, fn: func(context.Context) []byte {
+		if entered != nil {
+			entered <- struct{}{}
+		}
+		<-make(chan struct{})
+		return nil
+	}}
+}
+
+// Regression test for issue #219: a collector that never returns must cost its
+// own section only. Before the fix it stopped the cycle, so every later section
+// went missing for the remaining life of the node.
+func TestBlockedCollectorDoesNotStopCycle(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := newTestLogger(&buffer, 50*time.Millisecond,
+		blockingProducer("blocked", nil),
+		&producer{name: "after", fn: func(context.Context) []byte { return []byte("after-ran") }},
+	)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		logger.RunOnce(context.Background())
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("RunOnce did not return, the blocked collector stopped the cycle")
+	}
+
+	out := buffer.String()
+	assert.Contains(t, out, "|blocked\ncollector \"blocked\" timed out after 50ms",
+		"the blocked section must report the timeout as its body")
+	assert.Contains(t, out, "|after\nafter-ran", "sections after a blocked collector must still be emitted")
+}
+
+// A collector still stuck from a previous cycle must not be started again: the
+// wedged process cannot be killed, so respawning it accumulates one stuck
+// process and goroutine per cycle for the life of the node.
+func TestBlockedCollectorIsNotRestarted(t *testing.T) {
+	var buffer bytes.Buffer
+	entered := make(chan struct{}, 10)
+	logger := newTestLogger(&buffer, 50*time.Millisecond, blockingProducer("blocked", entered))
+
+	logger.RunOnce(context.Background())
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("collector was never started")
+	}
+
+	// the second cycle must skip the outstanding collector rather than wait for
+	// the timeout again.
+	buffer.Reset()
+	start := time.Now()
+	logger.RunOnce(context.Background())
+
+	assert.Empty(t, entered, "outstanding collector must not be started again")
+	assert.Less(t, time.Since(start), 50*time.Millisecond, "skipping must not wait for the timeout")
+	assert.Contains(t, buffer.String(), "has not returned after", "the section must report the collector as outstanding")
+}
+
+// A collector that returns normally is re-run every cycle, i.e. the single
+// flight guard releases on completion.
+func TestHealthyCollectorRunsEveryCycle(t *testing.T) {
+	var buffer bytes.Buffer
+	var runs atomic.Int32
+	logger := newTestLogger(&buffer, time.Minute,
+		&producer{name: "healthy", fn: func(context.Context) []byte {
+			runs.Add(1)
+			return []byte("ok")
+		}},
+	)
+
+	logger.RunOnce(context.Background())
+	logger.RunOnce(context.Background())
+
+	assert.Equal(t, int32(2), runs.Load())
+	assert.Equal(t, 2, strings.Count(buffer.String(), "|healthy\nok"))
+}
+
+// The collector context is cancelled at the deadline so that a killable child
+// process is terminated rather than left running.
+func TestCollectorContextIsCancelledAtDeadline(t *testing.T) {
+	var buffer bytes.Buffer
+	cancelled := make(chan error, 1)
+	logger := newTestLogger(&buffer, 50*time.Millisecond,
+		&producer{name: "watcher", fn: func(ctx context.Context) []byte {
+			<-ctx.Done()
+			cancelled <- ctx.Err()
+			return nil
+		}},
+	)
+
+	logger.RunOnce(context.Background())
+
+	select {
+	case err := <-cancelled:
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(10 * time.Second):
+		t.Fatal("collector context was never cancelled")
+	}
+}
+
+// Shutdown is reported as shutdown rather than as a collector timeout.
+func TestShutdownDuringCollection(t *testing.T) {
+	var buffer bytes.Buffer
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	logger := newTestLogger(&buffer, time.Minute, blockingProducer("blocked", nil))
+	logger.RunOnce(ctx)
+
+	assert.Contains(t, buffer.String(), "did not finish before shutdown")
+}
+
+// RunOnce emits one cycle and returns, which is what makes it usable for the
+// final flush on exit; Start would block on its ticker forever.
+func TestRunOnceEmitsSingleCycle(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := newTestLogger(&buffer, time.Minute,
+		&producer{name: "one", fn: func(context.Context) []byte { return []byte("body") }},
+	)
+
+	logger.RunOnce(context.Background())
+
+	assert.Equal(t, 1, strings.Count(buffer.String(), sectionMarker))
+}
+
+func TestNewDiagnosticLoggerDefaults(t *testing.T) {
+	logger := NewDiagnosticLogger(io.Discard, Settings{})
+	assert.Equal(t, defaultCollectorTimeout, logger.settings.CollectorTimeout)
+	assert.Equal(t, 5*time.Minute, logger.settings.LogInterval)
+	assert.NotEmpty(t, logger.producers, "producers must be built up front so they can track outstanding runs")
+	assert.Positive(t, logger.sectionBytes)
+
+	t.Run("RespectsExplicitTimeout", func(t *testing.T) {
+		logger := NewDiagnosticLogger(io.Discard, Settings{CollectorTimeout: time.Second})
+		assert.Equal(t, time.Second, logger.settings.CollectorTimeout)
+	})
 }
 
 func TestUtils(t *testing.T) {

--- a/pkg/diagnostic/logger_test.go
+++ b/pkg/diagnostic/logger_test.go
@@ -148,6 +148,54 @@ func TestBlockedCollectorIsNotRestarted(t *testing.T) {
 	assert.Contains(t, buffer.String(), "has not returned after", "the section must report the collector as outstanding")
 }
 
+// The skip message reports how long the outstanding run has actually been
+// blocked. The timestamp is stored only by the caller that claimed the slot; if a
+// refused caller could overwrite it, every skip would measure the gap between its
+// own two statements and report 0s, losing the only information the message
+// carries.
+func TestSkipMessageReportsRealBlockDuration(t *testing.T) {
+	var buffer bytes.Buffer
+	entered := make(chan struct{}, 10)
+	logger := newTestLogger(&buffer, 20*time.Millisecond, blockingProducer("blocked", entered))
+
+	logger.RunOnce(context.Background())
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("collector was never started")
+	}
+
+	// long enough that a correct implementation must round to a whole second.
+	time.Sleep(1100 * time.Millisecond)
+
+	buffer.Reset()
+	logger.RunOnce(context.Background())
+
+	out := buffer.String()
+	require.Contains(t, out, "has not returned after")
+	assert.NotContains(t, out, "after 0s",
+		"the duration must be measured from the outstanding run, not from this attempt")
+	assert.Regexp(t, `has not returned after [1-9][0-9]*s`, out,
+		"a collector blocked for over a second must report at least 1s")
+}
+
+// A skip that lands before the claiming caller has stored its start time reports
+// the skip without a duration, rather than measuring from the zero value.
+func TestSkipBeforeStartedAtIsStoredOmitsDuration(t *testing.T) {
+	p := &producer{name: "blocked", fn: func(context.Context) []byte { return nil }}
+	// the state a caller sees in the window between another caller's successful
+	// claim and its store of the start time.
+	p.running.Store(true)
+
+	var buffer bytes.Buffer
+	logger := newTestLogger(&buffer, time.Second, p)
+	logger.RunOnce(context.Background())
+
+	out := buffer.String()
+	assert.Contains(t, out, "has not returned and is skipped until it does")
+	assert.NotContains(t, out, "after", "no duration can be reported before one is known")
+}
+
 // A collector that returns normally is re-run every cycle, i.e. the single
 // flight guard releases on completion.
 func TestHealthyCollectorRunsEveryCycle(t *testing.T) {

--- a/pkg/log_collector/collect/accessor.go
+++ b/pkg/log_collector/collect/accessor.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -19,8 +20,12 @@ import (
 )
 
 type Accessor struct {
-	cfg    Config
-	imds   *imds.Client
+	cfg  Config
+	imds *imds.Client
+	// ctx bounds the lifetime of the commands run through this accessor.
+	// Collectors take no context of their own, so it is held here rather than
+	// threaded through every Collect implementation.
+	ctx    context.Context
 	logger logr.Logger
 }
 
@@ -33,7 +38,18 @@ type Config struct {
 	// Tags are used to provide context to Collectors about what tasks may or
 	// may not be applicable to the current instance.
 	Tags []string
+	// CommandTimeout bounds each command a Collector runs. Defaults to
+	// DefaultCommandTimeout.
+	CommandTimeout time.Duration
 }
+
+// DefaultCommandTimeout bounds a single collector command. Collectors run
+// commands that read host state and can block indefinitely rather than fail:
+// 'df' and 'du' against an unresponsive NFS or EFS mount, 'ps' against a task
+// stuck in the kernel, or 'journalctl' against a wedged journal. It is set well
+// above what any of these commands legitimately need, so that hitting it means
+// the command is stuck rather than slow.
+const DefaultCommandTimeout = 60 * time.Second
 
 const (
 	TagNvidia       = "nvidia"
@@ -51,8 +67,12 @@ func (c *Config) hasAnyTag(tags ...string) bool {
 	return false
 }
 
-func NewAccessor(cfg Config) (*Accessor, error) {
-	ctx := context.Background()
+// NewAccessor builds an Accessor for a single collection run. Commands executed
+// through it are bound to ctx, so cancelling ctx stops the collection.
+func NewAccessor(ctx context.Context, cfg Config) (*Accessor, error) {
+	if cfg.CommandTimeout <= 0 {
+		cfg.CommandTimeout = DefaultCommandTimeout
+	}
 	awscfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load SDK config, %w", err)
@@ -60,6 +80,7 @@ func NewAccessor(cfg Config) (*Accessor, error) {
 	return &Accessor{
 		cfg:    cfg,
 		imds:   imds.NewFromConfig(awscfg),
+		ctx:    ctx,
 		logger: zap.New().WithName("log-collector"),
 	}, nil
 }
@@ -111,8 +132,41 @@ const (
 	CommandOptionsNoStderr
 )
 
-func (a *Accessor) Command(name string, arg ...string) *exec.Cmd {
-	return osext.NewExec(a.cfg.Root).Command(name, arg...)
+// Output runs a command bounded by the configured CommandTimeout and returns its
+// standard output.
+func (a *Accessor) Output(args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("no command given")
+	}
+	return osext.Output(a.ctx, a.cfg.CommandTimeout, a.newCommand(nil, args))
+}
+
+// CombinedOutput runs a command bounded by the configured CommandTimeout and
+// returns its standard output and standard error.
+func (a *Accessor) CombinedOutput(args ...string) ([]byte, error) {
+	return a.CombinedOutputEnv(nil, args...)
+}
+
+// CombinedOutputEnv is CombinedOutput with an explicit child environment, which
+// a command needs when it must not inherit part of the agent's environment.
+func (a *Accessor) CombinedOutputEnv(env []string, args ...string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("no command given")
+	}
+	return osext.CombinedOutput(a.ctx, a.cfg.CommandTimeout, a.newCommand(env, args))
+}
+
+// newCommand builds the command under the configured root. Commands are always
+// bound to a context: a collector that blocks forever leaves the whole capture
+// stuck in Running, with no error for the caller to report.
+func (a *Accessor) newCommand(env []string, args []string) osext.CommandFunc {
+	return func(ctx context.Context) *exec.Cmd {
+		cmd := osext.NewExec(a.cfg.Root).CommandContext(ctx, args[0], args[1:]...)
+		if env != nil {
+			cmd.Env = env
+		}
+		return cmd
+	}
 }
 
 func (a *Accessor) CommandOutput(args []string, destination string, opts CommandOptions) error {
@@ -120,28 +174,31 @@ func (a *Accessor) CommandOutput(args []string, destination string, opts Command
 		output []byte
 		err    error
 	)
-	command := a.Command(args[0], args[1:]...)
 	if opts.is(CommandOptionsNoStderr) {
-		output, err = command.Output()
+		output, err = a.Output(args...)
 	} else {
-		output, err = command.CombinedOutput()
+		output, err = a.CombinedOutput(args...)
 	}
 	if err != nil {
 		if opts.is(CommandOptionsIgnoreFailure) {
 			a.logger.Info("ignoring command failure", "args", args, "output", string(output), "error", err)
 			return nil
 		}
-		msgs := []string{err.Error()}
+		// the command's own output is detail rather than part of the error chain,
+		// while err itself is wrapped, so that a caller can still tell a timeout
+		// apart from a command that ran and failed.
+		var details []string
 		if len(output) > 0 {
-			msgs = append(msgs, string(output))
+			details = append(details, strings.TrimSpace(string(output)))
 		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			msgs = append(msgs, string(exitErr.Stderr))
+			details = append(details, strings.TrimSpace(string(exitErr.Stderr)))
 		}
-		for i := range msgs {
-			msgs[i] = strings.TrimSpace(msgs[i])
+		wrapped := fmt.Errorf("executing command %q: %w", strings.Join(args, " "), err)
+		if len(details) > 0 {
+			wrapped = fmt.Errorf("%w: %s", wrapped, strings.Join(details, ": "))
 		}
-		return fmt.Errorf("executing command %q: %s", strings.Join(args, " "), strings.Join(msgs, ": "))
+		return wrapped
 	}
 	if opts.is(CommandOptionsAppend) {
 		return a.appendOutput(destination, output)

--- a/pkg/log_collector/collect/accessor.go
+++ b/pkg/log_collector/collect/accessor.go
@@ -206,20 +206,42 @@ func (a *Accessor) CommandOutput(args []string, destination string, opts Command
 	return a.WriteOutput(destination, output)
 }
 
+// CopyFile copies a host file into the capture directory, bounded by the
+// accessor context.
+//
+// The bound is cooperative: the open and each read are ordinary blocking
+// syscalls, so a source on an unresponsive mount can still block inside one of
+// them. What the context buys is that the copy stops at the first read boundary
+// after cancellation instead of running to completion, and that a large file
+// does not outlive the capture it belongs to. The caller
+// (nodeDiagnosticController.collectLogsBounded) is what bounds a copy already
+// stuck in a syscall, by abandoning the collection goroutine.
 func (a *Accessor) CopyFile(src string, dst string) error {
+	if err := a.ctx.Err(); err != nil {
+		return fmt.Errorf("copying %q, %w", src, err)
+	}
 	dstFilename, err := a.constructDestFile(dst)
 	if err != nil {
 		return fmt.Errorf("constructing destination file, %w", err)
 	}
-	return copyFileRaw(src, dstFilename)
+	return copyFileRaw(a.ctx, src, dstFilename)
 }
 
+// CopyDir copies a host directory tree into the capture directory, bounded by
+// the accessor context. See CopyFile for what the bound does and does not cover.
+//
+// The context is checked before each directory is read and before each entry, as
+// well as per read, so a cancelled capture stops descending promptly rather than
+// visiting every remaining entry first.
 func (a *Accessor) CopyDir(src string, dst string) error {
+	if err := a.ctx.Err(); err != nil {
+		return fmt.Errorf("copying %q, %w", src, err)
+	}
 	dstDirName, err := a.constructDestFile(dst)
 	if err != nil {
 		return fmt.Errorf("constructing destination directory, %w", err)
 	}
-	return copyRecursive(src, dstDirName)
+	return copyRecursive(a.ctx, src, dstDirName)
 }
 
 func (a *Accessor) constructDestFile(filename string) (string, error) {
@@ -233,7 +255,14 @@ func (a *Accessor) constructDestFile(filename string) (string, error) {
 	return destFile, nil
 }
 
-func copyRecursive(srcDir string, dstDir string) error {
+func copyRecursive(ctx context.Context, srcDir string, dstDir string) error {
+	// checked before MkdirAll and ReadDir, not just per entry: ReadDir is itself a
+	// call that blocks on an unresponsive mount, and creating the destination
+	// first would leave an empty directory behind that reads as a genuinely empty
+	// log directory in the bundle.
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("copying %q, %w", srcDir, err)
+	}
 	err := os.MkdirAll(dstDir, 0o755)
 	if err != nil {
 		return fmt.Errorf("creating destination directory, %w", err)
@@ -244,16 +273,21 @@ func copyRecursive(srcDir string, dstDir string) error {
 	}
 
 	for _, ent := range entries {
+		// re-checked per entry so a cancellation mid-walk stops here rather than
+		// visiting every remaining entry first.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("copying %q, %w", srcDir, err)
+		}
 		srcPath := filepath.Join(srcDir, ent.Name())
 		dstPath := filepath.Join(dstDir, ent.Name())
 		if st, err := os.Stat(srcPath); err != nil {
 			return fmt.Errorf("stating %q, %w", srcPath, err)
 		} else if st.IsDir() {
-			if err := copyRecursive(srcPath, dstPath); err != nil {
+			if err := copyRecursive(ctx, srcPath, dstPath); err != nil {
 				return err
 			}
 		} else {
-			if err := copyFileRaw(srcPath, dstPath); err != nil {
+			if err := copyFileRaw(ctx, srcPath, dstPath); err != nil {
 				return err
 			}
 		}
@@ -261,7 +295,7 @@ func copyRecursive(srcDir string, dstDir string) error {
 	return nil
 }
 
-func copyFileRaw(srcFilename string, dstFilename string) error {
+func copyFileRaw(ctx context.Context, srcFilename string, dstFilename string) error {
 	srcFile, err := os.Open(srcFilename)
 	if err != nil {
 		return fmt.Errorf("opening source file, %w", err)
@@ -274,9 +308,27 @@ func copyFileRaw(srcFilename string, dstFilename string) error {
 	}
 	defer dstFile.Close()
 
-	_, err = io.Copy(dstFile, srcFile)
+	// io.Copy over a context aware reader: the check lands between reads, so a
+	// cancelled capture stops at the next chunk boundary instead of copying a
+	// large file to the end. A read already blocked in the kernel is not
+	// interrupted by this.
+	_, err = io.Copy(dstFile, &ctxReader{ctx: ctx, r: srcFile})
 	if err != nil {
 		return fmt.Errorf("copying %q to %q, %w", srcFile.Name(), dstFile.Name(), err)
 	}
 	return nil
+}
+
+// ctxReader fails a read once its context is done, so that an io.Copy of a large
+// or slow source stops at a chunk boundary after cancellation.
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *ctxReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
 }

--- a/pkg/log_collector/collect/accessor_test.go
+++ b/pkg/log_collector/collect/accessor_test.go
@@ -1,13 +1,20 @@
 package collect_test
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aws/eks-node-monitoring-agent/pkg/log_collector/collect"
+	"github.com/aws/eks-node-monitoring-agent/pkg/osext"
 )
 
 func TestLogCollectorAccessor(t *testing.T) {
-	accessor, err := collect.NewAccessor(collect.Config{
+	accessor, err := collect.NewAccessor(context.Background(), collect.Config{
 		Root:        "/",
 		Destination: t.TempDir(),
 	})
@@ -39,4 +46,68 @@ func TestLogCollectorAccessor(t *testing.T) {
 		// them for unit test coverage because they are non-destructive.
 		c.Collect(accessor)
 	}
+}
+
+// Regression test for issue #219: a collector command that blocks must fail with
+// a timeout so that the existing per collector error handling can report it,
+// instead of hanging the whole capture with no error to report.
+func TestAccessorCommandTimeout(t *testing.T) {
+	acc, err := collect.NewAccessor(context.Background(), collect.Config{
+		Root:           "/",
+		Destination:    t.TempDir(),
+		CommandTimeout: 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	t.Run("CombinedOutput", func(t *testing.T) {
+		start := time.Now()
+		_, err := acc.CombinedOutput("sleep", "30")
+
+		require.ErrorIs(t, err, osext.ErrTimeout)
+		assert.Less(t, time.Since(start), 5*time.Second, "must return at the deadline")
+	})
+
+	t.Run("Output", func(t *testing.T) {
+		_, err := acc.Output("sleep", "30")
+		require.ErrorIs(t, err, osext.ErrTimeout)
+	})
+
+	// CommandOutput is what the collectors use, and its error is what ends up in
+	// log-capture-errors.log and in the failed task count.
+	t.Run("CommandOutput", func(t *testing.T) {
+		err := acc.CommandOutput([]string{"sleep", "30"}, "slow.txt", collect.CommandOptionsNone)
+		require.Error(t, err)
+		// the message is what lands in log-capture-errors.log, and the wrapped
+		// error is what lets a caller tell a timeout from a failed command.
+		assert.Contains(t, err.Error(), "executing command \"sleep 30\"")
+		assert.Contains(t, err.Error(), "timed out")
+		assert.ErrorIs(t, err, osext.ErrTimeout)
+	})
+
+	t.Run("IgnoredFailureStillReturnsNil", func(t *testing.T) {
+		err := acc.CommandOutput([]string{"sleep", "30"}, "slow.txt", collect.CommandOptionsIgnoreFailure)
+		assert.NoError(t, err)
+	})
+}
+
+func TestAccessorCommandTimeoutDefault(t *testing.T) {
+	dst := t.TempDir()
+	acc, err := collect.NewAccessor(context.Background(), collect.Config{Root: "/", Destination: dst})
+	require.NoError(t, err)
+
+	// a command well within the default bound still succeeds.
+	require.NoError(t, acc.CommandOutput([]string{"echo", "hello"}, "echo.txt", collect.CommandOptionsNone))
+	assert.FileExists(t, filepath.Join(dst, "echo.txt"))
+}
+
+// Cancelling the collection context stops in-flight commands, which is what lets
+// the controller give up on a capture.
+func TestAccessorContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	acc, err := collect.NewAccessor(ctx, collect.Config{Root: "/", Destination: t.TempDir()})
+	require.NoError(t, err)
+	cancel()
+
+	_, err = acc.CombinedOutput("sleep", "30")
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/pkg/log_collector/collect/accessor_test.go
+++ b/pkg/log_collector/collect/accessor_test.go
@@ -2,6 +2,7 @@ package collect_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -110,4 +111,105 @@ func TestAccessorContextCancellation(t *testing.T) {
 
 	_, err = acc.CombinedOutput("sleep", "30")
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestAccessorCopyFileCancelled(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "source.log")
+	require.NoError(t, os.WriteFile(src, []byte("contents"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dest := t.TempDir()
+	acc, err := collect.NewAccessor(ctx, collect.Config{Root: "/", Destination: dest})
+	require.NoError(t, err)
+	cancel()
+
+	err = acc.CopyFile(src, "copied.log")
+	require.ErrorIs(t, err, context.Canceled)
+	assert.NoFileExists(t, filepath.Join(dest, "copied.log"),
+		"a cancelled copy must not leave a destination file behind")
+}
+
+func TestAccessorCopyDirCancelled(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.log"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "b.log"), []byte("b"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	acc, err := collect.NewAccessor(ctx, collect.Config{Root: "/", Destination: t.TempDir()})
+	require.NoError(t, err)
+	cancel()
+
+	err = acc.CopyDir(srcDir, "copied")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestAccessorCopyFileSucceedsWhenLive(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "source.log")
+	require.NoError(t, os.WriteFile(src, []byte("contents"), 0o644))
+
+	dest := t.TempDir()
+	acc, err := collect.NewAccessor(context.Background(), collect.Config{Root: "/", Destination: dest})
+	require.NoError(t, err)
+
+	require.NoError(t, acc.CopyFile(src, "copied.log"))
+	body, err := os.ReadFile(filepath.Join(dest, "copied.log"))
+	require.NoError(t, err)
+	assert.Equal(t, "contents", string(body), "bounding the copy must not change what it copies")
+}
+
+func TestAccessorCopyDirSucceedsWhenLive(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.log"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "nested", "b.log"), []byte("b"), 0o644))
+
+	dest := t.TempDir()
+	acc, err := collect.NewAccessor(context.Background(), collect.Config{Root: "/", Destination: dest})
+	require.NoError(t, err)
+
+	require.NoError(t, acc.CopyDir(srcDir, "copied"))
+	for path, want := range map[string]string{
+		filepath.Join(dest, "copied", "a.log"):           "a",
+		filepath.Join(dest, "copied", "nested", "b.log"): "b",
+	} {
+		body, err := os.ReadFile(path)
+		require.NoErrorf(t, err, "expected %s to be copied", path)
+		assert.Equal(t, want, string(body))
+	}
+}
+
+// A copy cancelled mid-stream stops at a read boundary rather than running to the
+// end of a large source. Cancellation is driven from the source itself so the
+// assertions always run: a time based cancel would let a fast machine finish the
+// copy first and pass without testing anything.
+func TestAccessorCopyFileCancelledMidStream(t *testing.T) {
+	const size = 4 << 20 // several io.Copy chunks
+	src := filepath.Join(t.TempDir(), "big.log")
+	require.NoError(t, os.WriteFile(src, make([]byte, size), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dest := t.TempDir()
+	acc, err := collect.NewAccessor(ctx, collect.Config{Root: "/", Destination: dest})
+	require.NoError(t, err)
+
+	// cancel once the copy is demonstrably under way, using the destination file
+	// as the signal so this cannot race the copy to completion.
+	go func() {
+		for {
+			if info, err := os.Stat(filepath.Join(dest, "big.log")); err == nil && info.Size() > 0 {
+				cancel()
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	err = acc.CopyFile(src, "big.log")
+	require.ErrorIs(t, err, context.Canceled, "a cancelled copy must report cancellation")
+
+	info, statErr := os.Stat(filepath.Join(dest, "big.log"))
+	require.NoError(t, statErr)
+	assert.Less(t, info.Size(), int64(size),
+		"a cancelled copy must stop before writing the whole source")
 }

--- a/pkg/log_collector/collect/cni.go
+++ b/pkg/log_collector/collect/cni.go
@@ -22,7 +22,7 @@ func cniConfig(acc *Accessor) error {
 }
 
 func cniVariables(acc *Accessor) error {
-	listOutput, err := acc.Command("ctr", "--namespace", "k8s.io", "container", "list").CombinedOutput()
+	listOutput, err := acc.CombinedOutput("ctr", "--namespace", "k8s.io", "container", "list")
 	if err != nil {
 		return nil
 	}

--- a/pkg/log_collector/collect/iptables.go
+++ b/pkg/log_collector/collect/iptables.go
@@ -30,7 +30,7 @@ func (i IPTables) Collect(acc *Accessor) error {
 }
 
 func (i IPTables) collectRules(acc *Accessor, cmd []string, filename string) error {
-	output, err := acc.Command(cmd[0], cmd[1:]...).CombinedOutput()
+	output, err := acc.CombinedOutput(cmd...)
 	if err != nil {
 		return fmt.Errorf("error running %q, %w", cmd, err)
 	}

--- a/pkg/log_collector/collect/networking.go
+++ b/pkg/log_collector/collect/networking.go
@@ -69,7 +69,7 @@ func interfaces(acc *Accessor) error {
 	}
 	var merr error
 	for _, netInterface := range netInterfaces {
-		output, err := acc.Command("ethtool", "-S", netInterface.Name).CombinedOutput()
+		output, err := acc.CombinedOutput("ethtool", "-S", netInterface.Name)
 		// we can still use the output of ethtool if there is an error.
 		if err != nil && len(output) == 0 {
 			merr = errors.Join(merr, err)

--- a/pkg/log_collector/collect/nftables.go
+++ b/pkg/log_collector/collect/nftables.go
@@ -41,7 +41,7 @@ type nftable struct {
 }
 
 func (n NFTables) listTables(acc *Accessor) ([]nftable, error) {
-	output, err := acc.Command("nft", "list", "tables").CombinedOutput()
+	output, err := acc.CombinedOutput("nft", "list", "tables")
 	if err != nil {
 		return nil, fmt.Errorf("error running 'nft list tables': %w", err)
 	}
@@ -68,13 +68,12 @@ func (n NFTables) listTables(acc *Accessor) ([]nftable, error) {
 
 func (n NFTables) isNftAvailable(acc *Accessor) bool {
 	// Try to run 'nft --version' to check if binary exists and is functional
-	cmd := acc.Command("nft", "--version")
-	err := cmd.Run()
+	_, err := acc.CombinedOutput("nft", "--version")
 	return err == nil
 }
 
 func (n NFTables) collectRules(acc *Accessor, cmd []string, filename string) error {
-	output, err := acc.Command(cmd[0], cmd[1:]...).CombinedOutput()
+	output, err := acc.CombinedOutput(cmd...)
 	if err != nil {
 		return fmt.Errorf("error running %q, %w", cmd, err)
 	}

--- a/pkg/log_collector/collect/pressure_test.go
+++ b/pkg/log_collector/collect/pressure_test.go
@@ -1,6 +1,7 @@
 package collect_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +78,7 @@ func TestPressureCollect(t *testing.T) {
 				}
 			}
 
-			acc, err := collect.NewAccessor(collect.Config{
+			acc, err := collect.NewAccessor(context.Background(), collect.Config{
 				Root:        root,
 				Destination: dst,
 			})

--- a/pkg/log_collector/collect/throttles.go
+++ b/pkg/log_collector/collect/throttles.go
@@ -81,7 +81,7 @@ func cpuThrottles(acc *Accessor) error {
 		return errors.Join(merr, err)
 	}
 
-	psOut, err := acc.Command("ps", "ax").CombinedOutput()
+	psOut, err := acc.CombinedOutput("ps", "ax")
 	if err != nil {
 		return errors.Join(merr, err)
 	}

--- a/pkg/osext/exec.go
+++ b/pkg/osext/exec.go
@@ -1,6 +1,7 @@
 package osext
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -23,7 +24,24 @@ type execExt struct {
 }
 
 func (a *execExt) Command(name string, arg ...string) *exec.Cmd {
-	proc := exec.Command(name, arg...)
+	return a.resolve(exec.Command(name, arg...), name)
+}
+
+// CommandContext is Command with the process bound to ctx, so the child is
+// signalled when ctx is cancelled or its deadline passes.
+//
+// Binding the context is necessary but not sufficient for bounding execution: a
+// process wedged in uninterruptible sleep (state D, e.g. 'df' on an unresponsive
+// NFS/EFS mount) never receives the signal, so Wait on the returned command can
+// still block forever. Callers that must make progress regardless should use
+// Output or CombinedOutput rather than waiting on the command themselves.
+func (a *execExt) CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	return a.resolve(exec.CommandContext(ctx, name, arg...), name)
+}
+
+// resolve applies the host root to a command, so that the executable is looked
+// up on the host filesystem and the process is chrooted into it.
+func (a *execExt) resolve(proc *exec.Cmd, name string) *exec.Cmd {
 	if a.root != "/" {
 		if errors.Is(proc.Err, exec.ErrNotFound) {
 			// if the binary could not be discovered using exec.LookPath then

--- a/pkg/osext/run.go
+++ b/pkg/osext/run.go
@@ -1,0 +1,110 @@
+package osext
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// ErrTimeout is returned when a command does not complete within its timeout.
+// Callers can use errors.Is to distinguish a bounded run that gave up from a
+// command that ran and failed.
+var ErrTimeout = errors.New("timed out")
+
+// waitDelay bounds how long os/exec waits for the child's I/O pipes to close
+// after the context is cancelled. Without it, a killed process whose stdout is
+// held open by a grandchild keeps the collecting goroutine alive indefinitely.
+const waitDelay = 5 * time.Second
+
+// CommandFunc builds the command to run. Implementations must construct the
+// command from the context they are handed (exec.CommandContext or
+// execExt.CommandContext) so that cancellation reaches the child process.
+type CommandFunc func(context.Context) *exec.Cmd
+
+// Output runs a command bounded by timeout and returns its standard output.
+func Output(ctx context.Context, timeout time.Duration, newCmd CommandFunc) ([]byte, error) {
+	return run(ctx, timeout, newCmd, false)
+}
+
+// CombinedOutput runs a command bounded by timeout and returns its standard
+// output and standard error interleaved.
+func CombinedOutput(ctx context.Context, timeout time.Duration, newCmd CommandFunc) ([]byte, error) {
+	return run(ctx, timeout, newCmd, true)
+}
+
+// run executes the command and returns once it completes, the timeout elapses,
+// or ctx is cancelled — whichever happens first.
+//
+// The command is collected on its own goroutine, which is abandoned rather than
+// waited on when the bound is hit. That is deliberate: binding the context
+// signals the child, but a process in uninterruptible sleep never dies, and
+// cmd.Wait cannot return until it does. Waiting for the goroutine here would
+// reintroduce exactly the unbounded block this function exists to prevent.
+//
+// An abandoned goroutine holds its command and output buffer until the child
+// finally exits, if it ever does. Callers that run the same command repeatedly
+// should therefore avoid launching a fresh copy while a previous one is still
+// outstanding.
+func run(ctx context.Context, timeout time.Duration, newCmd CommandFunc, combined bool) ([]byte, error) {
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := newCmd(runCtx)
+	cmd.WaitDelay = waitDelay
+
+	type result struct {
+		output []byte
+		err    error
+	}
+	// Buffered so the goroutine can always publish its result and exit, even
+	// when nobody is left to receive it.
+	done := make(chan result, 1)
+	go func() {
+		var r result
+		if combined {
+			r.output, r.err = cmd.CombinedOutput()
+		} else {
+			r.output, r.err = cmd.Output()
+		}
+		done <- r
+	}()
+
+	select {
+	case r := <-done:
+		return r.output, r.err
+	case <-runCtx.Done():
+		// Report the parent's error when it is the parent that ended, so that
+		// shutdown is not reported as a command timeout.
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("running %q: %w", commandName(cmd), err)
+		}
+		return nil, fmt.Errorf("running %q: %w after %s", commandName(cmd), ErrTimeout, timeout)
+	}
+}
+
+// commandName is a short identifier for a command, for use in error messages.
+func commandName(cmd *exec.Cmd) string {
+	if len(cmd.Args) > 0 {
+		return cmd.Args[0]
+	}
+	return filepath.Base(cmd.Path)
+}
+
+// Output runs name with the given arguments under the configured host root,
+// bounded by timeout, and returns its standard output.
+func (a *execExt) Output(ctx context.Context, timeout time.Duration, name string, arg ...string) ([]byte, error) {
+	return Output(ctx, timeout, func(ctx context.Context) *exec.Cmd {
+		return a.CommandContext(ctx, name, arg...)
+	})
+}
+
+// CombinedOutput runs name with the given arguments under the configured host
+// root, bounded by timeout, and returns its output and standard error.
+func (a *execExt) CombinedOutput(ctx context.Context, timeout time.Duration, name string, arg ...string) ([]byte, error) {
+	return CombinedOutput(ctx, timeout, func(ctx context.Context) *exec.Cmd {
+		return a.CommandContext(ctx, name, arg...)
+	})
+}

--- a/pkg/osext/run_test.go
+++ b/pkg/osext/run_test.go
@@ -1,0 +1,89 @@
+package osext_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/eks-node-monitoring-agent/pkg/osext"
+)
+
+func TestOutput(t *testing.T) {
+	t.Run("ReturnsStdout", func(t *testing.T) {
+		out, err := osext.NewExec("/").Output(context.Background(), time.Minute, "echo", "hello")
+		require.NoError(t, err)
+		assert.Equal(t, "hello\n", string(out))
+	})
+
+	t.Run("ReturnsCommandError", func(t *testing.T) {
+		_, err := osext.NewExec("/").Output(context.Background(), time.Minute, "false")
+		require.Error(t, err)
+		// a command that ran and failed is not a timeout.
+		assert.NotErrorIs(t, err, osext.ErrTimeout)
+	})
+
+	// a command that outlives its bound must release the caller, and must do so
+	// at the deadline rather than when the command eventually finishes.
+	t.Run("TimeoutReleasesCaller", func(t *testing.T) {
+		start := time.Now()
+		_, err := osext.NewExec("/").Output(context.Background(), 100*time.Millisecond, "sleep", "30")
+		elapsed := time.Since(start)
+
+		require.ErrorIs(t, err, osext.ErrTimeout)
+		assert.Contains(t, err.Error(), "sleep")
+		assert.Less(t, elapsed, 5*time.Second, "must return at the deadline, not on command completion")
+	})
+
+	// a cancelled parent is reported as cancellation, not as a command timeout,
+	// so that shutdown is distinguishable from a wedged collector.
+	t.Run("ParentCancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := osext.NewExec("/").Output(ctx, time.Minute, "sleep", "30")
+		require.ErrorIs(t, err, context.Canceled)
+		assert.NotErrorIs(t, err, osext.ErrTimeout)
+	})
+}
+
+func TestCombinedOutput(t *testing.T) {
+	t.Run("IncludesStderr", func(t *testing.T) {
+		out, err := osext.NewExec("/").CombinedOutput(context.Background(), time.Minute, "sh", "-c", "echo out; echo err >&2")
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "out")
+		assert.Contains(t, string(out), "err")
+	})
+
+	t.Run("TimeoutReleasesCaller", func(t *testing.T) {
+		start := time.Now()
+		_, err := osext.NewExec("/").CombinedOutput(context.Background(), 100*time.Millisecond, "sleep", "30")
+
+		require.ErrorIs(t, err, osext.ErrTimeout)
+		assert.Less(t, time.Since(start), 5*time.Second)
+	})
+}
+
+// the package level helpers give the caller control of the whole command, which
+// collectors need in order to set a custom environment.
+func TestCommandFuncHelpers(t *testing.T) {
+	t.Run("Output", func(t *testing.T) {
+		out, err := osext.Output(context.Background(), time.Minute, func(ctx context.Context) *exec.Cmd {
+			cmd := exec.CommandContext(ctx, "sh", "-c", "echo $NMA_TEST_VAR")
+			cmd.Env = append(cmd.Environ(), "NMA_TEST_VAR=set")
+			return cmd
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "set\n", string(out))
+	})
+
+	t.Run("Timeout", func(t *testing.T) {
+		_, err := osext.CombinedOutput(context.Background(), 100*time.Millisecond, func(ctx context.Context) *exec.Cmd {
+			return exec.CommandContext(ctx, "sleep", "30")
+		})
+		require.ErrorIs(t, err, osext.ErrTimeout)
+	})
+}

--- a/pkg/util/networkutils/common.go
+++ b/pkg/util/networkutils/common.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -19,20 +18,21 @@ type NetworkctlOutput struct {
 	Interfaces []NetworkInterface `json:"Interfaces"`
 }
 
+// Commander runs a command with an enforced execution bound and returns its
+// combined output. A non-nil env replaces the child environment.
+//
+// The bound is the implementation's responsibility: networkctl talks to
+// systemd-networkd over dbus and can block indefinitely rather than fail, which
+// would otherwise stall the caller for the life of the process.
 type Commander interface {
-	Command(string, ...string) *exec.Cmd
+	CombinedOutputEnv(env []string, args ...string) ([]byte, error)
 }
 
 // GetNetworkInterfaces runs networkctl and returns parsed network interfaces
-// The exec parameter can be any type that implements Command method (osext.Exec or Accessor)
-func GetNetworkInterfaces(exec Commander) ([]NetworkInterface, error) {
-	var output []byte
-	var err error
-
+func GetNetworkInterfaces(cmder Commander) ([]NetworkInterface, error) {
 	// Temporarily unset DBUS_SYSTEM_BUS_ADDRESS to avoid issues with networkctl
-	originalDBusAddr := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
-	envWithoutDbus := os.Environ()
-	if originalDBusAddr != "" {
+	var envWithoutDbus []string
+	if os.Getenv("DBUS_SYSTEM_BUS_ADDRESS") != "" {
 		envWithoutDbus = make([]string, 0, len(os.Environ()))
 		for _, e := range os.Environ() {
 			if !strings.HasPrefix(e, "DBUS_SYSTEM_BUS_ADDRESS=") {
@@ -41,16 +41,7 @@ func GetNetworkInterfaces(exec Commander) ([]NetworkInterface, error) {
 		}
 	}
 
-	// Create command using the provided Commander interface
-	cmd := exec.Command("networkctl", "--json=short")
-
-	// Set environment if DBUS_SYSTEM_BUS_ADDRESS is present
-	if originalDBusAddr != "" {
-		cmd.Env = envWithoutDbus
-	}
-
-	output, err = cmd.CombinedOutput()
-
+	output, err := cmder.CombinedOutputEnv(envWithoutDbus, "networkctl", "--json=short")
 	if err != nil {
 		return nil, fmt.Errorf("networkctl command failed: %w", err)
 	}


### PR DESCRIPTION
**Issue #, if available**: Fixes #219

**Description of changes**:

Collectors in both affected paths now run under an execution bound. `exec.CommandContext` alone is not enough: a process in uninterruptible sleep never receives the kill that cancellation sends, so `cmd.Wait` cannot return. Each bound therefore releases its caller and abandons what it cannot interrupt.

- **`pkg/osext`** — adds `CommandContext` for chrooted commands, plus `Output`/`CombinedOutput` bounded by a timeout, returning `ErrTimeout`. `Command` is unchanged, so the monitors are unaffected.
- **`pkg/diagnostic`** — producers take a context and each runs isolated under a 30s bound, so a stuck collector costs its own section (`collector "disk" timed out after 30s`) instead of every later one. A producer whose previous run is still outstanding is skipped rather than started again, so a command that cannot be killed is not respawned every cycle for the life of the node.
- **`cmd/.../main.go`** — the deferred flush on exit called `Start`, which emitted one cycle and then blocked on its ticker forever, so a crashing agent never exited. It now calls a new `RunOnce` under a 30s bound.
- **`pkg/log_collector` + `pkg/controllers`** — the `Accessor` carries the collection context and a 60s `CommandTimeout`, replacing the direct `exec` calls in `CommandOutput` and in the six collectors that ran commands themselves. A stuck command now returns an error, which is what the existing per-collector isolation needs to do its job: the capture continues and names the failure in `log-capture-errors.log` and `subTasksFailed`. `LogCaptureTimeout` (20m) backstops a collector that blocks outside a subprocess, so `CaptureState` completes as a failure naming the timeout instead of staying `Running`.

Timeouts are set well above what these commands legitimately need, so hitting one means the command is stuck rather than slow.

**Testing Done**:

New unit tests cover each bound: a blocked collector no longer stops the console cycle and is not restarted while outstanding, a healthy collector still runs every cycle, shutdown is reported as shutdown rather than as a timeout, `CommandOutput` fails with `ErrTimeout` instead of hanging (and `IgnoreFailure` still tolerates it), and a blocked capture completes as `Failure` naming the timeout.

`make test` and `go test ./pkg/... -race -count=1` are green on Linux/amd64 with Go 1.26.4, including `helm lint`.

Not covered by unit tests: no test creates a genuinely unkillable process, since that needs a real unresponsive NFS/EFS mount. What the tests prove is that the caller is released at the deadline; the uninterruptible-sleep case rests on abandoning the goroutine rather than waiting on it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
