### PR TITLE
fix(chart): support runtimeClassName for the dcgm-server pod

### DIFF
--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -129,6 +129,11 @@
                     "description": "Name of an existing PriorityClass assigned to the dcgm-exporter pod.",
                     "default": "system-node-critical"
                 },
+                "runtimeClassName": {
+                    "type": "string",
+                    "description": "RuntimeClass assigned to the dcgm-server pod. Required when the NVIDIA container runtime is not the containerd default.",
+                    "default": ""
+                },
                 "resources": {
                     "$ref": "#/definitions/Resources"
                 },

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters for this chart and their d
 | dcgmAgent.priorityClassName | string | `"system-node-critical"` | PriorityClass for the dcgm exporter. |
 | dcgmAgent.resizePolicy | list | `[]` | Container resize policy for in-place pod vertical scaling (requires Kubernetes 1.33+) |
 | dcgmAgent.resources | object | `{}` | Container resources for the dcgm deployment |
+| dcgmAgent.runtimeClassName | string | `""` | RuntimeClass for the dcgm-server pod (e.g. "nvidia"). Required when the NVIDIA container runtime is not the containerd default. Empty uses the node's default runtime. |
 | dcgmAgent.tolerations | list | `[]` | Deployment tolerations for the dcgm |
 | extraObjects | list | see [`values.yaml`](./values.yaml), so template expressions (e.g. {{ .Release.Namespace }}) inside the manifests are evaluated. Example:   extraObjects:     - apiVersion: monitoring.coreos.com/v1       kind: PodMonitor       metadata:         name: eks-node-monitoring-agent         namespace: {{ .Release.Namespace }}       spec:         selector:           matchLabels:             app.kubernetes.io/name: eks-node-monitoring-agent         podMetricsEndpoints:           - port: metrics |
 | fullnameOverride | string | `"eks-node-monitoring-agent"` | A fullname override for the chart |

--- a/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
@@ -40,6 +40,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       priorityClassName: {{ .Values.dcgmAgent.priorityClassName | default "system-node-critical" }}
+      {{- with .Values.dcgmAgent.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-dcgm
           image: {{ template "dcgm-server.image" . }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -162,6 +162,8 @@ dcgmAgent:
   nodeSelector: {}
   # -- PriorityClass for the dcgm exporter.
   priorityClassName: system-node-critical
+  # -- RuntimeClass for the dcgm-server pod (e.g. "nvidia"). Required when the NVIDIA container runtime is not the containerd default. Empty uses the node's default runtime.
+  runtimeClassName: ""
   # -- Pod annotations applied to the dcgm exporter
   podAnnotations: {}  
 


### PR DESCRIPTION
Issue #241 

**Description of changes**:

Adds an opt-in `dcgmAgent.runtimeClassName` value, threaded through the chart template and `values.yaml`, and exposed in the managed addon schema (previously `additionalProperties: false` rejected it outright).

On GPU Operator clusters where the NVIDIA container runtime isn't the containerd default, the bundled dcgm-server pod needs `runtimeClassName: nvidia` (or `nvidia-cdi`) to see the GPUs at all. Without it, `dcgmi discovery -l` reports zero GPUs while the agent still sets `AcceleratedHardwareReady=True` — a silent false positive with no error surfaced anywhere.

Default is unset (current behavior unchanged); operators set the value only on clusters that need it.

**Testing Done**:

- Unit tests for template rendering with and without `runtimeClassName` set.
- Live validation (GPU Operator cluster): with `runtimeClassName: nvidia` set, `dcgmi discovery -l` reports all GPUs. Confirmed with `nvidia-cdi` as well.
- `helm lint` and `helm template` pass with the new value present and absent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.