### PR TITLE
feat(manager): Support condition recovery in node exporter

### DIFF
--- a/api/monitor/interface.go
+++ b/api/monitor/interface.go
@@ -44,6 +44,12 @@ type Condition struct {
 	// MinOccurrence is the minimal time the failure could occur before we export the condition.
 	// default is 0 if not assigned
 	MinOccurrences int64
+	// Resolved indicates that the issue previously reported under this Reason
+	// has recovered. A resolved condition clears the reason from the
+	// corresponding NodeCondition; when the last fatal reason for a
+	// NodeCondition is resolved, the condition returns to a healthy status.
+	// Resolving a reason that was never reported is a no-op.
+	Resolved bool
 }
 
 // A gauge for how severe the issue is, and whether actions need to be taken

--- a/pkg/manager/exporter.go
+++ b/pkg/manager/exporter.go
@@ -18,4 +18,10 @@ type Exporter interface {
 
 	// Fatal exports fatal conditions
 	Fatal(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType) error
+
+	// Resolve clears a previously exported fatal condition reason. It returns
+	// true when the node condition has returned to a healthy status, i.e.
+	// no other fatal reasons remain for it. Resolving a reason that was
+	// never reported is a no-op.
+	Resolve(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType) (bool, error)
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -133,6 +133,22 @@ func (m *MonitorManager) exportCondition(ctx context.Context, monitorName string
 	}
 	logger = logger.WithValues("conditionType", conditionType)
 
+	// Resolved conditions clear state instead of reporting it: reset the
+	// occurrence debounce for the reason and route to the exporter's resolve
+	// path, bypassing MinOccurrences gating.
+	if condition.Resolved {
+		m.conditionCountMap[condition.Reason] = 0
+		recovered, err := m.exporter.Resolve(ctx, condition, conditionType)
+		if err != nil {
+			return err
+		}
+		if recovered {
+			conditionTypeGauge.WithLabelValues(string(conditionType)).Set(0)
+		}
+		logger.Info("resolved condition", "recovered", recovered)
+		return nil
+	}
+
 	// Skip requests for conditions that have not met their minimum occurrences
 	if m.conditionCountMap[condition.Reason] < condition.MinOccurrences {
 		logger.Info("condition has not met MinOccurrences", "occurrences", m.conditionCountMap[condition.Reason])

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -33,7 +33,9 @@ func NewManagerWithExporterFuncs(fns ...func(*mockExporter)) (*manager.MonitorMa
 }
 
 type mockExporter struct {
-	notifyChan chan struct{}
+	notifyChan   chan struct{}
+	resolveChan  chan monitor.Condition
+	resolveValue bool
 }
 
 func (e *mockExporter) notify() error {
@@ -48,6 +50,12 @@ func (e *mockExporter) Warning(context.Context, monitor.Condition, corev1.NodeCo
 }
 func (e *mockExporter) Fatal(context.Context, monitor.Condition, corev1.NodeConditionType) error {
 	return e.notify()
+}
+func (e *mockExporter) Resolve(_ context.Context, condition monitor.Condition, _ corev1.NodeConditionType) (bool, error) {
+	if e.resolveChan != nil {
+		e.resolveChan <- condition
+	}
+	return e.resolveValue, nil
 }
 
 func TestManager_Notification(t *testing.T) {
@@ -133,6 +141,41 @@ func TestManager_MinOccurrences(t *testing.T) {
 			// expected to timeout because min occurrences was not met.
 		}
 	})
+}
+
+func TestManager_ResolvedConditionRoutedToExporter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	mockMon := &mockMonitor{
+		registerFunc: func(ctx context.Context, mgr monitor.Manager) error {
+			go mgr.Notify(ctx, monitor.Condition{
+				Reason:   "ExampleReason",
+				Severity: monitor.SeverityFatal,
+				Resolved: true,
+				// MinOccurrences must not gate resolution.
+				MinOccurrences: 5,
+			})
+			return nil
+		},
+	}
+	mMgr, mockExp := NewManagerWithExporterFuncs(func(e *mockExporter) {
+		e.resolveChan = make(chan monitor.Condition, 1)
+		e.resolveValue = true
+	})
+	if err := mMgr.Register(ctx, mockMon, "MockPassed"); err != nil {
+		t.Fatal(err)
+	}
+	go mMgr.Start(ctx)
+
+	select {
+	case cond := <-mockExp.resolveChan:
+		if cond.Reason != "ExampleReason" {
+			t.Fatalf("resolved reason = %q, want ExampleReason", cond.Reason)
+		}
+	case <-ctx.Done():
+		t.Fatal("resolved condition was not routed to the exporter")
+	}
 }
 
 // this tests the creation of an observable resource from end to end.

--- a/pkg/manager/node_exporter.go
+++ b/pkg/manager/node_exporter.go
@@ -48,6 +48,8 @@ func NewNodeExporter(
 		recorder:               recorder,
 		managedConditions:      initializeManagedConditions(managedConditionConfigs),
 		managedConditionsDirty: true,
+		conditionConfigs:       managedConditionConfigs,
+		fatalEntries:           make(map[corev1.NodeConditionType][]fatalEntry),
 	}
 }
 
@@ -92,6 +94,20 @@ type nodeExporter struct {
 	managedConditions      map[corev1.NodeConditionType]corev1.NodeCondition
 	managedConditionsDirty bool
 	managedConditionsLock  sync.Mutex
+
+	// conditionConfigs holds the ready-state configuration used to restore a
+	// condition once all of its fatal reasons have been resolved.
+	conditionConfigs map[corev1.NodeConditionType]NodeConditionConfig
+	// fatalEntries tracks the unresolved fatal reasons per condition type in
+	// arrival order, so that resolving one reason does not clear a condition
+	// that is still failing for another.
+	fatalEntries map[corev1.NodeConditionType][]fatalEntry
+}
+
+// fatalEntry is one unresolved fatal reason and its latest message.
+type fatalEntry struct {
+	reason  string
+	message string
 }
 
 // Info records an event for the specified condition.
@@ -108,36 +124,120 @@ func (e *nodeExporter) Warning(ctx context.Context, c monitor.Condition, conditi
 
 // Fatal updates the local state for the specified managed condition.
 // The condition will be reported in the Node.Status.Conditions periodically.
+// Each distinct Reason is tracked until it is resolved via Resolve; messages
+// from all unresolved reasons are aggregated into the condition message.
 func (e *nodeExporter) Fatal(ctx context.Context, monitorCondition monitor.Condition, conditionType corev1.NodeConditionType) error {
 	e.managedConditionsLock.Lock()
 	defer e.managedConditionsLock.Unlock()
+
+	entries := e.fatalEntries[conditionType]
+	updated := false
+	for i := range entries {
+		if entries[i].reason == monitorCondition.Reason {
+			entries[i].message = monitorCondition.Message
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		entries = append(entries, fatalEntry{reason: monitorCondition.Reason, message: monitorCondition.Message})
+	}
+	e.fatalEntries[conditionType] = entries
+
+	e.rebuildFatalCondition(conditionType)
+	return nil
+}
+
+// Resolve clears a previously reported fatal reason for the condition type.
+// When the last reason is cleared, the condition is restored to its healthy
+// ready state. It returns true when the condition is healthy after the
+// resolution. Resolving a reason that was never reported is a no-op.
+func (e *nodeExporter) Resolve(ctx context.Context, monitorCondition monitor.Condition, conditionType corev1.NodeConditionType) (bool, error) {
+	e.managedConditionsLock.Lock()
+	defer e.managedConditionsLock.Unlock()
+
+	entries := e.fatalEntries[conditionType]
+	removed := false
+	for i := range entries {
+		if entries[i].reason == monitorCondition.Reason {
+			entries = append(entries[:i], entries[i+1:]...)
+			removed = true
+			break
+		}
+	}
+	if !removed {
+		return len(entries) == 0, nil
+	}
+	e.fatalEntries[conditionType] = entries
+
+	e.recorder.Event(e.nodeRef, corev1.EventTypeNormal, string(conditionType),
+		fmt.Sprintf("%s: the previously reported issue has been resolved", monitorCondition.Reason))
+
+	if len(entries) > 0 {
+		// Other reasons are still failing; rebuild the condition without the
+		// resolved reason.
+		e.rebuildFatalCondition(conditionType)
+		return false, nil
+	}
+
+	// No fatal reasons remain: restore the ready state.
 	now := metav1.Now()
+	readyCondition := corev1.NodeCondition{
+		Type:               conditionType,
+		Status:             corev1.ConditionTrue,
+		Reason:             "Resolved",
+		Message:            "The previously reported issues have been resolved",
+		LastHeartbeatTime:  now,
+		LastTransitionTime: now,
+	}
+	if config, ok := e.conditionConfigs[conditionType]; ok {
+		readyCondition.Reason = config.ReadyReason
+		readyCondition.Message = config.ReadyMessage
+	}
+	if oldCondition, ok := e.managedConditions[conditionType]; ok && oldCondition.Status == readyCondition.Status {
+		readyCondition.LastTransitionTime = oldCondition.LastTransitionTime
+	}
+	e.managedConditions[conditionType] = readyCondition
+	e.managedConditionsDirty = true
+	return true, nil
+}
+
+// rebuildFatalCondition recomputes the managed condition for the type from
+// the tracked fatal entries. The caller must hold managedConditionsLock and
+// ensure at least one entry exists.
+func (e *nodeExporter) rebuildFatalCondition(conditionType corev1.NodeConditionType) {
+	entries := e.fatalEntries[conditionType]
+	now := metav1.Now()
+
+	// Aggregate distinct messages in arrival order.
+	var messages []string
+	for _, entry := range entries {
+		duplicate := false
+		for _, m := range messages {
+			if m == entry.message {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate && entry.message != "" {
+			messages = append(messages, entry.message)
+		}
+	}
+
 	newCondition := corev1.NodeCondition{
 		Type:               conditionType,
-		Reason:             monitorCondition.Reason,
-		Message:            monitorCondition.Message,
+		Reason:             entries[len(entries)-1].reason,
+		Message:            strings.Join(messages, "; "),
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: now,
 		LastHeartbeatTime:  now,
 	}
-	if oldCondition, ok := e.managedConditions[conditionType]; ok {
+	if oldCondition, ok := e.managedConditions[conditionType]; ok && oldCondition.Status == newCondition.Status {
 		// if the status has not changed, use the old transition time
-		if oldCondition.Status == newCondition.Status {
-			newCondition.LastTransitionTime = oldCondition.LastTransitionTime
-
-			// aggregate messages if the status is the same (e.g. both False)
-			// and ensure that we don't duplicate identical messages.
-			if oldCondition.Message != "" && oldCondition.Message != newCondition.Message && !strings.Contains(oldCondition.Message, newCondition.Message) {
-				newCondition.Message = oldCondition.Message + "; " + newCondition.Message
-			} else if strings.Contains(oldCondition.Message, newCondition.Message) {
-				// if the old message already contains the new one, preserve the old one (which might have other aggregated messages)
-				newCondition.Message = oldCondition.Message
-			}
-		}
+		newCondition.LastTransitionTime = oldCondition.LastTransitionTime
 	}
 	e.managedConditions[conditionType] = newCondition
 	e.managedConditionsDirty = true
-	return nil
 }
 
 // Run starts the node exporter's background tasks

--- a/pkg/manager/node_exporter_test.go
+++ b/pkg/manager/node_exporter_test.go
@@ -3,6 +3,7 @@ package manager_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -340,5 +341,136 @@ func TestNodeExporter_LastTransitionTimeFlapping(t *testing.T) {
 	// It should still be "MessageA; MessageB" because MessageA is already contained in it.
 	if latestMessage != "MessageA; MessageB" {
 		t.Errorf("Message was incorrectly updated with duplicates or cleared. expected: MessageA; MessageB, got: %s", latestMessage)
+	}
+}
+
+func TestNodeExporter_ResolveRestoresReadyState(t *testing.T) {
+	ctx := context.TODO()
+	fakeClient := fake.NewFakeClient()
+	initialNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	if err := fakeClient.Create(ctx, &initialNode); err != nil {
+		t.Fatal(err)
+	}
+
+	var recorder fakeEventRecorder
+	conditionType := corev1.NodeConditionType("NetworkingReady")
+	nodeExporter := manager.NewNodeExporter(
+		&initialNode,
+		fakeClient,
+		&recorder,
+		map[corev1.NodeConditionType]manager.NodeConditionConfig{
+			conditionType: {ReadyReason: "NetworkingIsReady", ReadyMessage: "Monitoring is active"},
+		},
+	)
+
+	failing := monitor.Condition{Reason: "IPAMDNotRunning", Message: "IPAMD is down", Severity: monitor.SeverityFatal}
+	if err := nodeExporter.Fatal(ctx, failing, conditionType); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolving an unrelated reason must not recover the condition.
+	recovered, err := nodeExporter.Resolve(ctx, monitor.Condition{Reason: "SomethingElse"}, conditionType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered {
+		t.Fatal("resolving an untracked reason must not report recovery while another reason is failing")
+	}
+
+	// Resolving the failing reason restores the ready state.
+	recovered, err = nodeExporter.Resolve(ctx, monitor.Condition{Reason: "IPAMDNotRunning"}, conditionType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recovered {
+		t.Fatal("expected recovery after resolving the only failing reason")
+	}
+
+	heartbeatChan := make(chan time.Time)
+	reportChan := make(chan time.Time)
+	go nodeExporter.RunWithTickers(ctx, heartbeatChan, reportChan)
+	reportChan <- time.Now()
+
+	expected := corev1.NodeCondition{
+		Type:    conditionType,
+		Status:  corev1.ConditionTrue,
+		Reason:  "NetworkingIsReady",
+		Message: "Monitoring is active",
+	}
+	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		var node corev1.Node
+		if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(&initialNode), &node); err != nil {
+			return false, err
+		}
+		return nodeHasCondition(node, expected), nil
+	}); err != nil {
+		t.Fatalf("condition did not return to ready state: %v", err)
+	}
+
+	// A recovery event should have been recorded for auditability.
+	var foundEvent bool
+	for _, event := range recorder.events.Items {
+		if event.Type == corev1.EventTypeNormal && strings.Contains(event.Message, "IPAMDNotRunning") && strings.Contains(event.Message, "resolved") {
+			foundEvent = true
+		}
+	}
+	if !foundEvent {
+		t.Errorf("expected a recovery event, got %+v", recorder.events.Items)
+	}
+}
+
+func TestNodeExporter_ResolveKeepsConditionFalseWhileOtherReasonsRemain(t *testing.T) {
+	ctx := context.TODO()
+	fakeClient := fake.NewFakeClient()
+	initialNode := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	if err := fakeClient.Create(ctx, &initialNode); err != nil {
+		t.Fatal(err)
+	}
+
+	conditionType := corev1.NodeConditionType("NetworkingReady")
+	nodeExporter := manager.NewNodeExporter(
+		&initialNode,
+		fakeClient,
+		record.NewFakeRecorder(100),
+		map[corev1.NodeConditionType]manager.NodeConditionConfig{
+			conditionType: {ReadyReason: "NetworkingIsReady", ReadyMessage: "Monitoring is active"},
+		},
+	)
+
+	if err := nodeExporter.Fatal(ctx, monitor.Condition{Reason: "ErrorA", Message: "MessageA"}, conditionType); err != nil {
+		t.Fatal(err)
+	}
+	if err := nodeExporter.Fatal(ctx, monitor.Condition{Reason: "ErrorB", Message: "MessageB"}, conditionType); err != nil {
+		t.Fatal(err)
+	}
+
+	recovered, err := nodeExporter.Resolve(ctx, monitor.Condition{Reason: "ErrorA"}, conditionType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered {
+		t.Fatal("condition must not recover while ErrorB is still failing")
+	}
+
+	heartbeatChan := make(chan time.Time)
+	reportChan := make(chan time.Time)
+	go nodeExporter.RunWithTickers(ctx, heartbeatChan, reportChan)
+	reportChan <- time.Now()
+
+	// The condition stays False, attributed to the remaining reason only.
+	expected := corev1.NodeCondition{
+		Type:    conditionType,
+		Status:  corev1.ConditionFalse,
+		Reason:  "ErrorB",
+		Message: "MessageB",
+	}
+	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		var node corev1.Node
+		if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(&initialNode), &node); err != nil {
+			return false, err
+		}
+		return nodeHasCondition(node, expected), nil
+	}); err != nil {
+		t.Fatalf("condition should remain False with only the remaining reason: %v", err)
 	}
 }


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

A monitor can report a fatal reason but has no way to withdraw one. Once a managed NodeCondition goes False it stays False for the life of the process, even after the underlying problem clears, and a condition failing for two separate reasons cannot be partially cleared at all.

Add a `Resolved` flag to `monitor.Condition` and a `Resolve` method to the `Exporter` interface. The node exporter tracks unresolved fatal reasons per condition type in arrival order, so resolving one reason rebuilds the condition message from the reasons that remain, and resolving the last one restores the configured ready state with a Normal event for auditability. The manager routes resolved conditions past `MinOccurrences` gating, resets that reason's debounce counter, and clears the fatal condition gauge on full recovery. Message aggregation and `LastTransitionTime` semantics are unchanged, and nothing emits a resolved condition yet.

**Testing Done**:

New exporter tests cover resolving one reason out of several, resolving the last reason, and resolving a reason that was never reported. The existing flapping regression test passes unchanged. `make test`, `hack/check-generate.sh`, `gofmt -l` and `GOOS=linux CGO_ENABLED=1 go build ./...` are green on this branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.