### PR TITLE
feat(manager): Add per-component event budgets

### DIFF
--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -152,6 +152,12 @@ func run() error {
 		BaseContext:            func() context.Context { return ctx },
 		Metrics:                server.Options{BindAddress: controllerMetricsAddress},
 		PprofBindAddress:       controllerPprofAddress,
+		// Component-aware event correlation (aggregation keyed on the owning
+		// component; spam filter as a backstop above the exporter's own
+		// budgets). controller-runtime does not shut down a user-provided
+		// broadcaster; this one intentionally lives for the process
+		// lifetime.
+		EventBroadcaster: manager.NewEventBroadcaster(),
 	})
 	if err != nil {
 		logger.Error(err, "failed to create controller manager")

--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/aws/eks-node-monitoring-agent/pkg/diagnostic"
 	"github.com/aws/eks-node-monitoring-agent/pkg/manager"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/registry"
+	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
 
 	// Import monitor packages to trigger auto-registration via init()
 	_ "github.com/aws/eks-node-monitoring-agent/monitors/kernel"
@@ -344,6 +345,20 @@ func run() error {
 		// Initialize monitoring manager
 		logger.Info("initializing monitoring manager")
 		monitorMgr := manager.NewMonitorManager(hostname, nodeExporter)
+
+		// Every monitor name must be a declared component in reasons.yaml: the
+		// monitor name is the fallback event-budget key for reasons that cannot
+		// be resolved by name (parameterized templates render to unregistered
+		// strings), so an undeclared monitor would emit outside the component
+		// capacity ledger and break the derived node-ceiling arithmetic.
+		monitorNames := make([]string, 0, len(enabledMonitors))
+		for _, mon := range enabledMonitors {
+			monitorNames = append(monitorNames, mon.Name())
+		}
+		if err := reasons.ValidateMonitorComponents(monitorNames...); err != nil {
+			logger.Error(err, "monitor component validation failed")
+			return err
+		}
 
 		// Register all monitors with the manager
 		for _, mon := range enabledMonitors {

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/google/nftables v0.3.1-0.20251119083706-1db35da82052 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260216142805-b3301c5f2a88 // indirect
 	github.com/mdlayher/netlink v1.8.1-0.20251028132421-dcc6cab9a6eb // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect

--- a/pkg/manager/broadcaster.go
+++ b/pkg/manager/broadcaster.go
@@ -1,0 +1,52 @@
+package manager
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
+)
+
+// Backstop spam-filter budget: twice the derived node ceiling, so that after
+// the exporter's own shaping (which bounds emission to the ceiling per event
+// type) the correlator can never drop an event first. The client-go default
+// spam key is already node-scoped for this agent — one recorder source, one
+// involved object, keyed per event type — so the backstop needs no custom
+// key, and unlike a component-keyed spam filter it cannot be defeated by
+// aggregation rebuilding events without their annotations.
+const (
+	backstopEventBurst = 2 * reasons.MaxComponents * componentEventBurst
+	backstopEventQPS   = 2 * reasons.MaxComponents * componentEventQPS
+)
+
+// NewEventBroadcaster returns the event broadcaster for the agent's
+// recorders. It customizes only two correlator behaviors, leaving the rest
+// at client-go defaults:
+//
+//   - Aggregation groups per component: the default aggregation key would
+//     collapse distinct messages from different components under the same
+//     condition-type reason into one aggregate, swallowing the quieter
+//     component's messages. The component annotation is part of the key, so
+//     one component's chatter can only aggregate with itself. The key is
+//     computed from each incoming event, where the annotation is intact.
+//   - The spam filter becomes a generously sized backstop (see constants
+//     above). Budget enforcement lives in the exporter's eventLimiter, where
+//     the component is known and drops are observable; a correlator-level
+//     budget would drop silently.
+func NewEventBroadcaster() record.EventBroadcaster {
+	return record.NewBroadcasterWithCorrelatorOptions(record.CorrelatorOptions{
+		KeyFunc:   aggregationKeyFunc,
+		BurstSize: backstopEventBurst,
+		QPS:       backstopEventQPS,
+	})
+}
+
+// aggregationKeyFunc is the client-go default aggregation key plus the
+// owning-component annotation, so similar events aggregate only within
+// their component.
+func aggregationKeyFunc(event *corev1.Event) (string, string) {
+	aggregateKey, localKey := record.EventAggregatorByReasonFunc(event)
+	return strings.Join([]string{aggregateKey, event.Annotations[componentAnnotation]}, ""), localKey
+}

--- a/pkg/manager/broadcaster_test.go
+++ b/pkg/manager/broadcaster_test.go
@@ -1,0 +1,78 @@
+package manager
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// countingSink counts every event write the correlator lets through.
+type countingSink struct {
+	ops atomic.Int64
+}
+
+func (s *countingSink) Create(event *corev1.Event) (*corev1.Event, error) {
+	s.ops.Add(1)
+	return event, nil
+}
+
+func (s *countingSink) Update(event *corev1.Event) (*corev1.Event, error) {
+	s.ops.Add(1)
+	return event, nil
+}
+
+func (s *countingSink) Patch(event *corev1.Event, data []byte) (*corev1.Event, error) {
+	s.ops.Add(1)
+	return event, nil
+}
+
+// TestBroadcasterBackstopNeverFiresBelowExporterCeiling drives the real
+// client-go correlator, configured exactly as production, with worst-case
+// exporter-shaped traffic: every declared component bursting its full
+// per-type budget with distinct messages. The exporter's shaping bounds this
+// traffic to the node ceiling per event type, and the correlator's spam
+// filter is sized at twice that ceiling, so not one event may be skipped.
+//
+// This test is the designated tripwire for k8s.io/client-go bumps: the
+// backstop-sizing argument depends on correlator internals (default spam key
+// composition, aggregation before filtering) verified at v0.36.2. If a bump
+// changes them, this fails before production does.
+func TestBroadcasterBackstopNeverFiresBelowExporterCeiling(t *testing.T) {
+	sink := &countingSink{}
+	broadcaster := NewEventBroadcaster()
+	defer broadcaster.Shutdown()
+	watch := broadcaster.StartRecordingToSink(sink)
+	defer watch.Stop()
+
+	recorder := broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "eks-node-monitoring-agent"})
+	nodeRef := &corev1.ObjectReference{Kind: "Node", Name: "test-node", APIVersion: "v1"}
+
+	components := []string{"container-runtime", "ipamd", "kernel", "networking", "neuron", "npa", "nvidia", "storage", "diagnostics"}
+	emitted := 0
+	for _, component := range components {
+		for _, eventType := range []string{corev1.EventTypeWarning, corev1.EventTypeNormal} {
+			for i := 0; i < componentEventBurst; i++ {
+				recorder.AnnotatedEventf(nodeRef,
+					map[string]string{componentAnnotation: component},
+					eventType, "NetworkingReady", "SomeReason: distinct failure detail %d for %s", i, component)
+				emitted++
+			}
+		}
+	}
+
+	// Every emitted event must reach the sink as a create or patch; a
+	// shortfall means the correlator skipped events below the exporter's
+	// ceiling. The queue (1000) is comfortably above the emitted count, so
+	// queue drops cannot explain a shortfall either.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if int(sink.ops.Load()) == emitted {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("sink received %d of %d events within deadline: the correlator backstop dropped exporter-shaped traffic", sink.ops.Load(), emitted)
+}

--- a/pkg/manager/event_limits.go
+++ b/pkg/manager/event_limits.go
@@ -1,0 +1,112 @@
+package manager
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
+)
+
+// Per-component event quota Q: a 25-event burst refilled at one token per
+// 300 seconds (~12/hour), per node, per event type. The component — the
+// owning agent or monitor from the reasons.yaml ledger — is the unit of the
+// budget, so one flooding component starves only itself. These are working
+// numbers pending the scale test; see
+// .kiro/specs/probe-framework-event-limits-spec.md section 2.
+const (
+	componentEventBurst = 25
+	componentEventQPS   = 1.0 / 300.0
+)
+
+var (
+	eventsEmitted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "nma_events_emitted_total",
+			Help: "Events recorded to the Kubernetes API, per component and event type.",
+		},
+		[]string{"component", "type"},
+	)
+	eventsDropped = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "nma_events_dropped_total",
+			Help: "Events dropped by the per-component budget, per component and event type.",
+		},
+		[]string{"component", "type"},
+	)
+	eventsCeilingRejected = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "nma_events_node_ceiling_rejected_total",
+			Help: "Events rejected by the derived node-global ceiling. The ceiling equals the sum of the per-component budgets, so any rejection means an emitter bypassed the component buckets — alarm on it as a bug.",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		eventsEmitted,
+		eventsDropped,
+		eventsCeilingRejected,
+	)
+}
+
+// eventLimiter shapes event emission ahead of the recorder: one token bucket
+// per (component, event type) as the guaranteed budget, and one node-global
+// bucket per event type, derived as MaxComponents times the component quota,
+// as the bug detector. Enforcement lives here, in the exporter path, rather
+// than in the client-go correlator: the correlator's spam-filter key cannot
+// carry the component through aggregation (aggregated events are rebuilt
+// without annotations), and its drops are silent, while drops here are
+// observable per component.
+type eventLimiter struct {
+	mu sync.Mutex
+	// componentBuckets is keyed by component + "/" + event type. Keys are
+	// bounded: components are validated against the reasons.yaml ledger at
+	// startup, and event types are Normal or Warning.
+	componentBuckets map[string]flowcontrol.RateLimiter
+	// nodeBuckets is keyed by event type. Per type, the ceiling equals the
+	// sum of the per-component budgets by construction, so it cannot fill
+	// during legitimate operation.
+	nodeBuckets map[string]flowcontrol.RateLimiter
+}
+
+func newEventLimiter() *eventLimiter {
+	return &eventLimiter{
+		componentBuckets: make(map[string]flowcontrol.RateLimiter),
+		nodeBuckets:      make(map[string]flowcontrol.RateLimiter),
+	}
+}
+
+// allow reports whether one event of the given type may be recorded for the
+// component, consuming budget. Component-budget rejections increment the
+// per-component drop counter; node-ceiling rejections increment the
+// emitter-bug counter.
+func (l *eventLimiter) allow(component, eventType string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	bucket, ok := l.componentBuckets[component+"/"+eventType]
+	if !ok {
+		bucket = flowcontrol.NewTokenBucketRateLimiter(componentEventQPS, componentEventBurst)
+		l.componentBuckets[component+"/"+eventType] = bucket
+	}
+	if !bucket.TryAccept() {
+		eventsDropped.WithLabelValues(component, eventType).Inc()
+		return false
+	}
+
+	node, ok := l.nodeBuckets[eventType]
+	if !ok {
+		node = flowcontrol.NewTokenBucketRateLimiter(reasons.MaxComponents*componentEventQPS, reasons.MaxComponents*componentEventBurst)
+		l.nodeBuckets[eventType] = node
+	}
+	if !node.TryAccept() {
+		eventsCeilingRejected.Inc()
+		return false
+	}
+
+	eventsEmitted.WithLabelValues(component, eventType).Inc()
+	return true
+}

--- a/pkg/manager/event_limits_test.go
+++ b/pkg/manager/event_limits_test.go
@@ -1,0 +1,96 @@
+package manager
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestEventLimiter_ComponentIsolation is the acceptance test for the
+// per-component budget: one component at worst-case flap drains only its own
+// buckets, while another component's events still deliver immediately.
+func TestEventLimiter_ComponentIsolation(t *testing.T) {
+	l := newEventLimiter()
+
+	// Component A floods Warnings: the burst delivers, the excess drops.
+	delivered := 0
+	for i := 0; i < componentEventBurst+10; i++ {
+		if l.allow("ipamd", corev1.EventTypeWarning) {
+			delivered++
+		}
+	}
+	if delivered != componentEventBurst {
+		t.Errorf("flooding component delivered %d Warnings, want exactly the burst %d", delivered, componentEventBurst)
+	}
+
+	// A's Warning bucket is empty now.
+	if l.allow("ipamd", corev1.EventTypeWarning) {
+		t.Error("flooding component's Warning must be rejected after its burst is drained")
+	}
+
+	// A's Normal budget is a separate bucket and still delivers (recovery
+	// events must not compete with the failure Warnings).
+	if !l.allow("ipamd", corev1.EventTypeNormal) {
+		t.Error("flooding component's Normal bucket must be unaffected by its Warning flood")
+	}
+
+	// Component B is isolated: its Warning delivers immediately.
+	if !l.allow("npa", corev1.EventTypeWarning) {
+		t.Error("innocent component's Warning must deliver despite another component flooding")
+	}
+}
+
+// TestEventLimiter_NodeCeilingUnreachableThroughComponentBuckets pins the
+// bug-detector property: traffic that passes the per-component buckets can
+// never fill the per-type node ceiling, because the ceiling equals the sum
+// of the component budgets by construction.
+func TestEventLimiter_NodeCeilingUnreachableThroughComponentBuckets(t *testing.T) {
+	l := newEventLimiter()
+
+	// Worst case: every declared component bursts fully, both event types.
+	components := []string{"container-runtime", "ipamd", "kernel", "networking", "neuron", "npa", "nvidia", "storage", "diagnostics"}
+	for _, c := range components {
+		for _, eventType := range []string{corev1.EventTypeWarning, corev1.EventTypeNormal} {
+			for i := 0; i < componentEventBurst+10; i++ {
+				l.allow(c, eventType)
+			}
+		}
+	}
+	if got := testutil.ToFloat64(eventsCeilingRejected); got != 0 {
+		t.Errorf("node ceiling rejected %v events under component-shaped worst case, want 0 (ceiling firing means an emitter bypassed the buckets)", got)
+	}
+}
+
+// TestAggregationKeyFunc pins per-component aggregation: events differing
+// only in their component annotation must never share an aggregate key,
+// while events from the same component keep the default grouping.
+func TestAggregationKeyFunc(t *testing.T) {
+	event := func(component, message string) *corev1.Event {
+		return &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{componentAnnotation: component},
+			},
+			InvolvedObject: corev1.ObjectReference{Kind: "Node", Name: "test-node"},
+			Source:         corev1.EventSource{Component: "eks-node-monitoring-agent"},
+			Type:           corev1.EventTypeWarning,
+			Reason:         "NetworkingReady",
+			Message:        message,
+		}
+	}
+
+	ipamdKey, _ := aggregationKeyFunc(event("ipamd", "IPAMDNotReady: a"))
+	npaKey, _ := aggregationKeyFunc(event("npa", "NPANotRunning: b"))
+	if ipamdKey == npaKey {
+		t.Error("events from different components must not share an aggregate key")
+	}
+
+	ipamdKey2, localKey := aggregationKeyFunc(event("ipamd", "IPAMDNotReady: c"))
+	if ipamdKey != ipamdKey2 {
+		t.Error("events from the same component must share an aggregate key")
+	}
+	if localKey != "IPAMDNotReady: c" {
+		t.Errorf("local key must stay the default (the message), got %q", localKey)
+	}
+}

--- a/pkg/manager/exporter.go
+++ b/pkg/manager/exporter.go
@@ -8,13 +8,18 @@ import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 )
 
-// Exporter handles propagating conditions from monitors to external systems
+// Exporter handles propagating conditions from monitors to external systems.
+// The component parameter on the event-recording methods is the owning
+// component from the reasons.yaml ledger — the unit of the per-component
+// event budget. It is resolved by the manager (never self-declared by
+// monitors) from the condition's reason, falling back to the emitting
+// monitor's name for reasons that cannot be resolved by name.
 type Exporter interface {
 	// Info exports informational conditions
-	Info(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType) error
+	Info(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType, component string) error
 
 	// Warning exports warning conditions
-	Warning(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType) error
+	Warning(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType, component string) error
 
 	// Fatal exports fatal conditions
 	Fatal(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType) error
@@ -23,5 +28,5 @@ type Exporter interface {
 	// true when the node condition has returned to a healthy status, i.e.
 	// no other fatal reasons remain for it. Resolving a reason that was
 	// never reported is a no-op.
-	Resolve(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType) (bool, error)
+	Resolve(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType, component string) (bool, error)
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 	"github.com/aws/eks-node-monitoring-agent/api/monitor/resource"
 	"github.com/aws/eks-node-monitoring-agent/pkg/observer"
+	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
 )
 
 var (
@@ -138,7 +139,7 @@ func (m *MonitorManager) exportCondition(ctx context.Context, monitorName string
 	// path, bypassing MinOccurrences gating.
 	if condition.Resolved {
 		m.conditionCountMap[condition.Reason] = 0
-		recovered, err := m.exporter.Resolve(ctx, condition, conditionType)
+		recovered, err := m.exporter.Resolve(ctx, condition, conditionType, resolveComponent(monitorName, condition.Reason))
 		if err != nil {
 			return err
 		}
@@ -157,17 +158,39 @@ func (m *MonitorManager) exportCondition(ctx context.Context, monitorName string
 	}
 	m.conditionCountMap[condition.Reason] = 0
 
-	return m.SendCondition(ctx, condition, conditionType)
+	return m.sendCondition(ctx, condition, conditionType, monitorName)
 }
 
-// SendCondition sends a condition to the exporter based on severity
+// resolveComponent maps an emitted condition to its owning component — the
+// unit of the per-component event budget. The reasons.yaml ledger wins when
+// the emitted reason is registered; otherwise the component is the emitting
+// monitor's name (the common path for parameterized reasons, whose rendered
+// strings never match a registered identifier). Resolution lives here, in
+// the manager, so monitors cannot self-declare their budget identity.
+func resolveComponent(monitorName, reason string) string {
+	if meta, ok := reasons.ByName(reason); ok {
+		return meta.Component()
+	}
+	return monitorName
+}
+
+// SendCondition sends a condition to the exporter based on severity. The
+// component is resolved from the monitor name alone, so prefer the internal
+// path when a reason-specific component may apply.
 func (m *MonitorManager) SendCondition(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType) error {
+	return m.sendCondition(ctx, condition, conditionType, "")
+}
+
+// sendCondition routes a condition to the exporter based on severity,
+// resolving the owning component for the event-recording paths.
+func (m *MonitorManager) sendCondition(ctx context.Context, condition monitor.Condition, conditionType corev1.NodeConditionType, monitorName string) error {
 	log.FromContext(ctx).Info("sending condition to exporter", "condition", condition, "conditionType", conditionType)
+	component := resolveComponent(monitorName, condition.Reason)
 	switch condition.Severity {
 	case monitor.SeverityInfo:
-		return m.exporter.Info(ctx, condition, conditionType)
+		return m.exporter.Info(ctx, condition, conditionType, component)
 	case monitor.SeverityWarning:
-		return m.exporter.Warning(ctx, condition, conditionType)
+		return m.exporter.Warning(ctx, condition, conditionType, component)
 	case monitor.SeverityFatal:
 		for _, cType := range m.conditionTypeMap {
 			if conditionType == cType {

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -42,16 +42,16 @@ func (e *mockExporter) notify() error {
 	e.notifyChan <- struct{}{}
 	return nil
 }
-func (e *mockExporter) Info(context.Context, monitor.Condition, corev1.NodeConditionType) error {
+func (e *mockExporter) Info(context.Context, monitor.Condition, corev1.NodeConditionType, string) error {
 	return e.notify()
 }
-func (e *mockExporter) Warning(context.Context, monitor.Condition, corev1.NodeConditionType) error {
+func (e *mockExporter) Warning(context.Context, monitor.Condition, corev1.NodeConditionType, string) error {
 	return e.notify()
 }
 func (e *mockExporter) Fatal(context.Context, monitor.Condition, corev1.NodeConditionType) error {
 	return e.notify()
 }
-func (e *mockExporter) Resolve(_ context.Context, condition monitor.Condition, _ corev1.NodeConditionType) (bool, error) {
+func (e *mockExporter) Resolve(_ context.Context, condition monitor.Condition, _ corev1.NodeConditionType, _ string) (bool, error) {
 	if e.resolveChan != nil {
 		e.resolveChan <- condition
 	}

--- a/pkg/manager/node_exporter.go
+++ b/pkg/manager/node_exporter.go
@@ -46,6 +46,7 @@ func NewNodeExporter(
 		nodeKey:                client.ObjectKeyFromObject(node),
 		kubeClient:             kubeClient,
 		recorder:               recorder,
+		limiter:                newEventLimiter(),
 		managedConditions:      initializeManagedConditions(managedConditionConfigs),
 		managedConditionsDirty: true,
 		conditionConfigs:       managedConditionConfigs,
@@ -88,6 +89,7 @@ func initializeManagedConditions(conditionConfigs map[corev1.NodeConditionType]N
 type nodeExporter struct {
 	kubeClient client.Client
 	recorder   record.EventRecorder
+	limiter    *eventLimiter
 	nodeRef    *corev1.ObjectReference
 	nodeKey    client.ObjectKey
 
@@ -110,16 +112,34 @@ type fatalEntry struct {
 	message string
 }
 
-// Info records an event for the specified condition.
-func (e *nodeExporter) Info(ctx context.Context, c monitor.Condition, conditionType corev1.NodeConditionType) error {
-	e.recorder.Event(e.nodeRef, corev1.EventTypeNormal, string(conditionType), fmt.Sprintf("%s: %s", c.Reason, c.Message))
+// componentAnnotation carries the owning component on every event NMA
+// records. It exists for consumer filtering and for the custom aggregation
+// key; it is deliberately not the budget-enforcement key (see eventLimiter).
+const componentAnnotation = "eks.amazonaws.com/component"
+
+// Info records an event for the specified condition, subject to the
+// component's event budget. The event reason and message shape are
+// load-bearing (asserted by the E2E suite and filtered on by consumers) and
+// must not change; the component travels as an annotation.
+func (e *nodeExporter) Info(ctx context.Context, c monitor.Condition, conditionType corev1.NodeConditionType, component string) error {
+	e.recordEvent(component, corev1.EventTypeNormal, string(conditionType), fmt.Sprintf("%s: %s", c.Reason, c.Message))
 	return nil
 }
 
-// Warning records an event for the specified condition.
-func (e *nodeExporter) Warning(ctx context.Context, c monitor.Condition, conditionType corev1.NodeConditionType) error {
-	e.recorder.Event(e.nodeRef, corev1.EventTypeWarning, string(conditionType), fmt.Sprintf("%s: %s", c.Reason, c.Message))
+// Warning records an event for the specified condition, subject to the
+// component's event budget.
+func (e *nodeExporter) Warning(ctx context.Context, c monitor.Condition, conditionType corev1.NodeConditionType, component string) error {
+	e.recordEvent(component, corev1.EventTypeWarning, string(conditionType), fmt.Sprintf("%s: %s", c.Reason, c.Message))
 	return nil
+}
+
+// recordEvent applies the per-component budget and the derived node ceiling,
+// then records the event with the component annotation attached.
+func (e *nodeExporter) recordEvent(component, eventType, reason, message string) {
+	if !e.limiter.allow(component, eventType) {
+		return
+	}
+	e.recorder.AnnotatedEventf(e.nodeRef, map[string]string{componentAnnotation: component}, eventType, reason, "%s", message)
 }
 
 // Fatal updates the local state for the specified managed condition.
@@ -152,7 +172,7 @@ func (e *nodeExporter) Fatal(ctx context.Context, monitorCondition monitor.Condi
 // When the last reason is cleared, the condition is restored to its healthy
 // ready state. It returns true when the condition is healthy after the
 // resolution. Resolving a reason that was never reported is a no-op.
-func (e *nodeExporter) Resolve(ctx context.Context, monitorCondition monitor.Condition, conditionType corev1.NodeConditionType) (bool, error) {
+func (e *nodeExporter) Resolve(ctx context.Context, monitorCondition monitor.Condition, conditionType corev1.NodeConditionType, component string) (bool, error) {
 	e.managedConditionsLock.Lock()
 	defer e.managedConditionsLock.Unlock()
 
@@ -170,7 +190,7 @@ func (e *nodeExporter) Resolve(ctx context.Context, monitorCondition monitor.Con
 	}
 	e.fatalEntries[conditionType] = entries
 
-	e.recorder.Event(e.nodeRef, corev1.EventTypeNormal, string(conditionType),
+	e.recordEvent(component, corev1.EventTypeNormal, string(conditionType),
 		fmt.Sprintf("%s: the previously reported issue has been resolved", monitorCondition.Reason))
 
 	if len(entries) > 0 {

--- a/pkg/manager/node_exporter_test.go
+++ b/pkg/manager/node_exporter_test.go
@@ -33,6 +33,15 @@ func (r *fakeEventRecorder) Event(object runtime.Object, eventtype, reason, mess
 	})
 }
 
+func (r *fakeEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.events.Items = append(r.events.Items, corev1.Event{
+		ObjectMeta: v1.ObjectMeta{Annotations: annotations},
+		Type:       eventtype,
+		Reason:     reason,
+		Message:    fmt.Sprintf(messageFmt, args...),
+	})
+}
+
 func TestNodeExporter_EventsRecordedImmediately(t *testing.T) {
 	ctx := context.TODO()
 
@@ -76,10 +85,10 @@ func TestNodeExporter_EventsRecordedImmediately(t *testing.T) {
 		Reason:  "TestReason",
 		Message: "TestMessage",
 	}
-	if err := nodeExporter.Info(ctx, testCondition, testConditionType); err != nil {
+	if err := nodeExporter.Info(ctx, testCondition, testConditionType, "test-component"); err != nil {
 		t.Fatal(err)
 	}
-	if err := nodeExporter.Warning(ctx, testCondition, testConditionType); err != nil {
+	if err := nodeExporter.Warning(ctx, testCondition, testConditionType, "test-component"); err != nil {
 		t.Fatal(err)
 	}
 	for _, eventType := range []string{corev1.EventTypeNormal, corev1.EventTypeWarning} {
@@ -369,7 +378,7 @@ func TestNodeExporter_ResolveRestoresReadyState(t *testing.T) {
 	}
 
 	// Resolving an unrelated reason must not recover the condition.
-	recovered, err := nodeExporter.Resolve(ctx, monitor.Condition{Reason: "SomethingElse"}, conditionType)
+	recovered, err := nodeExporter.Resolve(ctx, monitor.Condition{Reason: "SomethingElse"}, conditionType, "test-component")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +387,7 @@ func TestNodeExporter_ResolveRestoresReadyState(t *testing.T) {
 	}
 
 	// Resolving the failing reason restores the ready state.
-	recovered, err = nodeExporter.Resolve(ctx, monitor.Condition{Reason: "IPAMDNotRunning"}, conditionType)
+	recovered, err = nodeExporter.Resolve(ctx, monitor.Condition{Reason: "IPAMDNotRunning"}, conditionType, "test-component")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -444,7 +453,7 @@ func TestNodeExporter_ResolveKeepsConditionFalseWhileOtherReasonsRemain(t *testi
 		t.Fatal(err)
 	}
 
-	recovered, err := nodeExporter.Resolve(ctx, monitor.Condition{Reason: "ErrorA"}, conditionType)
+	recovered, err := nodeExporter.Resolve(ctx, monitor.Condition{Reason: "ErrorA"}, conditionType, "test-component")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/reasons/lookup_test.go
+++ b/pkg/reasons/lookup_test.go
@@ -1,6 +1,7 @@
 package reasons
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -9,13 +10,19 @@ import (
 
 func TestByName(t *testing.T) {
 	tests := []struct {
-		name         string
-		wantOK       bool
-		wantSeverity monitor.Severity
+		name          string
+		wantOK        bool
+		wantSeverity  monitor.Severity
+		wantComponent string
 	}{
-		{name: "IPAMDNotRunning", wantOK: true, wantSeverity: monitor.SeverityFatal},
-		{name: "NPARepeatedlyRestart", wantOK: true, wantSeverity: monitor.SeverityWarning},
-		{name: "LargeEnvironment", wantOK: true, wantSeverity: monitor.SeverityWarning},
+		{name: "IPAMDNotRunning", wantOK: true, wantSeverity: monitor.SeverityFatal, wantComponent: "ipamd"},
+		{name: "NPARepeatedlyRestart", wantOK: true, wantSeverity: monitor.SeverityWarning, wantComponent: "npa"},
+		{name: "LargeEnvironment", wantOK: true, wantSeverity: monitor.SeverityWarning, wantComponent: "kernel"},
+		{name: "InterfaceNotUp", wantOK: true, wantSeverity: monitor.SeverityFatal, wantComponent: "networking"},
+		{name: "NvidiaXIDError", wantOK: true, wantSeverity: monitor.SeverityFatal, wantComponent: "nvidia"},
+		{name: "NeuronDMAError", wantOK: true, wantSeverity: monitor.SeverityFatal, wantComponent: "neuron"},
+		{name: "RepeatedRestart", wantOK: true, wantSeverity: monitor.SeverityWarning, wantComponent: "container-runtime"},
+		{name: "IODelays", wantOK: true, wantSeverity: monitor.SeverityWarning, wantComponent: "storage"},
 		{name: "NoSuchReason", wantOK: false},
 		{name: "", wantOK: false},
 	}
@@ -31,7 +38,41 @@ func TestByName(t *testing.T) {
 			if got := meta.DefaultSeverity(); got != tt.wantSeverity {
 				t.Errorf("ByName(%q).DefaultSeverity() = %q, want %q", tt.name, got, tt.wantSeverity)
 			}
+			if got := meta.Component(); got != tt.wantComponent {
+				t.Errorf("ByName(%q).Component() = %q, want %q", tt.name, got, tt.wantComponent)
+			}
 		})
+	}
+}
+
+func TestComponents(t *testing.T) {
+	want := []string{"container-runtime", "ipamd", "kernel", "networking", "neuron", "npa", "nvidia", "storage"}
+	got := Components()
+	if !slices.Equal(got, want) {
+		t.Errorf("Components() = %v, want %v", got, want)
+	}
+	for _, c := range want {
+		if !IsComponent(c) {
+			t.Errorf("IsComponent(%q) = false, want true", c)
+		}
+	}
+	if IsComponent("mock") {
+		t.Error(`IsComponent("mock") = true, want false`)
+	}
+}
+
+func TestValidateMonitorComponents(t *testing.T) {
+	// The production monitor names must all be declared components; this is
+	// the same check main.go runs at startup.
+	if err := ValidateMonitorComponents("kernel", "networking", "storage", "container-runtime", "nvidia", "neuron"); err != nil {
+		t.Errorf("production monitor names must validate, got %v", err)
+	}
+	err := ValidateMonitorComponents("kernel", "not-a-component")
+	if err == nil {
+		t.Fatal("expected error for undeclared monitor name")
+	}
+	if !strings.Contains(err.Error(), "not-a-component") || !strings.Contains(err.Error(), "reasons.yaml") {
+		t.Errorf("error should name the offender and the ledger, got %q", err.Error())
 	}
 }
 

--- a/pkg/reasons/meta.go
+++ b/pkg/reasons/meta.go
@@ -4,6 +4,7 @@ package reasons
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 )
@@ -11,15 +12,58 @@ import (
 type ReasonMeta struct {
 	template        string
 	defaultSeverity monitor.Severity
+	component       string
 }
 
 // ByName returns the ReasonMeta registered under the given identifier from
 // reasons.yaml, and whether such a reason exists. It allows configuration
 // that references reasons by name (e.g. probe specs) to be validated against
 // the registered taxonomy at startup.
+//
+// Note that emitted condition reasons are rendered templates: for
+// parameterized reasons (e.g. "NvidiaXID%dError") the rendered string never
+// matches a registered identifier, so callers resolving metadata from an
+// emitted reason must handle a miss.
 func ByName(name string) (ReasonMeta, bool) {
 	m, ok := byName[name]
 	return m, ok
+}
+
+// Components returns the distinct component names declared in reasons.yaml,
+// sorted. A component is the owning agent or monitor of a set of reasons and
+// is the unit of the per-component event budget.
+func Components() []string {
+	out := make([]string, 0, len(components))
+	for c := range components {
+		out = append(out, c)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// IsComponent reports whether name is a component declared in reasons.yaml.
+func IsComponent(name string) bool {
+	_, ok := components[name]
+	return ok
+}
+
+// ValidateMonitorComponents checks that every given monitor name is a
+// declared component in reasons.yaml. Monitor names are the fallback budget
+// key for reasons that cannot be resolved through ByName (parameterized
+// templates render to unregistered strings), so an undeclared monitor would
+// emit outside the capacity ledger and break the derived node-ceiling
+// arithmetic. Call it at startup and fail loudly on error.
+func ValidateMonitorComponents(names ...string) error {
+	var unknown []string
+	for _, n := range names {
+		if !IsComponent(n) {
+			unknown = append(unknown, n)
+		}
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("monitors %v are not declared components in pkg/reasons/reasons.yaml; add Component entries for their reasons (see .kiro/specs/probe-framework-event-limits-spec.md section 3.2)", unknown)
+	}
+	return nil
 }
 
 // Template returns the reason template string as declared in reasons.yaml.
@@ -32,6 +76,12 @@ func (r ReasonMeta) Template() string {
 // DefaultSeverity returns the severity assigned to the reason in reasons.yaml.
 func (r ReasonMeta) DefaultSeverity() monitor.Severity {
 	return r.defaultSeverity
+}
+
+// Component returns the owning component of the reason as declared in
+// reasons.yaml — the unit of the per-component event budget.
+func (r ReasonMeta) Component() string {
+	return r.component
 }
 
 func (r ReasonMeta) Builder(templateArgs ...any) ConditionBuilder {

--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -489,3 +489,9 @@ var components = map[string]struct{}{
 	"nvidia":            {},
 	"storage":           {},
 }
+
+// MaxComponents is N, the declared platform capacity for event-budget
+// components, mirrored from the capacity ledger in tools/codegen-reasons.
+// The node-global event ceiling is derived as N times the per-component
+// quota and must never be tuned independently.
+const MaxComponents = 10

--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -9,86 +9,107 @@ var (
 	DCGMDiagnosticFailure = ReasonMeta{
 		template:        "DCGMDiagnosticFailure",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	DCGMError = ReasonMeta{
 		template:        "DCGMError",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	DCGMFieldError = ReasonMeta{
 		template:        "DCGMFieldError%d",
 		defaultSeverity: "Warning",
+		component:       "nvidia",
 	}
 	DCGMHealthCode = ReasonMeta{
 		template:        "DCGMHealthCode%d",
 		defaultSeverity: "Warning",
+		component:       "nvidia",
 	}
 	DCGMHealthCodeFatal = ReasonMeta{
 		template:        "DCGMHealthCode%d",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	FabricManagerNotRunning = ReasonMeta{
 		template:        "FabricManagerNotRunning",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	NeuronDMAError = ReasonMeta{
 		template:        "NeuronDMAError",
 		defaultSeverity: "Fatal",
+		component:       "neuron",
 	}
 	NeuronHBMUncorrectableError = ReasonMeta{
 		template:        "NeuronHBMUncorrectableError",
 		defaultSeverity: "Fatal",
+		component:       "neuron",
 	}
 	NeuronNCUncorrectableError = ReasonMeta{
 		template:        "NeuronNCUncorrectableError",
 		defaultSeverity: "Fatal",
+		component:       "neuron",
 	}
 	NeuronSRAMUncorrectableError = ReasonMeta{
 		template:        "NeuronSRAMUncorrectableError",
 		defaultSeverity: "Fatal",
+		component:       "neuron",
 	}
 	NvidiaDeviceCountMismatch = ReasonMeta{
 		template:        "NvidiaDeviceCountMismatch",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	NvidiaDoubleBitError = ReasonMeta{
 		template:        "NvidiaDoubleBitError",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	NvidiaFabricError = ReasonMeta{
 		template:        "NvidiaFabricError",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	NvidiaNCCLError = ReasonMeta{
 		template:        "NvidiaNCCLError",
 		defaultSeverity: "Warning",
+		component:       "nvidia",
 	}
 	NvidiaNVLinkError = ReasonMeta{
 		template:        "NvidiaNVLinkError",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	NvidiaPCIeError = ReasonMeta{
 		template:        "NvidiaPCIeError",
 		defaultSeverity: "Warning",
+		component:       "nvidia",
 	}
 	NvidiaPageRetirement = ReasonMeta{
 		template:        "NvidiaPageRetirement",
 		defaultSeverity: "Warning",
+		component:       "nvidia",
 	}
 	NvidiaPowerError = ReasonMeta{
 		template:        "NvidiaPowerError",
 		defaultSeverity: "Warning",
+		component:       "nvidia",
 	}
 	NvidiaThermalError = ReasonMeta{
 		template:        "NvidiaThermalError",
 		defaultSeverity: "Warning",
+		component:       "nvidia",
 	}
 	NvidiaXIDError = ReasonMeta{
 		template:        "NvidiaXID%dError",
 		defaultSeverity: "Fatal",
+		component:       "nvidia",
 	}
 	NvidiaXIDWarning = ReasonMeta{
 		template:        "NvidiaXID%dWarning",
 		defaultSeverity: "Warning",
+		component:       "nvidia",
 	}
 
 	// reasons for the ContainerRuntimeReady condition.
@@ -96,34 +117,42 @@ var (
 	ContainerRuntimeFailed = ReasonMeta{
 		template:        "ContainerRuntimeFailed",
 		defaultSeverity: "Warning",
+		component:       "container-runtime",
 	}
 	DeprecatedContainerdConfiguration = ReasonMeta{
 		template:        "DeprecatedContainerdConfiguration",
 		defaultSeverity: "Warning",
+		component:       "container-runtime",
 	}
 	KubeletFailed = ReasonMeta{
 		template:        "KubeletFailed",
 		defaultSeverity: "Warning",
+		component:       "container-runtime",
 	}
 	LivenessProbeFailures = ReasonMeta{
 		template:        "LivenessProbeFailures",
 		defaultSeverity: "Warning",
+		component:       "container-runtime",
 	}
 	PodStuckTerminating = ReasonMeta{
 		template:        "PodStuckTerminating",
 		defaultSeverity: "Fatal",
+		component:       "container-runtime",
 	}
 	ReadinessProbeFailures = ReasonMeta{
 		template:        "ReadinessProbeFailures",
 		defaultSeverity: "Warning",
+		component:       "container-runtime",
 	}
 	RepeatedRestart = ReasonMeta{
 		template:        "%sRepeatedRestart",
 		defaultSeverity: "Warning",
+		component:       "container-runtime",
 	}
 	ServiceFailedToStart = ReasonMeta{
 		template:        "ServiceFailedToStart",
 		defaultSeverity: "Warning",
+		component:       "container-runtime",
 	}
 
 	// reasons for the KernelReady condition.
@@ -131,50 +160,62 @@ var (
 	AppBlocked = ReasonMeta{
 		template:        "AppBlocked",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	AppCrash = ReasonMeta{
 		template:        "AppCrash",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	ApproachingKernelPidMax = ReasonMeta{
 		template:        "ApproachingKernelPidMax",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	ApproachingMaxOpenFiles = ReasonMeta{
 		template:        "ApproachingMaxOpenFiles",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	ClockUnsynchronized = ReasonMeta{
 		template:        "ClockUnsynchronized",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	ConntrackExceededKernel = ReasonMeta{
 		template:        "ConntrackExceededKernel",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	ExcessiveZombieProcesses = ReasonMeta{
 		template:        "ExcessiveZombieProcesses",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	ForkFailedOutOfPIDs = ReasonMeta{
 		template:        "ForkFailedOutOfPIDs",
 		defaultSeverity: "Fatal",
+		component:       "kernel",
 	}
 	KernelBug = ReasonMeta{
 		template:        "KernelBug",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	LargeEnvironment = ReasonMeta{
 		template:        "LargeEnvironment",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	RapidCron = ReasonMeta{
 		template:        "RapidCron",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 	SoftLockup = ReasonMeta{
 		template:        "SoftLockup",
 		defaultSeverity: "Warning",
+		component:       "kernel",
 	}
 
 	// reasons for the NetworkingReady condition.
@@ -182,102 +223,127 @@ var (
 	BandwidthInExceeded = ReasonMeta{
 		template:        "BandwidthInExceeded",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	BandwidthOutExceeded = ReasonMeta{
 		template:        "BandwidthOutExceeded",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	ConntrackExceeded = ReasonMeta{
 		template:        "ConntrackExceeded",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	EFAErrorMetric = ReasonMeta{
 		template:        "EFAErrorMetric",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	IPAMDInconsistentState = ReasonMeta{
 		template:        "IPAMDInconsistentState",
 		defaultSeverity: "Warning",
+		component:       "ipamd",
 	}
 	IPAMDNoIPs = ReasonMeta{
 		template:        "IPAMDNoIPs",
 		defaultSeverity: "Warning",
+		component:       "ipamd",
 	}
 	IPAMDNotReady = ReasonMeta{
 		template:        "IPAMDNotReady",
 		defaultSeverity: "Fatal",
+		component:       "ipamd",
 	}
 	IPAMDNotRunning = ReasonMeta{
 		template:        "IPAMDNotRunning",
 		defaultSeverity: "Fatal",
+		component:       "ipamd",
 	}
 	IPAMDRepeatedlyRestart = ReasonMeta{
 		template:        "IPAMDRepeatedlyRestart",
 		defaultSeverity: "Warning",
+		component:       "ipamd",
 	}
 	InterfaceNotRunning = ReasonMeta{
 		template:        "InterfaceNotRunning",
 		defaultSeverity: "Fatal",
+		component:       "networking",
 	}
 	InterfaceNotUp = ReasonMeta{
 		template:        "InterfaceNotUp",
 		defaultSeverity: "Fatal",
+		component:       "networking",
 	}
 	KubeProxyNotReady = ReasonMeta{
 		template:        "KubeProxyNotReady",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	LinkLocalExceeded = ReasonMeta{
 		template:        "LinkLocalExceeded",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	MACAddressPolicyMisconfigured = ReasonMeta{
 		template:        "MACAddressPolicyMisconfigured",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	MissingDefaultRoutes = ReasonMeta{
 		template:        "MissingDefaultRoutes",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	MissingIPRoutes = ReasonMeta{
 		template:        "MissingIPRoutes",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	MissingIPRules = ReasonMeta{
 		template:        "MissingIPRules",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	MissingLoopbackInterface = ReasonMeta{
 		template:        "MissingLoopbackInterface",
 		defaultSeverity: "Fatal",
+		component:       "networking",
 	}
 	NPABPFRecoveryError = ReasonMeta{
 		template:        "NPABPFRecoveryError",
 		defaultSeverity: "Warning",
+		component:       "npa",
 	}
 	NPANotRunning = ReasonMeta{
 		template:        "NPANotRunning",
 		defaultSeverity: "Fatal",
+		component:       "npa",
 	}
 	NPARepeatedlyRestart = ReasonMeta{
 		template:        "NPARepeatedlyRestart",
 		defaultSeverity: "Warning",
+		component:       "npa",
 	}
 	NetworkSysctl = ReasonMeta{
 		template:        "NetworkSysctl",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	PPSExceeded = ReasonMeta{
 		template:        "PPSExceeded",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	PortConflict = ReasonMeta{
 		template:        "PortConflict",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 	UnexpectedRejectRule = ReasonMeta{
 		template:        "UnexpectedRejectRule",
 		defaultSeverity: "Warning",
+		component:       "networking",
 	}
 
 	// reasons for the StorageReady condition.
@@ -285,38 +351,47 @@ var (
 	BlockDeviceIOError = ReasonMeta{
 		template:        "BlockDeviceIOError",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 	EBSInstanceIOPSExceeded = ReasonMeta{
 		template:        "EBSInstanceIOPSExceeded",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 	EBSInstanceThroughputExceeded = ReasonMeta{
 		template:        "EBSInstanceThroughputExceeded",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 	EBSVolumeIOPSExceeded = ReasonMeta{
 		template:        "EBSVolumeIOPSExceeded",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 	EBSVolumeThroughputExceeded = ReasonMeta{
 		template:        "EBSVolumeThroughputExceeded",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 	EtcHostsMountFailed = ReasonMeta{
 		template:        "EtcHostsMountFailed",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 	IODelays = ReasonMeta{
 		template:        "IODelays",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 	KubeletDiskUsageSlow = ReasonMeta{
 		template:        "KubeletDiskUsageSlow",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 	XFSSmallAverageClusterSize = ReasonMeta{
 		template:        "XFSSmallAverageClusterSize",
 		defaultSeverity: "Warning",
+		component:       "storage",
 	}
 )
 
@@ -399,4 +474,18 @@ var byName = map[string]ReasonMeta{
 	"IODelays":                          IODelays,
 	"KubeletDiskUsageSlow":              KubeletDiskUsageSlow,
 	"XFSSmallAverageClusterSize":        XFSSmallAverageClusterSize,
+}
+
+// components is the distinct set of event-budget components declared in
+// reasons.yaml. Together with the platform-reserved slots it is bounded by
+// the capacity ledger in tools/codegen-reasons.
+var components = map[string]struct{}{
+	"container-runtime": {},
+	"ipamd":             {},
+	"kernel":            {},
+	"networking":        {},
+	"neuron":            {},
+	"npa":               {},
+	"nvidia":            {},
+	"storage":           {},
 }

--- a/pkg/reasons/reasons.go.tpl
+++ b/pkg/reasons/reasons.go.tpl
@@ -35,3 +35,9 @@ var components = map[string]struct{}{
     "{{$component}}": {},
 {{- end }}
 }
+
+// MaxComponents is N, the declared platform capacity for event-budget
+// components, mirrored from the capacity ledger in tools/codegen-reasons.
+// The node-global event ceiling is derived as N times the per-component
+// quota and must never be tuned independently.
+const MaxComponents = {{ .MaxComponents }}

--- a/pkg/reasons/reasons.go.tpl
+++ b/pkg/reasons/reasons.go.tpl
@@ -3,13 +3,14 @@
 package reasons
 
 var (
-{{- range $condition, $reasons := . }}
+{{- range $condition, $reasons := .Conditions }}
 
     // reasons for the {{$condition}} condition.
 {{ range $reasonName, $reason := $reasons }}
     {{$reasonName}} = ReasonMeta{
         template:        "{{$reason.Template}}",
         defaultSeverity: "{{$reason.DefaultSeverity}}",
+        component:       "{{$reason.Component}}",
     }
 {{- end -}}
 {{- end -}}
@@ -19,9 +20,18 @@ var (
 // metadata. It backs the ByName lookup used to validate configuration that
 // references reasons by name.
 var byName = map[string]ReasonMeta{
-{{- range $condition, $reasons := . }}
+{{- range $condition, $reasons := .Conditions }}
 {{- range $reasonName, $reason := $reasons }}
     "{{$reasonName}}": {{$reasonName}},
 {{- end -}}
+{{- end }}
+}
+
+// components is the distinct set of event-budget components declared in
+// reasons.yaml. Together with the platform-reserved slots it is bounded by
+// the capacity ledger in tools/codegen-reasons.
+var components = map[string]struct{}{
+{{- range $component := .Components }}
+    "{{$component}}": {},
 {{- end }}
 }

--- a/pkg/reasons/reasons.yaml
+++ b/pkg/reasons/reasons.yaml
@@ -4,6 +4,7 @@ KernelReady:
   LargeEnvironment:
     Template: 'LargeEnvironment'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       The number of environment variables for this process is larger than
       expected, potentially caused by many services with `enableServiceLinks` set
@@ -11,28 +12,33 @@ KernelReady:
   RapidCron:
     Template: 'RapidCron'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       A cron job is running faster than every five minutes on this node, which
       may impact performance if the job consumes significant resources.
   SoftLockup:
     Template: 'SoftLockup'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       The CPU stalled for a given amount of time.
   AppBlocked:
     Template: 'AppBlocked'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       The task has been blocked for a long period of time from scheduling,
       usually caused by being blocked on input or output.
   AppCrash:
     Template: 'AppCrash'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       An application on the node has crashed.
   ApproachingKernelPidMax:
     Template: 'ApproachingKernelPidMax'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       The number of processes is approaching the maximum number of PIDs that are
       available per the current `kernel.pid_max` setting, after which no more
@@ -40,6 +46,7 @@ KernelReady:
   ApproachingMaxOpenFiles:
     Template: 'ApproachingMaxOpenFiles'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       The number of open files is approaching the maximum number of possible
       open files given the current kernel settings, after which opening new
@@ -47,6 +54,7 @@ KernelReady:
   ClockUnsynchronized:
     Template: 'ClockUnsynchronized'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       The kernel clock is not being disciplined by any time source. This is
       detected via `adjtimex(2)` reporting the `STA_UNSYNC` status flag and is
@@ -55,12 +63,14 @@ KernelReady:
   ConntrackExceededKernel:
     Template: 'ConntrackExceededKernel'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       Connection tracking exceeded the maximum for the kernel and new
       connections could not be established, which can result in packet loss.
   ExcessiveZombieProcesses:
     Template: 'ExcessiveZombieProcesses'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       Processes which can't be fully reclaimed are accumulating in large
       numbers, which indicates application issues and may lead to reaching
@@ -68,6 +78,7 @@ KernelReady:
   ForkFailedOutOfPIDs:
     Template: 'ForkFailedOutOfPIDs'
     DefaultSeverity: 'Fatal'
+    Component: 'kernel'
     Description: >-
       A fork or exec call has failed due to the system being out of process IDs
       or memory, which may be caused by zombie processes or physical memory
@@ -75,6 +86,7 @@ KernelReady:
   KernelBug:
     Template: 'KernelBug'
     DefaultSeverity: 'Warning'
+    Component: 'kernel'
     Description: >-
       A kernel bug was detected and reported by the Linux kernel itself, though
       this may sometimes be caused by nodes with high CPU or memory usage
@@ -83,45 +95,53 @@ ContainerRuntimeReady:
   KubeletFailed:
     Template: 'KubeletFailed'
     DefaultSeverity: 'Warning'
+    Component: 'container-runtime'
     Description: >-
       The kubelet entered a failed state.
   LivenessProbeFailures:
     Template: 'LivenessProbeFailures'
     DefaultSeverity: 'Warning'
+    Component: 'container-runtime'
     Description: >-
       A liveness probe failure was detected, potentially indicating application
       code issues or insufficient timeout values if occurring repeatedly.
   PodStuckTerminating:
     Template: 'PodStuckTerminating'
     DefaultSeverity: 'Fatal'
+    Component: 'container-runtime'
     Description: >-
       A Pod is or was stuck terminating for an excessive amount of time, which
       can be caused by CRI errors preventing pod state progression.
   ReadinessProbeFailures:
     Template: 'ReadinessProbeFailures'
     DefaultSeverity: 'Warning'
+    Component: 'container-runtime'
     Description: >-
       A readiness probe failure was detected, potentially indicating application
       code issues or insufficient timeout values if occurring repeatedly.
   RepeatedRestart:
     Template: '%sRepeatedRestart'
     DefaultSeverity: 'Warning'
+    Component: 'container-runtime'
     Description: >-
       A systemd unit is restarting frequently.
   ServiceFailedToStart:
     Template: 'ServiceFailedToStart'
     DefaultSeverity: 'Warning'
+    Component: 'container-runtime'
     Description: >-
       A systemd unit failed to start.
   ContainerRuntimeFailed:
     Template: 'ContainerRuntimeFailed'
     DefaultSeverity: 'Warning'
+    Component: 'container-runtime'
     Description: >-
       The container runtime has failed to create a container, likely related to
       any reported issues if occurring repeatedly.
   DeprecatedContainerdConfiguration:
     Template: 'DeprecatedContainerdConfiguration'
     DefaultSeverity: 'Warning'
+    Component: 'container-runtime'
     Description: >-
       A container image using deprecated image manifest version 2, schema 1 was
       recently pulled onto the node through `containerd`.
@@ -129,49 +149,58 @@ NetworkingReady:
   MACAddressPolicyMisconfigured:
     Template: 'MACAddressPolicyMisconfigured'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       The systemd-networkd link configuration has the incorrect
       `MACAddressPolicy` value.
   MissingDefaultRoutes:
     Template: 'MissingDefaultRoutes'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       There are missing default route rules.
   MissingIPRoutes:
     Template: 'MissingIPRoutes'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       There are missing routes for Pod IPs.
   MissingIPRules:
     Template: 'MissingIPRules'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       There are missing rules for Pod IPs.
   MissingLoopbackInterface:
     Template: 'MissingLoopbackInterface'
     DefaultSeverity: 'Fatal'
+    Component: 'networking'
     Description: >-
       The loopback interface is missing from this instance, causing failure of
       services depending on local connectivity.
   NetworkSysctl:
     Template: 'NetworkSysctl'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       This node's network `sysctl` settings are potentially incorrect.
   PPSExceeded:
     Template: 'PPSExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       Packets have been queued or dropped because the bidirectional PPS exceeded
       the maximum for the instance.
   KubeProxyNotReady:
     Template: 'KubeProxyNotReady'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       Kube-proxy failed to watch or list resources.
   PortConflict:
     Template: 'PortConflict'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       If a Pod uses hostPort, it can write `iptables` rules that override the
       host's already bound ports, potentially preventing API server access to
@@ -179,6 +208,7 @@ NetworkingReady:
   UnexpectedRejectRule:
     Template: 'UnexpectedRejectRule'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       An unexpected `REJECT` or `DROP` rule was found in the `iptables`,
       potentially blocking expected traffic. To suppress this for known-good
@@ -189,56 +219,66 @@ NetworkingReady:
   LinkLocalExceeded:
     Template: 'LinkLocalExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       Packets were dropped because the PPS of traffic to local proxy services
       exceeded the network interface maximum.
   BandwidthInExceeded:
     Template: 'BandwidthInExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       Packets have been queued or dropped because the inbound aggregate
       bandwidth exceeded the maximum for the instance.
   BandwidthOutExceeded:
     Template: 'BandwidthOutExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       Packets have been queued or dropped because the outbound aggregate
       bandwidth exceeded the maximum for the instance.
   ConntrackExceeded:
     Template: 'ConntrackExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       Connection tracking exceeded the maximum for the instance and new
       connections could not be established, which can result in packet loss.
   IPAMDInconsistentState:
     Template: 'IPAMDInconsistentState'
     DefaultSeverity: 'Warning'
+    Component: 'ipamd'
     Description: >-
       The state of the IPAMD checkpoint on disk does not reflect the IPs in the
       container runtime.
   IPAMDNoIPs:
     Template: 'IPAMDNoIPs'
     DefaultSeverity: 'Warning'
+    Component: 'ipamd'
     Description: >-
       IPAMD is out of IP addresses.
   IPAMDNotReady:
     Template: 'IPAMDNotReady'
     DefaultSeverity: 'Fatal'
+    Component: 'ipamd'
     Description: >-
       IPAMD fails to connect to the API server.
   IPAMDNotRunning:
     Template: 'IPAMDNotRunning'
     DefaultSeverity: 'Fatal'
+    Component: 'ipamd'
     Description: >-
       The Amazon VPC CNI process was not found to be running.
   IPAMDRepeatedlyRestart:
     Template: 'IPAMDRepeatedlyRestart'
     DefaultSeverity: 'Warning'
+    Component: 'ipamd'
     Description: >-
       Multiple restarts in the IPAMD service have occurred.
   InterfaceNotRunning:
     Template: 'InterfaceNotRunning'
     DefaultSeverity: 'Fatal'
+    Component: 'networking'
     Description: >-
       This interface appears to not be running or there are network issues. To
       suppress this for known non-node-networking interfaces (e.g. IPoIB
@@ -248,6 +288,7 @@ NetworkingReady:
   InterfaceNotUp:
     Template: 'InterfaceNotUp'
     DefaultSeverity: 'Fatal'
+    Component: 'networking'
     Description: >-
       This interface appears to not be up or there are network issues. To
       suppress this for known non-node-networking interfaces (e.g. IPoIB
@@ -257,6 +298,7 @@ NetworkingReady:
   NPARepeatedlyRestart:
     Template: 'NPARepeatedlyRestart'
     DefaultSeverity: 'Warning'
+    Component: 'npa'
     Description: >-
       The Network Policy Agent has restarted 5 or more times within a single
       poll interval, indicating a crash loop that may disrupt network policy
@@ -266,12 +308,14 @@ NetworkingReady:
   NPANotRunning:
     Template: 'NPANotRunning'
     DefaultSeverity: 'Fatal'
+    Component: 'npa'
     Description: >-
       The Network Policy Agent process was not found running on this
       Auto Mode node for more than 15 minutes.
   NPABPFRecoveryError:
     Template: 'NPABPFRecoveryError'
     DefaultSeverity: 'Warning'
+    Component: 'npa'
     Description: >-
       The Network Policy Agent encountered errors recovering or loading its
       BPF programs/maps after a restart. This is typically self-healing as the
@@ -280,63 +324,75 @@ NetworkingReady:
   EFAErrorMetric:
     Template: 'EFAErrorMetric'
     DefaultSeverity: 'Warning'
+    Component: 'networking'
     Description: >-
       EFA driver metrics shows there is an interface with performance degredation.
 AcceleratedHardwareReady:
   DCGMDiagnosticFailure:
     Template: 'DCGMDiagnosticFailure'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       A test case from the DCGM active diagnostics test suite failed.
   DCGMError:
     Template: 'DCGMError'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       Connection to the DCGM host process was lost or could not be established.
   DCGMFieldError:
     Template: 'DCGMFieldError%d'
     DefaultSeverity: 'Warning'
+    Component: 'nvidia'
     Description: >-
       DCGM detected GPU degredation through a field identifier.
   DCGMHealthCode:
     Template: 'DCGMHealthCode%d'
     DefaultSeverity: 'Warning'
+    Component: 'nvidia'
     Description: >-
       A DCGM health check failed in a non-fatal manner.
   DCGMHealthCodeFatal:
     Template: 'DCGMHealthCode%d'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       A DCGM health check failed in a fatal manner.
   NvidiaDeviceCountMismatch:
     Template: 'NvidiaDeviceCountMismatch'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       The number of GPUs detected on the node does not match the expected count,
       which indicates hardware failure or driver issues requiring investigation.
   NvidiaDoubleBitError:
     Template: 'NvidiaDoubleBitError'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       A double bit error was produced by the GPU driver.
   NvidiaNCCLError:
     Template: 'NvidiaNCCLError'
     DefaultSeverity: 'Warning'
+    Component: 'nvidia'
     Description: >-
       A segfault occurred in the NVIDIA Collective Communications library (`libnccl`).
   NvidiaNVLinkError:
     Template: 'NvidiaNVLinkError'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       NVLink errors were reported by the GPU driver.
   NvidiaPCIeError:
     Template: 'NvidiaPCIeError'
     DefaultSeverity: 'Warning'
+    Component: 'nvidia'
     Description: >-
       PCIe replays were triggered to recover from transmission errors.
   NvidiaPageRetirement:
     Template: 'NvidiaPageRetirement'
     DefaultSeverity: 'Warning'
+    Component: 'nvidia'
     Description: >-
       The GPU driver has marked a memory page for retirement. This may occur if
       there is a single double bit error or two single bit errors are
@@ -344,26 +400,31 @@ AcceleratedHardwareReady:
   NvidiaPowerError:
     Template: 'NvidiaPowerError'
     DefaultSeverity: 'Warning'
+    Component: 'nvidia'
     Description: >-
       Power utilization of GPUs breached the allowed thresholds.
   NvidiaThermalError:
     Template: 'NvidiaThermalError'
     DefaultSeverity: 'Warning'
+    Component: 'nvidia'
     Description: >-
       Thermal status of GPUs breached the allowed thresholds.
   NvidiaXIDError:
     Template: 'NvidiaXID%dError'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       A critical GPU error occurred.
   NvidiaXIDWarning:
     Template: 'NvidiaXID%dWarning'
     DefaultSeverity: 'Warning'
+    Component: 'nvidia'
     Description: >-
       A non-critical GPU error occurred.
   FabricManagerNotRunning:
     Template: 'FabricManagerNotRunning'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       The NVIDIA Fabric Manager service is not running on this NVSwitch-equipped
       instance. Fabric Manager is required for multi-GPU NVLink communication.
@@ -371,6 +432,7 @@ AcceleratedHardwareReady:
   NvidiaFabricError:
     Template: 'NvidiaFabricError'
     DefaultSeverity: 'Fatal'
+    Component: 'nvidia'
     Description: >-
       One or more GPUs reported a non-success fabric status, indicating NVSwitch
       fabric training failure. Affected GPUs cannot participate in multi-GPU
@@ -379,59 +441,70 @@ AcceleratedHardwareReady:
   NeuronDMAError:
     Template: 'NeuronDMAError'
     DefaultSeverity: 'Fatal'
+    Component: 'neuron'
     Description: >-
       A DMA engine encountered an unrecoverable error.
   NeuronHBMUncorrectableError:
     Template: 'NeuronHBMUncorrectableError'
     DefaultSeverity: 'Fatal'
+    Component: 'neuron'
     Description: >-
       An HBM encountered an uncorrectable error and produced incorrect results.
   NeuronNCUncorrectableError:
     Template: 'NeuronNCUncorrectableError'
     DefaultSeverity: 'Fatal'
+    Component: 'neuron'
     Description: >-
       A Neuron Core uncorrectable memory error was detected.
   NeuronSRAMUncorrectableError:
     Template: 'NeuronSRAMUncorrectableError'
     DefaultSeverity: 'Fatal'
+    Component: 'neuron'
     Description: >-
       An on-chip SRAM encountered a parity error and produced incorrect results.
 StorageReady:
   EBSInstanceIOPSExceeded:
     Template: 'EBSInstanceIOPSExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       Maximum IOPS for the instance was exceeded.
   EBSInstanceThroughputExceeded:
     Template: 'EBSInstanceThroughputExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       Maximum Throughput for the instance was exceeded.
   EBSVolumeIOPSExceeded:
     Template: 'EBSVolumeIOPSExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       Maximum IOPS to a particular EBS Volume was exceeded.
   EBSVolumeThroughputExceeded:
     Template: 'EBSVolumeThroughputExceeded'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       Maximum Throughput to a particular Amazon EBS volume was exceeded.
   EtcHostsMountFailed:
     Template: 'EtcHostsMountFailed'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       Mounting of the kubelet generated `/etc/hosts` failed due to userdata
       remounting `/var/lib/kubelet/pods` during `kubelet-container` operation.
   IODelays:
     Template: 'IODelays'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       Input or output delay detected in a process, potentially indicating
       insufficient input-output provisioning if excessive.
   KubeletDiskUsageSlow:
     Template: 'KubeletDiskUsageSlow'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       The `kubelet` is reporting slow disk usage while trying to access the
       filesystem. This potentially indicates insufficient disk input-output or
@@ -439,6 +512,7 @@ StorageReady:
   XFSSmallAverageClusterSize:
     Template: 'XFSSmallAverageClusterSize'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       The XFS Average Cluster size is small, indicating excessive free space
       fragmentation. This can prevent file creation despite available inodes or
@@ -446,6 +520,7 @@ StorageReady:
   BlockDeviceIOError:
     Template: 'BlockDeviceIOError'
     DefaultSeverity: 'Warning'
+    Component: 'storage'
     Description: >-
       An I/O error was detected on a block device, indicating a failed physical
       drive (instance store) or EBS volume. This can cause data loss and

--- a/tools/codegen-reasons/main.go
+++ b/tools/codegen-reasons/main.go
@@ -27,8 +27,9 @@ var reservedComponents = []string{"diagnostics"}
 
 // templateData is the root object rendered into reasons.go.
 type templateData struct {
-	Conditions map[string]map[string]internalReasonMeta
-	Components []string
+	Conditions    map[string]map[string]internalReasonMeta
+	Components    []string
+	MaxComponents int
 }
 
 func main() {
@@ -79,7 +80,7 @@ func main() {
 	}
 
 	var buf bytes.Buffer
-	err = template.Execute(&buf, templateData{Conditions: reasonConfig, Components: components})
+	err = template.Execute(&buf, templateData{Conditions: reasonConfig, Components: components, MaxComponents: maxComponents})
 	if err != nil {
 		panic(err)
 	}

--- a/tools/codegen-reasons/main.go
+++ b/tools/codegen-reasons/main.go
@@ -6,11 +6,30 @@ import (
 	"fmt"
 	"go/format"
 	"os"
+	"sort"
 	"text/template"
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
+
+// maxComponents is N, the declared platform capacity for event-budget
+// components. The unit of the per-component event quota is the component (an
+// owning agent or monitor), and the node-global event ceiling is derived as
+// N x Q, so registering capacity is a deliberate ledger change here — never
+// a runtime discovery. See .kiro/specs/probe-framework-event-limits-spec.md
+// section 2 and .kiro/specs/probe-framework-design.md "Limits and Scaling".
+const maxComponents = 10
+
+// reservedComponents are budget slots claimed by the platform for emitters
+// that own no reasons.yaml entries (the merged diagnostics collector).
+var reservedComponents = []string{"diagnostics"}
+
+// templateData is the root object rendered into reasons.go.
+type templateData struct {
+	Conditions map[string]map[string]internalReasonMeta
+	Components []string
+}
 
 func main() {
 	reasonConfigPath := flag.String("config-path", "", "path to the config file for reasons")
@@ -29,10 +48,24 @@ func main() {
 		panic(err)
 	}
 
+	componentSet := map[string]struct{}{}
 	for _, c := range reasonConfig {
-		for _, r := range c {
-			r.validate()
+		for name, r := range c {
+			r.validate(name)
+			componentSet[r.Component] = struct{}{}
 		}
+	}
+	components := make([]string, 0, len(componentSet))
+	for c := range componentSet {
+		components = append(components, c)
+	}
+	sort.Strings(components)
+	if len(components)+len(reservedComponents) > maxComponents {
+		panic(fmt.Errorf(
+			"reasons.yaml declares %d distinct components %v plus %d reserved %v, exceeding the declared platform capacity N=%d; "+
+				"raising N is a deliberate ledger change that recomputes the node-global event ceiling — "+
+				"see .kiro/specs/probe-framework-event-limits-spec.md section 2",
+			len(components), components, len(reservedComponents), reservedComponents, maxComponents))
 	}
 
 	reasonTemplateData, err := os.ReadFile(*reasonTemplatePath)
@@ -46,7 +79,7 @@ func main() {
 	}
 
 	var buf bytes.Buffer
-	err = template.Execute(&buf, reasonConfig)
+	err = template.Execute(&buf, templateData{Conditions: reasonConfig, Components: components})
 	if err != nil {
 		panic(err)
 	}
@@ -67,12 +100,16 @@ func main() {
 type internalReasonMeta struct {
 	Template        string           `yaml:"Template"`
 	DefaultSeverity monitor.Severity `yaml:"DefaultSeverity"`
+	Component       string           `yaml:"Component"`
 }
 
-func (ir *internalReasonMeta) validate() {
+func (ir *internalReasonMeta) validate(name string) {
 	switch ir.DefaultSeverity {
 	case monitor.SeverityFatal, monitor.SeverityWarning, monitor.SeverityInfo:
 	default:
 		panic(fmt.Errorf("severity it not an accepted value: %q", ir.DefaultSeverity))
+	}
+	if ir.Component == "" {
+		panic(fmt.Errorf("reason %q is missing a Component: every reason must declare its owning component for the per-component event budget", name))
 	}
 }


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

Every event this agent records on a node shares a single client-go spam-filter budget. The filter keys on the event source, the involved object and the event type, not on the reason, so all monitors and probes on a node compete for one 25-event burst refilled at one token per five minutes. A single component in a failure loop can starve every other component's events for hours, and the drops are silent — no error reaches the caller and no metric moves.

Make the component the unit of the budget. Every reason in `reasons.yaml` now declares its owning component, so ownership lives in the same ledger as the taxonomy, and the generator fails when declared plus reserved components exceed the platform capacity. Onboarding capacity becomes a deliberate ledger change rather than something the next agent discovers through silent drops. The exporter shapes emission ahead of the recorder with one token bucket per component and event type as the guaranteed budget, plus a per-type node ceiling derived from that quota as a bug detector. A flooding component starves only itself, and every drop is counted per component on new `nma_events_*` metrics.

Enforcement sits in the exporter rather than in the correlator's spam key on purpose. The correlator runs aggregation before the spam filter and rebuilds aggregated events without annotations, so a component-keyed spam filter would be defeated by the correlator itself and its drops would stay invisible. The custom broadcaster is still installed, but only to key aggregation on the component and to size the spam filter as a backstop above the exporter's own shaping. Event reason and message are byte-identical to today; the component travels as an `eks.amazonaws.com/component` annotation.

**Testing Done**:

An isolation test drives one component to its burst limit and confirms a second component's event still delivers immediately, and that the flooding component's other event type is unaffected. A second test drives every declared component to its burst and asserts the node ceiling never rejects, which is the invariant that makes a ceiling rejection a bug rather than capacity. A third drives the real client-go correlator with production options and worst-case exporter-shaped traffic to confirm the backstop never drops first; it is the intended tripwire for `client-go` bumps. `make test`, `hack/check-generate.sh`, `gofmt -l` and `GOOS=linux CGO_ENABLED=1 go build ./...` are green on this branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.