### PR TITLE
feat(probe): Add probe spec types and startup validation

### DIFF
--- a/api/probe/probe.go
+++ b/api/probe/probe.go
@@ -1,0 +1,92 @@
+// Package probe defines the declarative contract for subagent health probes.
+//
+// A probe declares how the node monitoring agent observes the health of one
+// AWS-owned subagent (e.g. IPAMD, the Network Policy Agent) through the
+// agent's own health surface. Probes are pure data: the framework in
+// pkg/probe interprets a Spec and emits conditions through the parent
+// monitor, so onboarding an agent is a spec addition rather than new
+// detection code.
+package probe
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+)
+
+// TransportKind identifies how a Check reaches its target agent.
+type TransportKind string
+
+const (
+	// TransportHTTPLoopback performs an HTTP GET against a local-only
+	// address. A 2xx response is healthy; any other response, including a
+	// refused connection, is unhealthy.
+	TransportHTTPLoopback TransportKind = "http-loopback"
+	// TransportSystemdDBus queries the ActiveState of a systemd unit over
+	// D-Bus. Liveness only: "active" is healthy, anything else is unhealthy.
+	// A failure to reach D-Bus itself is unknown, not unhealthy.
+	TransportSystemdDBus TransportKind = "systemd-dbus"
+)
+
+// Spec declares a health probe for one AWS-owned subagent. It is fully
+// JSON/YAML-serializable so that probe registration can later move from
+// binary-baked defaults to the agent's configuration surface without
+// reshaping the contract.
+type Spec struct {
+	// Subsystem identifies the target agent, e.g. "ipamd" or
+	// "network-policy-agent". Used in logs and condition messages.
+	Subsystem string `json:"subsystem"`
+
+	// Checks defines the agent's health surface.
+	Checks Checks `json:"checks"`
+
+	// ReasonOnFail is the reason identifier (a key in reasons.yaml) emitted
+	// when the probe fails. It must reference a registered,
+	// non-parameterized reason; this is validated at startup.
+	ReasonOnFail string `json:"reasonOnFail"`
+
+	// FailureSeverity is the severity of the emitted condition on probe
+	// failure. If empty, the reason's default severity from reasons.yaml is
+	// used.
+	FailureSeverity monitor.Severity `json:"failureSeverity,omitempty"`
+
+	// Interval is the time between check rounds.
+	Interval metav1.Duration `json:"interval"`
+
+	// FailureThreshold is the number of consecutive unhealthy results
+	// required before the failure condition is emitted. The counter resets
+	// on any healthy result. Must be at least 1.
+	FailureThreshold int `json:"failureThreshold"`
+
+	// StartupGracePeriod suppresses failure emission for this duration after
+	// the runner starts, tolerating agents that come up after the monitoring
+	// agent during boot.
+	StartupGracePeriod metav1.Duration `json:"startupGracePeriod,omitempty"`
+}
+
+// Checks defines the individual checks that make up a probe. Liveness is
+// required; readiness and diagnostics are optional because not every
+// transport can express them (systemd ActiveState has no notion of
+// readiness).
+type Checks struct {
+	// Liveness answers "is the agent running".
+	Liveness Check `json:"liveness"`
+	// Readiness answers "is the agent performing its function". The depth of
+	// the readiness answer is owned by the agent, not by this contract.
+	Readiness *Check `json:"readiness,omitempty"`
+	// Diagnostics optionally returns free-form structured detail that is
+	// surfaced as informational events, never as condition flips.
+	Diagnostics *Check `json:"diagnostics,omitempty"`
+}
+
+// Check is a single health question asked over a specific transport.
+type Check struct {
+	// Transport selects how the target is reached.
+	Transport TransportKind `json:"transport"`
+	// Address is the transport-specific target, e.g. "127.0.0.1:8901" for
+	// http-loopback or "ipamd.service" for systemd-dbus.
+	Address string `json:"address"`
+	// Path is the HTTP request path, e.g. "/healthz". Required for
+	// http-loopback and must be empty for systemd-dbus.
+	Path string `json:"path,omitempty"`
+}

--- a/api/probe/probe_test.go
+++ b/api/probe/probe_test.go
@@ -1,0 +1,88 @@
+package probe
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+)
+
+func makeSpec() Spec {
+	return Spec{
+		Subsystem: "ipamd",
+		Checks: Checks{
+			Liveness: Check{
+				Transport: TransportSystemdDBus,
+				Address:   "ipamd.service",
+			},
+			Readiness: &Check{
+				Transport: TransportHTTPLoopback,
+				Address:   "127.0.0.1:8173",
+				Path:      "/readyz",
+			},
+		},
+		ReasonOnFail:       "IPAMDNotRunning",
+		FailureSeverity:    monitor.SeverityFatal,
+		Interval:           metav1.Duration{Duration: 30 * time.Second},
+		FailureThreshold:   3,
+		StartupGracePeriod: metav1.Duration{Duration: 5 * time.Minute},
+	}
+}
+
+func TestSpecJSONRoundTrip(t *testing.T) {
+	in := makeSpec()
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Spec
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Interval.Duration != 30*time.Second {
+		t.Errorf("interval = %v, want 30s", out.Interval.Duration)
+	}
+	if out.Checks.Readiness == nil || out.Checks.Readiness.Path != "/readyz" {
+		t.Errorf("readiness check did not round-trip: %+v", out.Checks.Readiness)
+	}
+	if out.Subsystem != in.Subsystem || out.ReasonOnFail != in.ReasonOnFail || out.FailureThreshold != in.FailureThreshold {
+		t.Errorf("spec did not round-trip: got %+v, want %+v", out, in)
+	}
+}
+
+func TestSpecYAMLHumanReadableDurations(t *testing.T) {
+	// The eventual configuration surface is YAML; durations must parse from
+	// human-readable strings like "30s", not integer nanoseconds.
+	in := []byte(`
+subsystem: network-policy-agent
+checks:
+  liveness:
+    transport: http-loopback
+    address: 127.0.0.1:8901
+    path: /healthz
+reasonOnFail: NPANotRunning
+interval: 30s
+failureThreshold: 3
+startupGracePeriod: 5m
+`)
+	var spec Spec
+	if err := yaml.UnmarshalStrict(in, &spec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if spec.Interval.Duration != 30*time.Second {
+		t.Errorf("interval = %v, want 30s", spec.Interval.Duration)
+	}
+	if spec.StartupGracePeriod.Duration != 5*time.Minute {
+		t.Errorf("startupGracePeriod = %v, want 5m", spec.StartupGracePeriod.Duration)
+	}
+	if spec.Checks.Readiness != nil {
+		t.Errorf("readiness should be nil when omitted, got %+v", spec.Checks.Readiness)
+	}
+	if spec.FailureSeverity != "" {
+		t.Errorf("failureSeverity should be empty when omitted, got %q", spec.FailureSeverity)
+	}
+}

--- a/pkg/probe/validate.go
+++ b/pkg/probe/validate.go
@@ -1,0 +1,82 @@
+// Package probe implements the runtime for the declarative probe contract in
+// api/probe: spec validation, the transports that execute checks, and the
+// runner that schedules checks and emits conditions through a parent
+// monitor's manager.
+package probe
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
+)
+
+// Validate checks that a Spec is internally consistent and references only
+// registered reasons and known transports. It is intended to run at startup
+// so that a bad spec fails the agent loudly instead of silently never
+// probing.
+func Validate(spec probe.Spec) error {
+	if spec.Subsystem == "" {
+		return fmt.Errorf("probe spec is missing subsystem")
+	}
+	if err := validateCheck("liveness", spec.Checks.Liveness); err != nil {
+		return fmt.Errorf("probe %q: %w", spec.Subsystem, err)
+	}
+	if spec.Checks.Readiness != nil {
+		if err := validateCheck("readiness", *spec.Checks.Readiness); err != nil {
+			return fmt.Errorf("probe %q: %w", spec.Subsystem, err)
+		}
+	}
+	if spec.Checks.Diagnostics != nil {
+		if err := validateCheck("diagnostics", *spec.Checks.Diagnostics); err != nil {
+			return fmt.Errorf("probe %q: %w", spec.Subsystem, err)
+		}
+	}
+
+	meta, ok := reasons.ByName(spec.ReasonOnFail)
+	if !ok {
+		return fmt.Errorf("probe %q: reasonOnFail %q is not a registered reason", spec.Subsystem, spec.ReasonOnFail)
+	}
+	if strings.Contains(meta.Template(), "%") {
+		return fmt.Errorf("probe %q: reasonOnFail %q has a parameterized template %q and cannot be used by a probe", spec.Subsystem, spec.ReasonOnFail, meta.Template())
+	}
+
+	switch spec.FailureSeverity {
+	case "", monitor.SeverityInfo, monitor.SeverityWarning, monitor.SeverityFatal:
+	default:
+		return fmt.Errorf("probe %q: invalid failureSeverity %q", spec.Subsystem, spec.FailureSeverity)
+	}
+
+	if spec.Interval.Duration <= 0 {
+		return fmt.Errorf("probe %q: interval must be positive, got %v", spec.Subsystem, spec.Interval.Duration)
+	}
+	if spec.FailureThreshold < 1 {
+		return fmt.Errorf("probe %q: failureThreshold must be at least 1, got %d", spec.Subsystem, spec.FailureThreshold)
+	}
+	if spec.StartupGracePeriod.Duration < 0 {
+		return fmt.Errorf("probe %q: startupGracePeriod must not be negative, got %v", spec.Subsystem, spec.StartupGracePeriod.Duration)
+	}
+	return nil
+}
+
+// validateCheck validates a single check's transport, address, and path.
+func validateCheck(name string, c probe.Check) error {
+	if c.Address == "" {
+		return fmt.Errorf("%s check is missing address", name)
+	}
+	switch c.Transport {
+	case probe.TransportHTTPLoopback:
+		if !strings.HasPrefix(c.Path, "/") {
+			return fmt.Errorf("%s check: http-loopback requires a path starting with %q, got %q", name, "/", c.Path)
+		}
+	case probe.TransportSystemdDBus:
+		if c.Path != "" {
+			return fmt.Errorf("%s check: systemd-dbus does not use a path, got %q", name, c.Path)
+		}
+	default:
+		return fmt.Errorf("%s check: unknown transport %q", name, c.Transport)
+	}
+	return nil
+}

--- a/pkg/probe/validate_test.go
+++ b/pkg/probe/validate_test.go
@@ -1,0 +1,136 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+)
+
+func validSpec() probe.Spec {
+	return probe.Spec{
+		Subsystem: "ipamd",
+		Checks: probe.Checks{
+			Liveness: probe.Check{
+				Transport: probe.TransportSystemdDBus,
+				Address:   "ipamd.service",
+			},
+		},
+		ReasonOnFail:       "IPAMDNotRunning",
+		FailureSeverity:    monitor.SeverityFatal,
+		Interval:           metav1.Duration{Duration: 30 * time.Second},
+		FailureThreshold:   3,
+		StartupGracePeriod: metav1.Duration{Duration: 5 * time.Minute},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*probe.Spec)
+		wantErr string
+	}{
+		{
+			name:   "valid systemd-dbus spec",
+			mutate: func(s *probe.Spec) {},
+		},
+		{
+			name: "valid http-loopback spec with readiness",
+			mutate: func(s *probe.Spec) {
+				s.Checks.Liveness = probe.Check{Transport: probe.TransportHTTPLoopback, Address: "127.0.0.1:8173", Path: "/healthz"}
+				s.Checks.Readiness = &probe.Check{Transport: probe.TransportHTTPLoopback, Address: "127.0.0.1:8173", Path: "/readyz"}
+			},
+		},
+		{
+			name:   "empty failureSeverity defaults later and is valid",
+			mutate: func(s *probe.Spec) { s.FailureSeverity = "" },
+		},
+		{
+			name:    "missing subsystem",
+			mutate:  func(s *probe.Spec) { s.Subsystem = "" },
+			wantErr: "missing subsystem",
+		},
+		{
+			name:    "missing liveness address",
+			mutate:  func(s *probe.Spec) { s.Checks.Liveness.Address = "" },
+			wantErr: "liveness check is missing address",
+		},
+		{
+			name:    "unknown transport",
+			mutate:  func(s *probe.Spec) { s.Checks.Liveness.Transport = "carrier-pigeon" },
+			wantErr: `unknown transport "carrier-pigeon"`,
+		},
+		{
+			name: "http check without path",
+			mutate: func(s *probe.Spec) {
+				s.Checks.Liveness = probe.Check{Transport: probe.TransportHTTPLoopback, Address: "127.0.0.1:8173"}
+			},
+			wantErr: "requires a path",
+		},
+		{
+			name:    "dbus check with path",
+			mutate:  func(s *probe.Spec) { s.Checks.Liveness.Path = "/healthz" },
+			wantErr: "does not use a path",
+		},
+		{
+			name: "invalid readiness check",
+			mutate: func(s *probe.Spec) {
+				s.Checks.Readiness = &probe.Check{Transport: probe.TransportHTTPLoopback, Address: ""}
+			},
+			wantErr: "readiness check is missing address",
+		},
+		{
+			name:    "unregistered reason",
+			mutate:  func(s *probe.Spec) { s.ReasonOnFail = "NoSuchReason" },
+			wantErr: "not a registered reason",
+		},
+		{
+			name:    "parameterized reason template",
+			mutate:  func(s *probe.Spec) { s.ReasonOnFail = "NvidiaXIDError" },
+			wantErr: "parameterized template",
+		},
+		{
+			name:    "invalid severity",
+			mutate:  func(s *probe.Spec) { s.FailureSeverity = "Critical" },
+			wantErr: "invalid failureSeverity",
+		},
+		{
+			name:    "zero interval",
+			mutate:  func(s *probe.Spec) { s.Interval = metav1.Duration{} },
+			wantErr: "interval must be positive",
+		},
+		{
+			name:    "zero failure threshold",
+			mutate:  func(s *probe.Spec) { s.FailureThreshold = 0 },
+			wantErr: "failureThreshold must be at least 1",
+		},
+		{
+			name:    "negative grace period",
+			mutate:  func(s *probe.Spec) { s.StartupGracePeriod = metav1.Duration{Duration: -time.Second} },
+			wantErr: "must not be negative",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := validSpec()
+			tt.mutate(&spec)
+			err := Validate(spec)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Validate() = %q, want error containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

Detection for the AWS-owned agents that ship on the node is written by hand per agent, so onboarding one means new Go code inside a monitor rather than a declaration. Nothing rejects a bad health-check definition either — a typo in a reason name would simply never emit.

Introduce `api/probe` with a declarative Spec covering the checks, the reason emitted on failure, the interval and the thresholds, plus `pkg/probe` validation that runs at startup. Specs are pure data and serialize to JSON and YAML through `metav1.Duration`, so registration can move from binary-baked defaults onto the configuration surface later without reshaping the contract. Validation resolves the failure reason against the generated lookup, rejects parameterized reason templates a probe cannot render, and enforces the address and path rules for each transport.

**Testing Done**:

Validation tests cover each rejection path, and the Spec is round-tripped through both JSON and YAML to confirm the serialized shape. `make test`, `hack/check-generate.sh`, `gofmt -l` and `GOOS=linux CGO_ENABLED=1 go build ./...` are green on this branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.