### PR TITLE
feat(probe): Add the probe runner and its failure semantics

### DIFF
--- a/api/probe/probe.go
+++ b/api/probe/probe.go
@@ -58,6 +58,14 @@ type Spec struct {
 	// on any healthy result. Must be at least 1.
 	FailureThreshold int `json:"failureThreshold"`
 
+	// RecoveryThreshold is the number of consecutive healthy results
+	// required before a previously emitted failure condition is resolved.
+	// It damps condition flapping: every False→True transition resets Auto
+	// Repair's wait clock, so a flapping agent would otherwise never be
+	// repaired. If zero, it defaults to 1, which resolves on the first
+	// healthy result and preserves the pre-hysteresis behavior.
+	RecoveryThreshold int `json:"recoveryThreshold,omitempty"`
+
 	// StartupGracePeriod suppresses failure emission for this duration after
 	// the runner starts, tolerating agents that come up after the monitoring
 	// agent during boot.

--- a/api/probe/probe_test.go
+++ b/api/probe/probe_test.go
@@ -29,6 +29,7 @@ func makeSpec() Spec {
 		FailureSeverity:    monitor.SeverityFatal,
 		Interval:           metav1.Duration{Duration: 30 * time.Second},
 		FailureThreshold:   3,
+		RecoveryThreshold:  2,
 		StartupGracePeriod: metav1.Duration{Duration: 5 * time.Minute},
 	}
 }
@@ -49,7 +50,7 @@ func TestSpecJSONRoundTrip(t *testing.T) {
 	if out.Checks.Readiness == nil || out.Checks.Readiness.Path != "/readyz" {
 		t.Errorf("readiness check did not round-trip: %+v", out.Checks.Readiness)
 	}
-	if out.Subsystem != in.Subsystem || out.ReasonOnFail != in.ReasonOnFail || out.FailureThreshold != in.FailureThreshold {
+	if out.Subsystem != in.Subsystem || out.ReasonOnFail != in.ReasonOnFail || out.FailureThreshold != in.FailureThreshold || out.RecoveryThreshold != in.RecoveryThreshold {
 		t.Errorf("spec did not round-trip: got %+v, want %+v", out, in)
 	}
 }

--- a/pkg/probe/runner.go
+++ b/pkg/probe/runner.go
@@ -16,15 +16,20 @@ import (
 // Runner executes one probe spec on its interval and emits conditions
 // through the parent monitor's manager. It owns the probe's failure
 // semantics: a startup grace period, a consecutive-failure threshold that
-// resets on success, and a recovery signal once a previously failing probe
-// is healthy again. Unknown results (checks that could not execute for
-// monitoring-side reasons) never count toward the threshold.
+// resets on success, a consecutive-healthy recovery threshold that damps
+// condition flapping, and a one-shot Warning summarizing failure episodes
+// that recover before reaching the failure threshold. Unknown results
+// (checks that could not execute for monitoring-side reasons) never count
+// toward either threshold.
 type Runner struct {
 	spec       probe.Spec
 	transports map[probe.TransportKind]Transport
 	manager    monitor.Manager
 	log        logr.Logger
 	severity   monitor.Severity
+	// recoveryThreshold is spec.RecoveryThreshold with the zero value
+	// defaulted to 1 (resolve on first healthy result).
+	recoveryThreshold int
 
 	// now and newTicker are injectable for tests.
 	now       func() time.Time
@@ -33,11 +38,23 @@ type Runner struct {
 	startedAt           time.Time
 	consecutiveFailures int
 	failureEmitted      bool
+	// consecutiveHealthy counts healthy results since the last unhealthy
+	// one while a fired failure awaits resolution.
+	consecutiveHealthy int
+	// lastFailedCheck names the check ("liveness" or "readiness") that
+	// produced the streak's most recent unhealthy result, for the episode
+	// summary message.
+	lastFailedCheck string
+	// streakStartedInGrace records whether the current failure streak began
+	// inside the startup grace period; such streaks are boot noise and do
+	// not produce an episode summary.
+	streakStartedInGrace bool
 }
 
 // NewRunner validates the spec and returns a Runner that emits through the
 // given manager. The failure severity defaults to the reason's severity from
-// reasons.yaml when the spec does not set one.
+// reasons.yaml when the spec does not set one; the recovery threshold
+// defaults to 1 when the spec does not set one.
 func NewRunner(spec probe.Spec, mgr monitor.Manager, log logr.Logger) (*Runner, error) {
 	if err := Validate(spec); err != nil {
 		return nil, err
@@ -47,17 +64,22 @@ func NewRunner(spec probe.Spec, mgr monitor.Manager, log logr.Logger) (*Runner, 
 	if severity == "" {
 		severity = meta.DefaultSeverity()
 	}
+	recoveryThreshold := spec.RecoveryThreshold
+	if recoveryThreshold == 0 {
+		recoveryThreshold = 1
+	}
 	if spec.Checks.Diagnostics != nil {
 		log.Info("probe diagnostics checks are not implemented yet and will be ignored", "subsystem", spec.Subsystem)
 	}
 	return &Runner{
-		spec:       spec,
-		transports: NewTransports(),
-		manager:    mgr,
-		log:        log.WithValues("probe", spec.Subsystem),
-		severity:   severity,
-		now:        time.Now,
-		newTicker:  util.TimeTickWithJitterContext,
+		spec:              spec,
+		transports:        NewTransports(),
+		manager:           mgr,
+		log:               log.WithValues("probe", spec.Subsystem),
+		severity:          severity,
+		recoveryThreshold: recoveryThreshold,
+		now:               time.Now,
+		newTicker:         util.TimeTickWithJitterContext,
 	}, nil
 }
 
@@ -81,19 +103,47 @@ func (r *Runner) Start(ctx context.Context) error {
 // runOnce executes one probe cycle: liveness, then readiness when configured,
 // then applies the failure semantics to the combined result.
 func (r *Runner) runOnce(ctx context.Context) error {
-	result := r.check(ctx)
+	result, checkName := r.check(ctx)
 	switch result.Outcome {
 	case OutcomeUnknown:
-		// The check could not execute; this is not evidence about the agent.
-		// Leave the failure counter untouched.
+		// The check could not execute; this is not evidence about the agent
+		// in either direction. Leave the failure and recovery counters
+		// untouched.
 		r.log.Info("probe check could not execute, skipping cycle", "detail", result.Detail)
 		return nil
 	case OutcomeHealthy:
+		streak := r.consecutiveFailures
 		r.consecutiveFailures = 0
 		if !r.failureEmitted {
+			if streak == 0 {
+				return nil
+			}
+			// A failure streak completed below the failure threshold. The
+			// agent cannot record its own brief outage, so emit exactly one
+			// Warning summarizing the completed episode — unless the streak
+			// began inside the startup grace period, which is boot noise.
+			startedInGrace := r.streakStartedInGrace
+			r.streakStartedInGrace = false
+			if startedInGrace {
+				r.log.Info("probe episode began during startup grace, suppressing summary", "failures", streak)
+				return nil
+			}
+			duration := time.Duration(streak) * r.spec.Interval.Duration
+			r.log.Info("probe episode recovered below threshold, emitting summary", "failures", streak, "duration", duration)
+			return r.manager.Notify(ctx, monitor.Condition{
+				Reason:   r.spec.ReasonOnFail,
+				Message:  fmt.Sprintf("%s %s check unhealthy for %d consecutive checks over %s, recovered", r.spec.Subsystem, r.lastFailedCheck, streak, duration),
+				Severity: monitor.SeverityWarning,
+			})
+		}
+		r.consecutiveHealthy++
+		if r.consecutiveHealthy < r.recoveryThreshold {
+			r.log.Info("probe healthy below recovery threshold, awaiting hysteresis", "consecutiveHealthy", r.consecutiveHealthy, "recoveryThreshold", r.recoveryThreshold)
 			return nil
 		}
 		r.failureEmitted = false
+		r.consecutiveHealthy = 0
+		r.streakStartedInGrace = false
 		r.log.Info("probe recovered, resolving condition", "reason", r.spec.ReasonOnFail)
 		return r.manager.Notify(ctx, monitor.Condition{
 			Reason:   r.spec.ReasonOnFail,
@@ -102,7 +152,14 @@ func (r *Runner) runOnce(ctx context.Context) error {
 			Resolved: true,
 		})
 	case OutcomeUnhealthy:
+		if r.consecutiveFailures == 0 {
+			r.streakStartedInGrace = r.now().Sub(r.startedAt) < r.spec.StartupGracePeriod.Duration
+		}
 		r.consecutiveFailures++
+		// A failure interrupts recovery: the resolution hysteresis requires
+		// consecutive healthy results.
+		r.consecutiveHealthy = 0
+		r.lastFailedCheck = checkName
 		if grace := r.spec.StartupGracePeriod.Duration; r.now().Sub(r.startedAt) < grace {
 			r.log.Info("probe failing within startup grace period, suppressing", "detail", result.Detail, "consecutiveFailures", r.consecutiveFailures)
 			return nil
@@ -122,17 +179,18 @@ func (r *Runner) runOnce(ctx context.Context) error {
 	}
 }
 
-// check runs the probe's checks in order and combines their results:
-// any unhealthy result wins, then any unknown, then healthy.
-func (r *Runner) check(ctx context.Context) Result {
+// check runs the probe's checks in order and combines their results: any
+// unhealthy result wins, then any unknown, then healthy. The second return
+// value names the check that produced the result.
+func (r *Runner) check(ctx context.Context) (Result, string) {
 	liveness := r.do(ctx, "liveness", r.spec.Checks.Liveness)
 	if liveness.Outcome != OutcomeHealthy {
-		return liveness
+		return liveness, "liveness"
 	}
 	if r.spec.Checks.Readiness != nil {
-		return r.do(ctx, "readiness", *r.spec.Checks.Readiness)
+		return r.do(ctx, "readiness", *r.spec.Checks.Readiness), "readiness"
 	}
-	return liveness
+	return liveness, "liveness"
 }
 
 // do executes a single check via its transport and prefixes the detail with

--- a/pkg/probe/runner.go
+++ b/pkg/probe/runner.go
@@ -1,0 +1,151 @@
+package probe
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
+	"github.com/aws/eks-node-monitoring-agent/pkg/util"
+)
+
+// Runner executes one probe spec on its interval and emits conditions
+// through the parent monitor's manager. It owns the probe's failure
+// semantics: a startup grace period, a consecutive-failure threshold that
+// resets on success, and a recovery signal once a previously failing probe
+// is healthy again. Unknown results (checks that could not execute for
+// monitoring-side reasons) never count toward the threshold.
+type Runner struct {
+	spec       probe.Spec
+	transports map[probe.TransportKind]Transport
+	manager    monitor.Manager
+	log        logr.Logger
+	severity   monitor.Severity
+
+	// now and newTicker are injectable for tests.
+	now       func() time.Time
+	newTicker func(ctx context.Context, d time.Duration) <-chan time.Time
+
+	startedAt           time.Time
+	consecutiveFailures int
+	failureEmitted      bool
+}
+
+// NewRunner validates the spec and returns a Runner that emits through the
+// given manager. The failure severity defaults to the reason's severity from
+// reasons.yaml when the spec does not set one.
+func NewRunner(spec probe.Spec, mgr monitor.Manager, log logr.Logger) (*Runner, error) {
+	if err := Validate(spec); err != nil {
+		return nil, err
+	}
+	meta, _ := reasons.ByName(spec.ReasonOnFail)
+	severity := spec.FailureSeverity
+	if severity == "" {
+		severity = meta.DefaultSeverity()
+	}
+	if spec.Checks.Diagnostics != nil {
+		log.Info("probe diagnostics checks are not implemented yet and will be ignored", "subsystem", spec.Subsystem)
+	}
+	return &Runner{
+		spec:       spec,
+		transports: NewTransports(),
+		manager:    mgr,
+		log:        log.WithValues("probe", spec.Subsystem),
+		severity:   severity,
+		now:        time.Now,
+		newTicker:  util.TimeTickWithJitterContext,
+	}, nil
+}
+
+// Start runs the probe loop until the context is canceled.
+func (r *Runner) Start(ctx context.Context) error {
+	r.startedAt = r.now()
+	r.log.Info("starting probe", "interval", r.spec.Interval.Duration, "failureThreshold", r.spec.FailureThreshold, "startupGracePeriod", r.spec.StartupGracePeriod.Duration)
+	ticks := r.newTicker(ctx, r.spec.Interval.Duration)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticks:
+			if err := r.runOnce(ctx); err != nil {
+				r.log.Error(err, "probe cycle failed to report")
+			}
+		}
+	}
+}
+
+// runOnce executes one probe cycle: liveness, then readiness when configured,
+// then applies the failure semantics to the combined result.
+func (r *Runner) runOnce(ctx context.Context) error {
+	result := r.check(ctx)
+	switch result.Outcome {
+	case OutcomeUnknown:
+		// The check could not execute; this is not evidence about the agent.
+		// Leave the failure counter untouched.
+		r.log.Info("probe check could not execute, skipping cycle", "detail", result.Detail)
+		return nil
+	case OutcomeHealthy:
+		r.consecutiveFailures = 0
+		if !r.failureEmitted {
+			return nil
+		}
+		r.failureEmitted = false
+		r.log.Info("probe recovered, resolving condition", "reason", r.spec.ReasonOnFail)
+		return r.manager.Notify(ctx, monitor.Condition{
+			Reason:   r.spec.ReasonOnFail,
+			Message:  fmt.Sprintf("The %s probe is healthy again", r.spec.Subsystem),
+			Severity: r.severity,
+			Resolved: true,
+		})
+	case OutcomeUnhealthy:
+		r.consecutiveFailures++
+		if grace := r.spec.StartupGracePeriod.Duration; r.now().Sub(r.startedAt) < grace {
+			r.log.Info("probe failing within startup grace period, suppressing", "detail", result.Detail, "consecutiveFailures", r.consecutiveFailures)
+			return nil
+		}
+		if r.consecutiveFailures < r.spec.FailureThreshold {
+			r.log.Info("probe failing below threshold", "detail", result.Detail, "consecutiveFailures", r.consecutiveFailures)
+			return nil
+		}
+		r.failureEmitted = true
+		return r.manager.Notify(ctx, monitor.Condition{
+			Reason:   r.spec.ReasonOnFail,
+			Message:  result.Detail,
+			Severity: r.severity,
+		})
+	default:
+		return fmt.Errorf("unexpected probe outcome %q", result.Outcome)
+	}
+}
+
+// check runs the probe's checks in order and combines their results:
+// any unhealthy result wins, then any unknown, then healthy.
+func (r *Runner) check(ctx context.Context) Result {
+	liveness := r.do(ctx, "liveness", r.spec.Checks.Liveness)
+	if liveness.Outcome != OutcomeHealthy {
+		return liveness
+	}
+	if r.spec.Checks.Readiness != nil {
+		return r.do(ctx, "readiness", *r.spec.Checks.Readiness)
+	}
+	return liveness
+}
+
+// do executes a single check via its transport and prefixes the detail with
+// the probe and check identity for condition messages.
+func (r *Runner) do(ctx context.Context, name string, check probe.Check) Result {
+	transport, ok := r.transports[check.Transport]
+	if !ok {
+		// Validate rejects unknown transports; this guards runtime drift.
+		return Result{Outcome: OutcomeUnknown, Detail: fmt.Sprintf("no transport %q", check.Transport)}
+	}
+	result := transport.Do(ctx, check)
+	if result.Detail != "" {
+		result.Detail = fmt.Sprintf("%s %s check: %s", r.spec.Subsystem, name, result.Detail)
+	}
+	return result
+}

--- a/pkg/probe/runner_test.go
+++ b/pkg/probe/runner_test.go
@@ -106,7 +106,9 @@ func TestRunner_EmitsAfterConsecutiveFailures(t *testing.T) {
 
 func TestRunner_SuccessResetsCounter(t *testing.T) {
 	mgr := &fakeManager{}
-	// U U H U U — never 3 consecutive, so nothing may be emitted.
+	// U U H U U — never 3 consecutive, so the failure condition may not be
+	// emitted. The completed below-threshold episode (U U H) emits exactly
+	// one Warning summary; the trailing in-progress streak emits nothing.
 	r := newTestRunner(t, runnerSpec(3, 0), mgr, unhealthy(), unhealthy(), healthy(), unhealthy(), unhealthy())
 
 	for i := 0; i < 5; i++ {
@@ -114,8 +116,18 @@ func TestRunner_SuccessResetsCounter(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if len(mgr.conditions) != 0 {
-		t.Fatalf("expected no emission without 3 consecutive failures, got %+v", mgr.conditions)
+	if len(mgr.conditions) != 1 {
+		t.Fatalf("expected exactly the episode summary, got %+v", mgr.conditions)
+	}
+	c := mgr.conditions[0]
+	if c.Severity != monitor.SeverityWarning || c.Resolved {
+		t.Errorf("episode summary must be a non-resolved Warning: %+v", c)
+	}
+	if c.Reason != "IPAMDNotRunning" {
+		t.Errorf("episode summary must use the probe's reason, got %q", c.Reason)
+	}
+	if !strings.Contains(c.Message, "ipamd liveness check") || !strings.Contains(c.Message, "2 consecutive checks") || !strings.Contains(c.Message, "recovered") {
+		t.Errorf("episode summary message should carry check, streak length, and recovery, got %q", c.Message)
 	}
 }
 
@@ -138,6 +150,92 @@ func TestRunner_RecoveryEmitsResolvedCondition(t *testing.T) {
 	c := mgr.conditions[1]
 	if !c.Resolved || c.Reason != "IPAMDNotRunning" {
 		t.Errorf("second condition should resolve the reason: %+v", c)
+	}
+}
+
+func TestRunner_RecoveryHysteresis(t *testing.T) {
+	mgr := &fakeManager{}
+	spec := runnerSpec(3, 0)
+	spec.RecoveryThreshold = 2
+	// U U U → failure fires; H counts 1 of 2 healthy; U resets the recovery
+	// counter (below the failure threshold, so no re-notification, and no
+	// episode summary while the failure is fired); H counts 1; H counts 2 →
+	// resolution.
+	r := newTestRunner(t, spec, mgr,
+		unhealthy(), unhealthy(), unhealthy(), healthy(), unhealthy(), healthy(), healthy())
+
+	for i := 0; i < 6; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// After 6 ticks: only the failure. A premature resolution here means the
+	// mid-recovery failure did not reset the counter; a Warning here means an
+	// episode summary was emitted while the failure was fired.
+	if len(mgr.conditions) != 1 || mgr.conditions[0].Resolved {
+		t.Fatalf("expected only the fired failure after 6 ticks, got %+v", mgr.conditions)
+	}
+
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(mgr.conditions) != 2 || !mgr.conditions[1].Resolved {
+		t.Fatalf("expected resolution on 2nd consecutive healthy tick, got %+v", mgr.conditions)
+	}
+}
+
+func TestRunner_UnknownDoesNotCountTowardRecovery(t *testing.T) {
+	mgr := &fakeManager{}
+	spec := runnerSpec(1, 0)
+	spec.RecoveryThreshold = 2
+	// U → failure fires; H counts 1 of 2; ? leaves the recovery counter
+	// untouched; H counts 2 → resolution.
+	r := newTestRunner(t, spec, mgr, unhealthy(), healthy(), unknown(), healthy())
+
+	for i := 0; i < 3; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A resolution here would mean the unknown tick counted as healthy.
+	if len(mgr.conditions) != 1 {
+		t.Fatalf("expected only the fired failure after unknown tick, got %+v", mgr.conditions)
+	}
+
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// A missing resolution here would mean the unknown tick reset the counter.
+	if len(mgr.conditions) != 2 || !mgr.conditions[1].Resolved {
+		t.Fatalf("expected resolution on 2nd countable healthy tick, got %+v", mgr.conditions)
+	}
+}
+
+func TestRunner_EpisodeInGraceEmitsNoSummary(t *testing.T) {
+	mgr := &fakeManager{}
+	r := newTestRunner(t, runnerSpec(3, 5*time.Minute), mgr,
+		unhealthy(), unhealthy(), healthy(), unhealthy(), healthy())
+
+	// U U H inside grace: a completed below-threshold episode, but it began
+	// during startup grace — boot noise, no summary.
+	for i := 0; i < 3; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(mgr.conditions) != 0 {
+		t.Fatalf("episode that began in grace must not emit, got %+v", mgr.conditions)
+	}
+
+	// Past grace: U H is a completed below-threshold episode — one summary.
+	r.now = func() time.Time { return r.startedAt.Add(10 * time.Minute) }
+	for i := 0; i < 2; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(mgr.conditions) != 1 || mgr.conditions[0].Severity != monitor.SeverityWarning {
+		t.Fatalf("expected exactly one summary Warning for the post-grace episode, got %+v", mgr.conditions)
 	}
 }
 

--- a/pkg/probe/runner_test.go
+++ b/pkg/probe/runner_test.go
@@ -1,0 +1,234 @@
+package probe
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/api/monitor/resource"
+	"github.com/aws/eks-node-monitoring-agent/api/probe"
+)
+
+// fakeManager records notified conditions.
+type fakeManager struct {
+	conditions []monitor.Condition
+}
+
+func (m *fakeManager) Subscribe(resource.Type, []resource.Part) (<-chan string, error) {
+	return nil, nil
+}
+
+func (m *fakeManager) Notify(_ context.Context, c monitor.Condition) error {
+	m.conditions = append(m.conditions, c)
+	return nil
+}
+
+// scriptedTransport returns canned results in sequence, repeating the last.
+type scriptedTransport struct {
+	results []Result
+	i       int
+}
+
+func (t *scriptedTransport) Do(context.Context, probe.Check) Result {
+	r := t.results[min(t.i, len(t.results)-1)]
+	t.i++
+	return r
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func newTestRunner(t *testing.T, spec probe.Spec, mgr *fakeManager, results ...Result) *Runner {
+	t.Helper()
+	r, err := NewRunner(spec, mgr, logr.Discard())
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	r.transports[spec.Checks.Liveness.Transport] = &scriptedTransport{results: results}
+	r.startedAt = time.Now() // grace period baseline for direct runOnce calls
+	return r
+}
+
+func runnerSpec(threshold int, grace time.Duration) probe.Spec {
+	return probe.Spec{
+		Subsystem: "ipamd",
+		Checks: probe.Checks{
+			Liveness: probe.Check{Transport: probe.TransportSystemdDBus, Address: "ipamd.service"},
+		},
+		ReasonOnFail:       "IPAMDNotRunning",
+		FailureSeverity:    monitor.SeverityFatal,
+		Interval:           metav1.Duration{Duration: 30 * time.Second},
+		FailureThreshold:   threshold,
+		StartupGracePeriod: metav1.Duration{Duration: grace},
+	}
+}
+
+func healthy() Result   { return Result{Outcome: OutcomeHealthy} }
+func unhealthy() Result { return Result{Outcome: OutcomeUnhealthy, Detail: "ActiveState=failed"} }
+func unknown() Result   { return Result{Outcome: OutcomeUnknown, Detail: "dbus down"} }
+
+func TestRunner_EmitsAfterConsecutiveFailures(t *testing.T) {
+	mgr := &fakeManager{}
+	r := newTestRunner(t, runnerSpec(3, 0), mgr, unhealthy())
+
+	for i := 0; i < 2; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(mgr.conditions) != 0 {
+		t.Fatalf("emitted before threshold: %+v", mgr.conditions)
+	}
+
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(mgr.conditions) != 1 {
+		t.Fatalf("expected 1 condition after threshold, got %d", len(mgr.conditions))
+	}
+	c := mgr.conditions[0]
+	if c.Reason != "IPAMDNotRunning" || c.Severity != monitor.SeverityFatal || c.Resolved {
+		t.Errorf("unexpected condition: %+v", c)
+	}
+	if !strings.Contains(c.Message, "ipamd liveness check") || !strings.Contains(c.Message, "ActiveState=failed") {
+		t.Errorf("message should identify the check and detail, got %q", c.Message)
+	}
+}
+
+func TestRunner_SuccessResetsCounter(t *testing.T) {
+	mgr := &fakeManager{}
+	// U U H U U — never 3 consecutive, so nothing may be emitted.
+	r := newTestRunner(t, runnerSpec(3, 0), mgr, unhealthy(), unhealthy(), healthy(), unhealthy(), unhealthy())
+
+	for i := 0; i < 5; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(mgr.conditions) != 0 {
+		t.Fatalf("expected no emission without 3 consecutive failures, got %+v", mgr.conditions)
+	}
+}
+
+func TestRunner_RecoveryEmitsResolvedCondition(t *testing.T) {
+	mgr := &fakeManager{}
+	r := newTestRunner(t, runnerSpec(2, 0), mgr, unhealthy(), unhealthy(), healthy(), healthy())
+
+	for i := 0; i < 4; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Expect: failure at tick 2, resolution at tick 3, nothing at tick 4.
+	if len(mgr.conditions) != 2 {
+		t.Fatalf("expected exactly failure+resolution, got %+v", mgr.conditions)
+	}
+	if mgr.conditions[0].Resolved {
+		t.Error("first condition should be the failure")
+	}
+	c := mgr.conditions[1]
+	if !c.Resolved || c.Reason != "IPAMDNotRunning" {
+		t.Errorf("second condition should resolve the reason: %+v", c)
+	}
+}
+
+func TestRunner_UnknownDoesNotCountOrReset(t *testing.T) {
+	mgr := &fakeManager{}
+	// U U ? U — unknown neither increments nor resets, so the 4th tick is the
+	// 3rd consecutive failure and emits.
+	r := newTestRunner(t, runnerSpec(3, 0), mgr, unhealthy(), unhealthy(), unknown(), unhealthy())
+
+	for i := 0; i < 3; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(mgr.conditions) != 0 {
+		t.Fatalf("unknown tick must not emit: %+v", mgr.conditions)
+	}
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(mgr.conditions) != 1 {
+		t.Fatalf("expected emission on 3rd consecutive failure after unknown, got %d", len(mgr.conditions))
+	}
+}
+
+func TestRunner_StartupGraceSuppressesEmission(t *testing.T) {
+	mgr := &fakeManager{}
+	r := newTestRunner(t, runnerSpec(1, 5*time.Minute), mgr, unhealthy())
+
+	// Within grace: failures counted but suppressed.
+	for i := 0; i < 3; i++ {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(mgr.conditions) != 0 {
+		t.Fatalf("expected suppression during grace period, got %+v", mgr.conditions)
+	}
+
+	// After grace: the accumulated failures emit on the next cycle.
+	r.now = func() time.Time { return r.startedAt.Add(10 * time.Minute) }
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(mgr.conditions) != 1 {
+		t.Fatalf("expected emission after grace period, got %d", len(mgr.conditions))
+	}
+}
+
+func TestRunner_ReadinessFailureCounts(t *testing.T) {
+	mgr := &fakeManager{}
+	spec := runnerSpec(1, 0)
+	spec.Checks.Liveness = probe.Check{Transport: probe.TransportHTTPLoopback, Address: "127.0.0.1:8173", Path: "/healthz"}
+	spec.Checks.Readiness = &probe.Check{Transport: probe.TransportHTTPLoopback, Address: "127.0.0.1:8173", Path: "/readyz"}
+
+	r, err := NewRunner(spec, mgr, logr.Discard())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.startedAt = time.Now()
+	// Liveness healthy, readiness unhealthy.
+	r.transports[probe.TransportHTTPLoopback] = &scriptedTransport{results: []Result{
+		healthy(), {Outcome: OutcomeUnhealthy, Detail: "GET /readyz: 503"},
+	}}
+
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(mgr.conditions) != 1 {
+		t.Fatalf("expected readiness failure to emit, got %d", len(mgr.conditions))
+	}
+	if !strings.Contains(mgr.conditions[0].Message, "readiness check") {
+		t.Errorf("message should attribute the readiness check, got %q", mgr.conditions[0].Message)
+	}
+}
+
+func TestRunner_StartExitsOnContextCancel(t *testing.T) {
+	mgr := &fakeManager{}
+	r := newTestRunner(t, runnerSpec(1, 0), mgr, healthy())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not exit on context cancellation")
+	}
+}

--- a/pkg/probe/validate.go
+++ b/pkg/probe/validate.go
@@ -55,6 +55,9 @@ func Validate(spec probe.Spec) error {
 	if spec.FailureThreshold < 1 {
 		return fmt.Errorf("probe %q: failureThreshold must be at least 1, got %d", spec.Subsystem, spec.FailureThreshold)
 	}
+	if spec.RecoveryThreshold < 0 {
+		return fmt.Errorf("probe %q: recoveryThreshold must not be negative, got %d", spec.Subsystem, spec.RecoveryThreshold)
+	}
 	if spec.StartupGracePeriod.Duration < 0 {
 		return fmt.Errorf("probe %q: startupGracePeriod must not be negative, got %v", spec.Subsystem, spec.StartupGracePeriod.Duration)
 	}

--- a/pkg/probe/validate_test.go
+++ b/pkg/probe/validate_test.go
@@ -109,6 +109,15 @@ func TestValidate(t *testing.T) {
 			wantErr: "failureThreshold must be at least 1",
 		},
 		{
+			name:   "unset recovery threshold defaults later and is valid",
+			mutate: func(s *probe.Spec) { s.RecoveryThreshold = 0 },
+		},
+		{
+			name:    "negative recovery threshold",
+			mutate:  func(s *probe.Spec) { s.RecoveryThreshold = -1 },
+			wantErr: "recoveryThreshold must not be negative",
+		},
+		{
 			name:    "negative grace period",
 			mutate:  func(s *probe.Spec) { s.StartupGracePeriod = metav1.Duration{Duration: -time.Second} },
 			wantErr: "must not be negative",


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

With the contract and the transports in place, something has to schedule checks and decide when a probe failure becomes a node condition. Detection latency needs to be predictable, an agent that starts after the monitoring agent must not trip a failure during boot, and a flapping agent must not be able to evade repair.

The runner executes one spec on its interval using the shared jittered ticker. A consecutive-failure threshold resets on any healthy result, making detection latency threshold times interval. A startup grace period suppresses emission while agents come up. `Unknown` results move neither counter. Liveness runs first and readiness only when liveness is healthy, with failures attributed by check name in the condition message.

Two behaviors keep events cheap and repair reachable. A failure streak that recovers before reaching the threshold emits exactly one Warning summarizing the completed episode, since the probed agent cannot record its own brief outage; streaks that begin inside the grace period are boot noise and emit nothing. `RecoveryThreshold` sets how many consecutive healthy results are required before a fired failure resolves, because every False to True transition resets the repair wait clock and resolving on the first healthy tick would let a flapping agent avoid repair indefinitely. Zero defaults to one and preserves the simpler behavior.

**Testing Done**:

Runner tests are table-driven on a single cycle with an injected clock and ticker, so none of them depend on wall-clock timing. They cover emission after consecutive failures, success resetting the counter, resolution after recovery, recovery hysteresis, `Unknown` counting toward neither threshold, grace-period suppression, episode summaries below the threshold, summary suppression for streaks beginning in grace, readiness failures, and exit on context cancellation. `make test`, `hack/check-generate.sh`, `gofmt -l` and `GOOS=linux CGO_ENABLED=1 go build ./...` are green on this branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.