### PR TITLE
feat(probe): Add http-loopback and systemd-dbus transports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-logr/logr v1.4.4
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/prometheus/client_golang v1.24.1
@@ -86,7 +87,6 @@ require (
 	github.com/go-openapi/swag/stringutils v0.25.5 // indirect
 	github.com/go-openapi/swag/typeutils v0.25.5 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
-	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/nftables v0.3.1-0.20251119083706-1db35da82052 // indirect

--- a/pkg/probe/transport.go
+++ b/pkg/probe/transport.go
@@ -1,0 +1,43 @@
+package probe
+
+import (
+	"context"
+
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+)
+
+// Outcome classifies the result of executing a single check.
+type Outcome string
+
+const (
+	// OutcomeHealthy means the check executed and the agent reported healthy.
+	OutcomeHealthy Outcome = "Healthy"
+	// OutcomeUnhealthy means the check executed and the agent is not healthy.
+	// A refused connection to the agent's own endpoint counts as unhealthy:
+	// an agent that is not answering its health surface is not healthy.
+	OutcomeUnhealthy Outcome = "Unhealthy"
+	// OutcomeUnknown means the check could not be executed for reasons on the
+	// monitoring side (e.g. the D-Bus socket is unreachable). Unknown results
+	// do not count toward a probe's failure threshold.
+	OutcomeUnknown Outcome = "Unknown"
+)
+
+// Result is the outcome of one check execution plus human-readable detail
+// for condition messages and logs.
+type Result struct {
+	Outcome Outcome
+	Detail  string
+}
+
+// Transport executes a single check against its target.
+type Transport interface {
+	Do(ctx context.Context, check probe.Check) Result
+}
+
+// NewTransports returns the default transport for each supported kind.
+func NewTransports() map[probe.TransportKind]Transport {
+	return map[probe.TransportKind]Transport{
+		probe.TransportHTTPLoopback: NewHTTPLoopbackTransport(),
+		probe.TransportSystemdDBus:  NewSystemdDBusTransport(),
+	}
+}

--- a/pkg/probe/transport_dbus.go
+++ b/pkg/probe/transport_dbus.go
@@ -1,0 +1,67 @@
+package probe
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+)
+
+// dbusConn is the subset of the go-systemd dbus connection used by the
+// transport, extracted so tests can substitute a fake.
+type dbusConn interface {
+	GetUnitPropertyContext(ctx context.Context, unit string, propertyName string) (*dbus.Property, error)
+	Close()
+}
+
+// SystemdDBusTransport executes liveness checks by querying a systemd unit's
+// ActiveState over D-Bus. It generalizes the ActiveState query used by the
+// networking monitor's IPAMD and NPA handlers. Failure to reach D-Bus itself
+// is Unknown, not Unhealthy: the inability to ask the question is not
+// evidence about the agent.
+type SystemdDBusTransport struct {
+	newConn func(ctx context.Context) (dbusConn, error)
+}
+
+// NewSystemdDBusTransport returns a transport backed by real D-Bus
+// connections.
+func NewSystemdDBusTransport() *SystemdDBusTransport {
+	return &SystemdDBusTransport{
+		newConn: func(ctx context.Context) (dbusConn, error) {
+			return dbus.NewWithContext(ctx)
+		},
+	}
+}
+
+func (t *SystemdDBusTransport) Do(ctx context.Context, check probe.Check) Result {
+	conn, err := t.newConn(ctx)
+	if err != nil {
+		return Result{Outcome: OutcomeUnknown, Detail: fmt.Sprintf("connecting to D-Bus: %v", err)}
+	}
+	defer conn.Close()
+
+	property, err := conn.GetUnitPropertyContext(ctx, check.Address, "ActiveState")
+	if err != nil {
+		return Result{Outcome: OutcomeUnknown, Detail: fmt.Sprintf("querying ActiveState of %s: %v", check.Address, err)}
+	}
+	activeState, ok := property.Value.Value().(string)
+	if !ok {
+		return Result{Outcome: OutcomeUnknown, Detail: fmt.Sprintf("unexpected ActiveState type for %s", check.Address)}
+	}
+	if activeState == "active" {
+		return Result{Outcome: OutcomeHealthy}
+	}
+
+	// Best-effort diagnostic enrichment: why/how the unit is in its state.
+	detail := fmt.Sprintf("unit %s ActiveState=%q", check.Address, activeState)
+	for _, prop := range []string{"SubState", "Result"} {
+		if p, err := conn.GetUnitPropertyContext(ctx, check.Address, prop); err == nil {
+			if s, ok := p.Value.Value().(string); ok {
+				detail += fmt.Sprintf(" %s=%q", prop, s)
+			}
+		}
+	}
+	return Result{Outcome: OutcomeUnhealthy, Detail: detail}
+}

--- a/pkg/probe/transport_dbus_test.go
+++ b/pkg/probe/transport_dbus_test.go
@@ -1,0 +1,102 @@
+package probe
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+	godbus "github.com/godbus/dbus/v5"
+
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+)
+
+// fakeDBusConn implements dbusConn with canned unit properties.
+type fakeDBusConn struct {
+	props   map[string]any // property name -> value
+	propErr error
+	closed  bool
+}
+
+func (f *fakeDBusConn) GetUnitPropertyContext(ctx context.Context, unit string, propertyName string) (*dbus.Property, error) {
+	if f.propErr != nil {
+		return nil, f.propErr
+	}
+	v, ok := f.props[propertyName]
+	if !ok {
+		return nil, errors.New("no such property")
+	}
+	return &dbus.Property{Name: propertyName, Value: godbus.MakeVariant(v)}, nil
+}
+
+func (f *fakeDBusConn) Close() { f.closed = true }
+
+func dbusTransport(conn dbusConn, connErr error) *SystemdDBusTransport {
+	return &SystemdDBusTransport{
+		newConn: func(ctx context.Context) (dbusConn, error) {
+			if connErr != nil {
+				return nil, connErr
+			}
+			return conn, nil
+		},
+	}
+}
+
+func dbusCheck() probe.Check {
+	return probe.Check{Transport: probe.TransportSystemdDBus, Address: "ipamd.service"}
+}
+
+func TestSystemdDBusTransport_Active(t *testing.T) {
+	conn := &fakeDBusConn{props: map[string]any{"ActiveState": "active"}}
+	result := dbusTransport(conn, nil).Do(context.Background(), dbusCheck())
+	if result.Outcome != OutcomeHealthy {
+		t.Fatalf("outcome = %q (%s), want Healthy", result.Outcome, result.Detail)
+	}
+	if !conn.closed {
+		t.Error("connection was not closed")
+	}
+}
+
+func TestSystemdDBusTransport_InactiveWithEnrichment(t *testing.T) {
+	conn := &fakeDBusConn{props: map[string]any{
+		"ActiveState": "failed",
+		"SubState":    "auto-restart",
+		"Result":      "exit-code",
+	}}
+	result := dbusTransport(conn, nil).Do(context.Background(), dbusCheck())
+	if result.Outcome != OutcomeUnhealthy {
+		t.Fatalf("outcome = %q, want Unhealthy", result.Outcome)
+	}
+	for _, want := range []string{`ActiveState="failed"`, `SubState="auto-restart"`, `Result="exit-code"`, "ipamd.service"} {
+		if !strings.Contains(result.Detail, want) {
+			t.Errorf("detail %q should contain %q", result.Detail, want)
+		}
+	}
+}
+
+func TestSystemdDBusTransport_ConnectionErrorIsUnknown(t *testing.T) {
+	result := dbusTransport(nil, errors.New("socket unavailable")).Do(context.Background(), dbusCheck())
+	if result.Outcome != OutcomeUnknown {
+		t.Fatalf("outcome = %q, want Unknown for D-Bus connection failure", result.Outcome)
+	}
+}
+
+func TestSystemdDBusTransport_PropertyErrorIsUnknown(t *testing.T) {
+	conn := &fakeDBusConn{propErr: errors.New("dbus timeout")}
+	result := dbusTransport(conn, nil).Do(context.Background(), dbusCheck())
+	if result.Outcome != OutcomeUnknown {
+		t.Fatalf("outcome = %q, want Unknown for property query failure", result.Outcome)
+	}
+	if !conn.closed {
+		t.Error("connection was not closed")
+	}
+}
+
+func TestSystemdDBusTransport_UnexpectedTypeIsUnknown(t *testing.T) {
+	conn := &fakeDBusConn{props: map[string]any{"ActiveState": uint32(7)}}
+	result := dbusTransport(conn, nil).Do(context.Background(), dbusCheck())
+	if result.Outcome != OutcomeUnknown {
+		t.Fatalf("outcome = %q, want Unknown for unexpected property type", result.Outcome)
+	}
+}

--- a/pkg/probe/transport_http.go
+++ b/pkg/probe/transport_http.go
@@ -1,0 +1,65 @@
+package probe
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+)
+
+const (
+	// httpCheckTimeout bounds a single HTTP check execution.
+	httpCheckTimeout = 5 * time.Second
+	// maxDetailBytes bounds how much of a response body is captured into the
+	// result detail for condition messages.
+	maxDetailBytes = 1024
+)
+
+// HTTPLoopbackTransport executes checks as HTTP GET requests against
+// local-only addresses. A 2xx response is healthy. Any non-2xx response or a
+// failure to connect to the agent's endpoint is unhealthy — an agent that is
+// not answering its own health surface is not healthy.
+type HTTPLoopbackTransport struct {
+	client *http.Client
+}
+
+// NewHTTPLoopbackTransport returns an HTTP transport with a bounded
+// per-check timeout.
+func NewHTTPLoopbackTransport() *HTTPLoopbackTransport {
+	return &HTTPLoopbackTransport{
+		client: &http.Client{Timeout: httpCheckTimeout},
+	}
+}
+
+func (t *HTTPLoopbackTransport) Do(ctx context.Context, check probe.Check) Result {
+	url := "http://" + check.Address + check.Path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		// A malformed spec, not an agent failure.
+		return Result{Outcome: OutcomeUnknown, Detail: fmt.Sprintf("building request for %s: %v", url, err)}
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			// The agent is shutting down or the caller gave up; do not
+			// attribute this to the probed agent.
+			return Result{Outcome: OutcomeUnknown, Detail: fmt.Sprintf("check canceled: %v", ctx.Err())}
+		}
+		return Result{Outcome: OutcomeUnhealthy, Detail: fmt.Sprintf("GET %s: %v", url, err)}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return Result{Outcome: OutcomeHealthy}
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxDetailBytes))
+	detail := fmt.Sprintf("GET %s: %s", url, resp.Status)
+	if b := strings.TrimSpace(string(body)); b != "" {
+		detail += ": " + b
+	}
+	return Result{Outcome: OutcomeUnhealthy, Detail: detail}
+}

--- a/pkg/probe/transport_http_test.go
+++ b/pkg/probe/transport_http_test.go
@@ -1,0 +1,70 @@
+package probe
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+)
+
+func httpCheck(address string) probe.Check {
+	return probe.Check{Transport: probe.TransportHTTPLoopback, Address: address, Path: "/healthz"}
+}
+
+func TestHTTPLoopbackTransport_Healthy(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	result := NewHTTPLoopbackTransport().Do(context.Background(), httpCheck(strings.TrimPrefix(ts.URL, "http://")))
+	if result.Outcome != OutcomeHealthy {
+		t.Fatalf("outcome = %q (%s), want Healthy", result.Outcome, result.Detail)
+	}
+}
+
+func TestHTTPLoopbackTransport_UnhealthyStatusWithBodyDetail(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"error":"ebpf map write failed"}`))
+	}))
+	defer ts.Close()
+
+	result := NewHTTPLoopbackTransport().Do(context.Background(), httpCheck(strings.TrimPrefix(ts.URL, "http://")))
+	if result.Outcome != OutcomeUnhealthy {
+		t.Fatalf("outcome = %q, want Unhealthy", result.Outcome)
+	}
+	if !strings.Contains(result.Detail, "503") || !strings.Contains(result.Detail, "ebpf map write failed") {
+		t.Errorf("detail %q should contain status and body", result.Detail)
+	}
+}
+
+func TestHTTPLoopbackTransport_ConnectionRefusedIsUnhealthy(t *testing.T) {
+	// Reserve a port, then close the listener so the connection is refused.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	addr := strings.TrimPrefix(ts.URL, "http://")
+	ts.Close()
+
+	result := NewHTTPLoopbackTransport().Do(context.Background(), httpCheck(addr))
+	if result.Outcome != OutcomeUnhealthy {
+		t.Fatalf("outcome = %q (%s), want Unhealthy for refused connection", result.Outcome, result.Detail)
+	}
+}
+
+func TestHTTPLoopbackTransport_CanceledContextIsUnknown(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := NewHTTPLoopbackTransport().Do(ctx, httpCheck(strings.TrimPrefix(ts.URL, "http://")))
+	if result.Outcome != OutcomeUnknown {
+		t.Fatalf("outcome = %q, want Unknown for canceled context", result.Outcome)
+	}
+}


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

A probe has to reach its target, and the two shapes present on the node today are an HTTP endpoint on loopback and a systemd unit's `ActiveState` over D-Bus. The networking monitor already queries `ActiveState` in two places with the logic duplicated between them.

Add a `Transport` interface returning a three-valued outcome. `Healthy` and `Unhealthy` are both answers about the agent, and a refused connection to an agent's own health endpoint counts as `Unhealthy`. `Unknown` is deliberately distinct: the check could not execute for reasons on the monitoring side, such as an unreachable D-Bus socket, and those results must not count toward a failure threshold, because being unable to ask the question is not evidence about the agent. The http-loopback transport treats 2xx as healthy and captures a bounded portion of a non-2xx response body into the result detail. The systemd-dbus transport generalizes the duplicated `ActiveState` query and adds best-effort `SubState` and `Result` enrichment when a unit is not active.

**Testing Done**:

Transport tests cover healthy, non-2xx with body detail, connection refused, and cancelled-context paths for HTTP, and active, inactive-with-enrichment, connection error, property error, and unexpected-type paths for D-Bus via a fake connection. `make test`, `hack/check-generate.sh`, `gofmt -l` and `GOOS=linux CGO_ENABLED=1 go build ./...` are green on this branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.