### PR TITLE
fix(kernel): do not report intentional int3 traps as AppCrash

### DIFF
--- a/monitors/kernel/monitor.go
+++ b/monitors/kernel/monitor.go
@@ -89,6 +89,9 @@ var (
 		// dmesg timestamp prefix
 		`\s([^\s\[]+)\[\d+]: segfault at.*`,
 	}, "|"))
+	// int3 is a breakpoint trap that applications raise deliberately, for example via
+	// __builtin_trap() or Chromium's IMMEDIATE_CRASH(), so it does not indicate a node problem
+	intentionalTrap = regexp.MustCompile(`traps:.* trap int3\b`)
 )
 var (
 	appBlocked        = regexp.MustCompile(`task (.*?):\d+ blocked for more than`)
@@ -111,7 +114,7 @@ func (k *KernelMonitor) handleDmesg(line string) error {
 				Message("A kernel bug was detected and reported by the Linux kernel").
 				Build(),
 		)
-	} else if matches := appCrash.FindStringSubmatch(line); matches != nil {
+	} else if matches := appCrash.FindStringSubmatch(line); matches != nil && !intentionalTrap.MatchString(line) {
 		processName := appCrashProcessName(matches)
 		return k.manager.Notify(context.Background(),
 			reasons.AppCrash.

--- a/monitors/kernel/monitor.go
+++ b/monitors/kernel/monitor.go
@@ -83,15 +83,16 @@ var (
 	)
 	appCrash = regexp.MustCompile(strings.Join([]string{
 		// each top level group is expected to have one sub group capture for the
-		// process name, use appCrashProcessName to read whichever one matched
-		`traps:\s*(.*?)\[`,
+		// process name, use appCrashProcessName to read whichever one matched.
+		// the fault names are a bounded allowlist from arch/x86/kernel/traps.c. int3
+		// is left out because it is a breakpoint applications raise deliberately (for
+		// example Chromium's IMMEDIATE_CRASH()), not a node problem. divide error is
+		// printed with a "trap " prefix, the rest are not.
+		`traps:\s*(.*?)\[\d+] (?:trap )?(?:divide error|general protection fault|stack segment|segment not present|invalid TSS|alignment check|bounds)`,
 		// anchored on the bracketed pid so the capture cannot grow left into the
 		// dmesg timestamp prefix
 		`\s([^\s\[]+)\[\d+]: segfault at.*`,
 	}, "|"))
-	// int3 is a breakpoint trap that applications raise deliberately, for example via
-	// __builtin_trap() or Chromium's IMMEDIATE_CRASH(), so it does not indicate a node problem
-	intentionalTrap = regexp.MustCompile(`traps:.* trap int3\b`)
 )
 var (
 	appBlocked        = regexp.MustCompile(`task (.*?):\d+ blocked for more than`)
@@ -114,7 +115,7 @@ func (k *KernelMonitor) handleDmesg(line string) error {
 				Message("A kernel bug was detected and reported by the Linux kernel").
 				Build(),
 		)
-	} else if matches := appCrash.FindStringSubmatch(line); matches != nil && !intentionalTrap.MatchString(line) {
+	} else if matches := appCrash.FindStringSubmatch(line); matches != nil {
 		processName := appCrashProcessName(matches)
 		return k.manager.Notify(context.Background(),
 			reasons.AppCrash.

--- a/monitors/kernel/monitor_test.go
+++ b/monitors/kernel/monitor_test.go
@@ -158,6 +158,19 @@ func TestKernelMonitor(t *testing.T) {
 		}
 	})
 
+	t.Run("AppCrashIgnoresIntentionalTrap", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		mon := &KernelMonitor{}
+		mockManager := &mockManager{obs: newMockObserver(), res: make(chan monitor.Condition, 5)}
+		mon.Register(ctx, mockManager)
+		line := "[Wed Aug 12 19:49:58 2026] traps: chrome[1450999] trap int3 ip:5c6363ff7f04 sp:7fffb68653e0 error:0 in chrome[5c6361908000+c48d000]"
+		if err := mon.handleDmesg(line); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, 0, len(mockManager.res))
+	})
+
 	t.Run("SubscribeError", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()

--- a/monitors/kernel/monitor_test.go
+++ b/monitors/kernel/monitor_test.go
@@ -86,6 +86,7 @@ func TestKernelMonitor(t *testing.T) {
 		{"failed to create new OS thread (foo; errno=11)", "ForkFailedOutOfPIDs", resource.ResourceTypeJournal, "kubelet", monitor.SeverityFatal, ""},
 		{"[   32.298491][  T896] kexec[896]: segfault at 0 ip 0000000000000000 sp 00007ffeaf0ff420 error 14 in dash[561ac3c57000+4000]", "AppCrash", resource.ResourceTypeDmesg, "", monitor.SeverityWarning, `Process "kexec" on the node has crashed`},
 		{"[Wed Aug 12 19:49:58 2026] traps: chrome[1450999] trap divide error ip:5c6363ff7f04 sp:7fffb68653e0 error:0 in chrome[5c6361908000+c48d000]", "AppCrash", resource.ResourceTypeDmesg, "", monitor.SeverityWarning, `Process "chrome" on the node has crashed`},
+		{"[Wed Aug 12 19:49:58 2026] traps: app[1234] general protection fault ip:5c6363ff7f04 sp:7fffb68653e0 error:0 in app[5c6361908000+c48d000]", "AppCrash", resource.ResourceTypeDmesg, "", monitor.SeverityWarning, `Process "app" on the node has crashed`},
 		{"task foo:123 blocked for more than 20s", "AppBlocked", resource.ResourceTypeDmesg, "", monitor.SeverityWarning, ""},
 		{"nf_conntrack: nf_conntrack: table full, dropping packet", "ConntrackExceededKernel", resource.ResourceTypeDmesg, "", monitor.SeverityWarning, ""},
 	} {
@@ -165,6 +166,21 @@ func TestKernelMonitor(t *testing.T) {
 		mockManager := &mockManager{obs: newMockObserver(), res: make(chan monitor.Condition, 5)}
 		mon.Register(ctx, mockManager)
 		line := "[Wed Aug 12 19:49:58 2026] traps: chrome[1450999] trap int3 ip:5c6363ff7f04 sp:7fffb68653e0 error:0 in chrome[5c6361908000+c48d000]"
+		if err := mon.handleDmesg(line); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, 0, len(mockManager.res))
+	})
+
+	t.Run("AppCrashIgnoresInvalidOpcode", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		mon := &KernelMonitor{}
+		mockManager := &mockManager{obs: newMockObserver(), res: make(chan monitor.Condition, 5)}
+		mon.Register(ctx, mockManager)
+		// __builtin_trap() lowers to ud2 and prints "trap invalid opcode", which is a
+		// wrong-binary problem rather than a node problem, so it is not in the allowlist
+		line := "[Wed Aug 12 19:49:58 2026] traps: app[1234] trap invalid opcode ip:5c6363ff7f04 sp:7fffb68653e0 error:0 in app[5c6361908000+c48d000]"
 		if err := mon.handleDmesg(line); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Fixes the `int3` half of #223. Minimal on purpose: it does not touch the capture-group bug or the missing deduplication also described there.

## Problem

`appCrash` accepts any `traps:` line:

```go
appCrash = regexp.MustCompile(strings.Join([]string{
	`traps:\s*(.*?)\[`,
	`\s(.*?)\[\d+]: segfault at.*`,
}, "|"))
```

But `trap int3` is a breakpoint trap applications raise **deliberately** — `__builtin_trap()`, or Chromium's `IMMEDIATE_CRASH()` on a failed `CHECK`. It is not a fault and carries no information about node health.

On nodes running browser-based CI this means a continuous stream of `KernelReady` / `AppCrash` warnings. Measured on one cluster over ~20h: **~5,500 events across 10 nodes**, worst single node 1,511, every one of them headless Chrome ending a test session:

```
[Wed Aug 12 19:48:53 2026] traps: chrome[1356759] trap int3 ip:5f9ad8850f04 sp:7fff57cb87c0 error:0 in chrome[5f9ad6161000+c48d000]
[Wed Aug 12 19:48:57 2026] traps: chrome[1361870] trap int3 ip:587223a07f04 sp:7ffe4686e870 error:0 in chrome[587221318000+c48d000]
```

All 711 traps on the node I examined hit the identical offset in the Chrome binary (`ip - base = 0x26eff04`, 711/711) — a single deterministic code path, once per browser session, which is what you would expect from a fixed `CHECK` rather than from anything going wrong on the host. I attributed the processes to a CI pod by sampling `/proc/<pid>/cgroup`, and the traps stop entirely when no test pods are scheduled.

## Fix

Skip `int3` specifically. Go's `regexp` has no negative lookahead, so this is a separate pattern rather than an inline exclusion:

```go
// int3 is a breakpoint trap that applications raise deliberately, for example via
// __builtin_trap() or Chromium's IMMEDIATE_CRASH(), so it does not indicate a node problem
intentionalTrap = regexp.MustCompile(`traps:.* trap int3\b`)
```

Genuine faults are unaffected — verified directly:

```
appCrash=true intentional=true   | traps: chrome[1450999] trap int3 ip:5c6363ff7f04 ...
appCrash=true intentional=false  | traps: myapp[42] trap divide error ip:400abc ...
appCrash=true intentional=false  | traps: myapp[42] general protection fault ip:400abc ...
appCrash=true intentional=true   | traps: weird[7] trap int3
```

The `\b` rather than a trailing space covers `int3` at end of line.

I deliberately did **not** use an allowlist of fault types (`divide error`, `general protection fault`, ...), even though #223 floats that as the tidier option. An allowlist silently drops any trap type not enumerated, and `trap invalid opcode` is genuinely ambiguous — `ud2` is emitted both by compiler-inserted trap paths and intentionally by some language runtimes. Denying the one type known to be intentional keeps current behaviour for everything else. Happy to switch to an allowlist if maintainers prefer it, including or excluding `invalid opcode` as you see fit.

## Testing

Added `TestKernelMonitor/AppCrashIgnoresIntentionalTrap`, using a real dmesg line, asserting no notification is emitted.

Full package passes on Linux (`golang:1.26` container, since the package needs `unix.Adjtimex`/`STA_UNSYNC` and will not build on darwin):

```
ok  	github.com/aws/eks-node-monitoring-agent/monitors/kernel	0.096s
```

I also confirmed the test is not vacuous — reverting just the one-line condition makes it fail:

```
--- FAIL: TestKernelMonitor/AppCrashIgnoresIntentionalTrap
    Error: Not equal: expected: 0, actual: 1
```

`go vet` is clean for the package. `GOOS=linux go build ./...` fails only inside the NVIDIA go-dcgm cgo dependency, which is a pre-existing cross-compilation limitation unrelated to this change.

## Note on scope

This stops the agent from misreporting the traps. It does not stop Chrome from raising them — that is a workload-side problem I am fixing separately. The two remaining items in #223 (segfault reporting `Process ""` because `matches[1]` is the wrong capture group, and the lack of per-process deduplication) are untouched here and I am happy to send them as follow-ups.
