### PR TITLE
feat(networking): Migrate Auto Mode IPAMD liveness to probe framework

### DIFF
--- a/monitors/networking/monitor.go
+++ b/monitors/networking/monitor.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-systemd/v22/dbus"
 	"github.com/go-logr/logr"
 	"github.com/shirou/gopsutil/v4/process"
 	"golang.org/x/time/rate"
@@ -34,6 +33,7 @@ import (
 	"github.com/aws/eks-node-monitoring-agent/monitors/networking/npa"
 	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 	"github.com/aws/eks-node-monitoring-agent/pkg/osext"
+	"github.com/aws/eks-node-monitoring-agent/pkg/probe"
 	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
 	"github.com/aws/eks-node-monitoring-agent/pkg/util"
 )
@@ -247,6 +247,17 @@ func (m *NetworkingMonitor) Register(ctx context.Context, mgr monitor.Manager) e
 		go handler.Start(ctx)
 	}
 
+	// Subagent health probes (Auto Mode: IPAMD liveness). Runners emit
+	// through this monitor's manager, so probe findings surface under the
+	// NetworkingReady condition like any handler-derived condition.
+	for _, spec := range m.probeSpecs() {
+		runner, err := probe.NewRunner(spec, mgr, m.log)
+		if err != nil {
+			return err
+		}
+		go runner.Start(ctx)
+	}
+
 	// NPA (Network Policy Agent) D-Bus state monitoring (crash-loop + not-running) — Auto Mode only.
 	if npaEnabled {
 		go util.NewChannelHandler(
@@ -328,21 +339,9 @@ func (m *NetworkingMonitor) handleIPAMDLogs(line string) error {
 
 func (m *NetworkingMonitor) handleIPAMD() error {
 	if slices.Contains(m.runtimeContext.Tags(), config.EKSAuto) {
-		// on the system, indicating ipamd should be running if there are no errors.
-		dbus, err := dbus.NewWithContext(context.Background())
-		if err != nil {
-			return err
-		}
-		defer dbus.Close()
-		property, err := dbus.GetUnitPropertyContext(context.Background(), "ipamd.service", "ActiveState")
-		if err != nil {
-			return err
-		}
-		ipamdRunning := false
-		if property.Value.Value().(string) == "active" {
-			ipamdRunning = true
-		}
-		return m.checkIPAMD(ipamdRunning)
+		// Liveness of ipamd.service is owned by the IPAMD probe registered in
+		// probeSpecs; only the checkpoint/CRI cross-check runs here.
+		return m.checkIPAMD(true)
 	} else {
 		ipamdRunning := false
 		podName, isInstalled, err := m.isVPCCNIInstalled()

--- a/monitors/networking/probes.go
+++ b/monitors/networking/probes.go
@@ -1,0 +1,41 @@
+package networking
+
+import (
+	"slices"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiprobe "github.com/aws/eks-node-monitoring-agent/api/probe"
+	"github.com/aws/eks-node-monitoring-agent/pkg/config"
+)
+
+// probeSpecs returns the subagent health probes supervised by the networking
+// monitor for the current delivery path. Probes replace only agent-mediated
+// liveness detection; checkpoint cross-checks and configuration validation
+// remain handler-based.
+func (m *NetworkingMonitor) probeSpecs() []apiprobe.Spec {
+	if !slices.Contains(m.runtimeContext.Tags(), config.EKSAuto) {
+		// On the DaemonSet path IPAMD runs inside the VPC CNI pod and is
+		// observed via the existing process scan in handleIPAMD; its gRPC
+		// health surface is a future transport.
+		return nil
+	}
+	return []apiprobe.Spec{
+		{
+			Subsystem: "ipamd",
+			Checks: apiprobe.Checks{
+				Liveness: apiprobe.Check{
+					Transport: apiprobe.TransportSystemdDBus,
+					Address:   "ipamd.service",
+				},
+			},
+			ReasonOnFail:     "IPAMDNotRunning",
+			Interval:         metav1.Duration{Duration: 30 * time.Second},
+			FailureThreshold: 3,
+			// Tolerate ipamd.service coming up after the monitoring agent
+			// during boot; systemd ordering does not sequence the two.
+			StartupGracePeriod: metav1.Duration{Duration: 5 * time.Minute},
+		},
+	}
+}

--- a/monitors/networking/probes_test.go
+++ b/monitors/networking/probes_test.go
@@ -1,0 +1,40 @@
+package networking
+
+import (
+	"testing"
+
+	apiprobe "github.com/aws/eks-node-monitoring-agent/api/probe"
+	"github.com/aws/eks-node-monitoring-agent/pkg/config"
+	"github.com/aws/eks-node-monitoring-agent/pkg/probe"
+)
+
+func TestProbeSpecs_EmptyOffAutoMode(t *testing.T) {
+	mon := NewNetworkingMonitor(WithRuntimeContext(&config.RuntimeContext{}))
+	if specs := mon.probeSpecs(); len(specs) != 0 {
+		t.Fatalf("expected no probes off Auto Mode, got %+v", specs)
+	}
+}
+
+func TestProbeSpecs_AutoModeIPAMDLiveness(t *testing.T) {
+	rc := &config.RuntimeContext{}
+	rc.AddTags(config.EKSAuto)
+	mon := NewNetworkingMonitor(WithRuntimeContext(rc))
+
+	specs := mon.probeSpecs()
+	if len(specs) != 1 {
+		t.Fatalf("expected exactly the IPAMD probe on Auto Mode, got %+v", specs)
+	}
+	spec := specs[0]
+	if spec.Subsystem != "ipamd" || spec.ReasonOnFail != "IPAMDNotRunning" {
+		t.Errorf("unexpected identity: %+v", spec)
+	}
+	if spec.Checks.Liveness.Transport != apiprobe.TransportSystemdDBus || spec.Checks.Liveness.Address != "ipamd.service" {
+		t.Errorf("unexpected liveness check: %+v", spec.Checks.Liveness)
+	}
+
+	// Every shipped spec must pass the same startup validation the runner
+	// applies, including the reason taxonomy lookup.
+	if err := probe.Validate(spec); err != nil {
+		t.Errorf("shipped probe spec is invalid: %v", err)
+	}
+}


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

Auto Mode IPAMD liveness is an inline D-Bus `ActiveState` query inside `handleIPAMD`, debounced by a fifteen-minute consistency window that exists to absorb noise from the DaemonSet path's process scan. On Auto Mode the query is deterministic and does not need that window, and recovery never restores `NetworkingReady` because nothing withdraws the reason.

Register the equivalent probe instead: systemd-dbus liveness of `ipamd.service` on a thirty-second interval, three consecutive failures, five-minute startup grace to tolerate the service coming up after the monitoring agent. Detection tightens from roughly five to fifteen minutes down to ninety seconds. The probe reuses the `IPAMDNotRunning` reason and inherits Fatal from the taxonomy, so customer auto-repair configuration keyed on that reason is unaffected, and recovery now restores the condition. What stays in `handleIPAMD` on Auto Mode is the checkpoint and CRI cross-check, which reads a file IPAMD wrote rather than asking the agent about itself. The DaemonSet path is untouched.

**Testing Done**:

A test asserts the Auto Mode spec shape (subsystem, reason, transport, address) and that the DaemonSet path registers no probe. The existing `IPAMDNotRunning` monitor test passes unchanged, covering the DaemonSet process-scan path. `make test`, `hack/check-generate.sh`, `gofmt -l` and `GOOS=linux CGO_ENABLED=1 go build ./...` are green on this branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.