### PR TITLE
feat(networking): Expand default interface exclusion list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ nodeAgent:
         - "filter/MY-CUSTOM-CHAIN"
 ```
 
-The networking monitor also supports `excludedInterfaceNameRegexps` to suppress `InterfaceNotUp` / `InterfaceNotRunning` findings for interfaces that are not part of Kubernetes node networking. This is useful on accelerated instance types (e.g. P6) that expose host-visible Mellanox/NVIDIA IPoIB interfaces such as `ibp115s0f0`, which may legitimately remain down. Each entry is a Go regular expression matched against the interface name; invalid regexps fail fast at startup:
+The networking monitor also supports `excludedInterfaceNameRegexps` to suppress `InterfaceNotUp` / `InterfaceNotRunning` findings for interfaces that are not part of Kubernetes node networking. This is useful on accelerated instance types (e.g. P6) that expose host-visible Mellanox/NVIDIA IPoIB interfaces such as `ibp115s0f0`, which may legitimately remain down. Each entry is a Go regular expression matched against the interface name; invalid regexps fail fast at startup.
+
+By default the following interfaces are excluded: kernel tunnel fallback devices (`gre*`, `gretap*`, `erspan*`, `ip6gre*`, `ip6gretap*`, `tunl*`, `sit*`, `ip6tnl*`) and InfiniBand / IPoIB interfaces (`ib*`, `ibp*`). Setting `excludedInterfaceNameRegexps` overrides this default; set it to an empty list to disable exclusions entirely.
 
 ```yaml
 nodeAgent:

--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -242,8 +242,8 @@
                 },
                 "excludedInterfaceNameRegexps": {
                     "type": "array",
-                    "description": "List of regular expressions matching interface names that should be excluded from InterfaceNotUp / InterfaceNotRunning checks. Use this to suppress false positives from known non-node-networking interfaces (e.g. Mellanox/NVIDIA IPoIB interfaces such as \"^ibp[0-9]+s[0-9]+f[0-9]+$\"). Defaults to excluding IPoIB interfaces; set to an empty list to disable the default exclusion.",
-                    "default": ["^ibp[0-9]+s[0-9]+f[0-9]+$"],
+                    "description": "List of regular expressions matching interface names that should be excluded from InterfaceNotUp / InterfaceNotRunning checks. Use this to suppress false positives from known non-node-networking interfaces (e.g. Mellanox/NVIDIA IPoIB interfaces such as \"^ibp[0-9]+s[0-9]+f[0-9]+$\"). Defaults to excluding kernel tunnel fallback devices (gre, gretap, erspan, ip6gre, ip6gretap, tunl, sit, ip6tnl) and InfiniBand / IPoIB interfaces; set to an empty list to disable the default exclusion.",
+                    "default": ["^gre[0-9]+$", "^gretap[0-9]+$", "^erspan[0-9]+$", "^ip6gre[0-9]+$", "^ip6gretap[0-9]+$", "^tunl[0-9]+$", "^sit[0-9]+$", "^ip6tnl[0-9]+$", "^ib[0-9]+$", "^ibp[0-9]+s[0-9]+(f[0-9]+)?$"],
                     "items": {
                       "type": "string"
                     }

--- a/pkg/config/monitor.go
+++ b/pkg/config/monitor.go
@@ -63,11 +63,27 @@ func (mc *MonitorConfig) GetAllowedIPTablesChains() []string {
 }
 
 // DefaultExcludedInterfaceNameRegexps are the interface-name exclusion regexps
-// applied when the networking monitor has none explicitly configured. It
-// excludes Mellanox/NVIDIA IPoIB interfaces (e.g. "ibp115s0f0") by default,
-// which are not node-networking interfaces and would otherwise cause false
-// positive InterfaceNotUp / InterfaceNotRunning notifications.
-var DefaultExcludedInterfaceNameRegexps = []string{`^ibp[0-9]+s[0-9]+f[0-9]+$`}
+// applied when the networking monitor has none explicitly configured. These
+// interfaces are not part of Kubernetes node networking and would otherwise
+// cause false positive InterfaceNotUp / InterfaceNotRunning notifications:
+//   - Kernel tunnel fallback devices (gre, gretap, erspan, ip6gre, ip6gretap,
+//     tunl, sit, ip6tnl) that the kernel creates but leaves administratively down.
+//   - Mellanox/NVIDIA InfiniBand / IPoIB interfaces (e.g. "ib0", "ibp115s0f0")
+//     found on accelerated instance families such as P6.
+var DefaultExcludedInterfaceNameRegexps = []string{
+	// Kernel tunnel fallback devices
+	`^gre[0-9]+$`,
+	`^gretap[0-9]+$`,
+	`^erspan[0-9]+$`,
+	`^ip6gre[0-9]+$`,
+	`^ip6gretap[0-9]+$`,
+	`^tunl[0-9]+$`,
+	`^sit[0-9]+$`,
+	`^ip6tnl[0-9]+$`,
+	// InfiniBand / IPoIB (P6 etc.)
+	`^ib[0-9]+$`,
+	`^ibp[0-9]+s[0-9]+(f[0-9]+)?$`,
+}
 
 // GetExcludedInterfaceNameRegexps returns the interface-name exclusion regexps
 // configured for the networking monitor. When the networking monitor has no


### PR DESCRIPTION
Add kernel tunnel fallback devices (gre, gretap, erspan, ip6gre, ip6gretap, tunl, sit, ip6tnl) and InfiniBand / IPoIB interfaces (ib*, ibp*) to the default excludedInterfaceNameRegexps. These are not part of Kubernetes node networking and would otherwise produce false-positive InterfaceNotUp / InterfaceNotRunning findings out of the box.

The prior IPoIB pattern ^ibp[0-9]+s[0-9]+f[0-9]+$ is replaced by the broader ^ibp[0-9]+s[0-9]+(f[0-9]+)?$ so the trailing function suffix is optional. Update the chart schema default/description and README to match.

**Issue #, if available**:

**Description of changes**:

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
