### PR TITLE
fix: close the apiserver response body and reuse one client

### DIFF
--- a/pkg/diagnostic/logger.go
+++ b/pkg/diagnostic/logger.go
@@ -224,22 +224,33 @@ func readFileTail(path string, n int64) []byte {
 	return buf
 }
 
-func testAPIServerEndpoint(host string) []byte {
-	client := &http.Client{
-		Timeout: 5 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				// Skipping TLS verification is ok as we are just validating the
-				// connectivity to the API server
-				InsecureSkipVerify: true,
-			},
+// apiServerClient is built once and reused for every check. A client and
+// transport per call would give each check its own connection pool, so every
+// cycle would pay a fresh TCP connect and TLS handshake for the life of the node.
+var apiServerClient = &http.Client{
+	Timeout: 5 * time.Second,
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{
+			// Skipping TLS verification is ok as we are just validating the
+			// connectivity to the API server
+			InsecureSkipVerify: true,
 		},
-	}
+		// A hand-built transport leaves this at zero, which means no limit, so
+		// idle connections would only ever be reclaimed by the peer closing them.
+		// Matches http.DefaultTransport and the API server's own idle timeout.
+		IdleConnTimeout: 90 * time.Second,
+	},
+}
+
+func testAPIServerEndpoint(host string) []byte {
 	url := fmt.Sprintf("%s/livez?verbose", host)
-	r, err := client.Get(url)
+	r, err := apiServerClient.Get(url)
 	if err != nil {
 		return []byte(fmt.Sprintf("failed to make request endpoint due to: %s\n", err))
 	}
+	// the body must be closed for the connection to be released, whether or not
+	// it is read successfully below.
+	defer r.Body.Close()
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return []byte(fmt.Sprintf("failed to read response body due to: %s\n", err))

--- a/pkg/diagnostic/logger_test.go
+++ b/pkg/diagnostic/logger_test.go
@@ -4,8 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +33,41 @@ func Test_ContextStopsLogger(t *testing.T) {
 	if buffer.Len() == 0 {
 		t.Errorf("should have written diagnostic to logger")
 	}
+}
+
+// Regression test for issue #221: the client is reused across checks, so the
+// agent does not open a new connection and repeat the TLS handshake every cycle.
+// Reuse is only possible if the response body is released, so this covers the
+// missing Close as well.
+func TestAPIServerEndpointReusesConnection(t *testing.T) {
+	var newConnections atomic.Int32
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/livez", r.URL.Path)
+		assert.Equal(t, "verbose", r.URL.RawQuery)
+		fmt.Fprint(w, "livez check passed")
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	for i := 0; i < 3; i++ {
+		body := testAPIServerEndpoint(server.URL)
+		require.Equal(t, "livez check passed", string(body), "call %d", i+1)
+	}
+
+	assert.Equal(t, int32(1), newConnections.Load(),
+		"the checks should share one connection; a client per call opens one each")
+}
+
+func TestAPIServerEndpointUnreachable(t *testing.T) {
+	// port 1 is not listening, so this exercises the path where there is no
+	// response and therefore no body to close.
+	body := testAPIServerEndpoint("https://127.0.0.1:1")
+	assert.Contains(t, string(body), "failed to make request endpoint")
 }
 
 func TestUtils(t *testing.T) {


### PR DESCRIPTION
**Issue #, if available**: Fixes #221

**Description of changes**:

The apiserver console-diagnostics check built an `http.Client` and `http.Transport` per call and never closed the response body. Each check therefore had its own connection pool, so every cycle paid a fresh TCP connect and TLS handshake, and the connection was left for the peer to close — a hand-built transport leaves `IdleConnTimeout` at zero, meaning no limit, so nothing client-side would ever reclaim it. Today the API server's own 90s idle timeout is what does.

- The client is built once at package level and reused.
- `IdleConnTimeout` is set to 90s, matching `http.DefaultTransport` and the API server's own idle timeout, so the client no longer depends on the peer to reap idle connections.
- The body is closed with a `defer`, so it is released whether or not the read succeeds.

The check runs once per `LogInterval` (5 minutes by default) for the life of a node with console diagnostics enabled, which is always the case on EKS Auto Mode.

**Testing Done**:

Added a test that serves the check from an `httptest` TLS server and counts new connections via `ConnState`: three sequential checks now share one connection, where before they opened three. Verified it fails without the production change (`expected: 1, actual: 3`), so it covers both the client reuse and the missing `Close` — reuse is impossible unless the body is released. A second test covers the no-response path, where there is no body to close.

`go test ./pkg/diagnostic/ -race` is green.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
