### PR TITLE
fix(chart): support hostNetwork for the dcgm-server pod

### DIFF
--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -129,6 +129,11 @@
                     "description": "Name of an existing PriorityClass assigned to the dcgm-exporter pod.",
                     "default": "system-node-critical"
                 },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Run the dcgm-server pod on the host network so nv-hostengine binds node port 5555 directly. Required on clusters whose CNI does not implement hostPort.",
+                    "default": false
+                },
                 "resources": {
                     "$ref": "#/definitions/Resources"
                 },

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters for this chart and their d
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | dcgmAgent.affinity | object | see [`values.yaml`](./values.yaml) | Map of dcgm pod affinities |
+| dcgmAgent.hostNetwork | bool | `false` | Run the dcgm-server pod on the host network so nv-hostengine binds node port 5555 directly. Required on clusters whose CNI does not implement hostPort. |
 | dcgmAgent.image.account | string | `"602401143452"` | ECR repository account number for the dcgm-exporter. Only used when a tag is set. |
 | dcgmAgent.image.containerRegistry | string | `""` | Full container registry URL override (e.g., 602401143452.dkr.ecr.us-west-2.amazonaws.com). When set, this takes precedence over account/endpoint/region/domain fields. Only used when a tag is set. |
 | dcgmAgent.image.domain | string | `"amazonaws.com"` | ECR repository domain for the dcgm-exporter. Only used when a tag is set. |

--- a/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
+++ b/charts/eks-node-monitoring-agent/templates/dcgm-daemonset.yaml
@@ -40,6 +40,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       priorityClassName: {{ .Values.dcgmAgent.priorityClassName | default "system-node-critical" }}
+      {{- if .Values.dcgmAgent.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-dcgm
           image: {{ template "dcgm-server.image" . }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -162,6 +162,8 @@ dcgmAgent:
   nodeSelector: {}
   # -- PriorityClass for the dcgm exporter.
   priorityClassName: system-node-critical
+  # -- Run the dcgm-server pod on the host network so nv-hostengine binds node port 5555 directly. Required on clusters whose CNI does not implement hostPort.
+  hostNetwork: false
   # -- Pod annotations applied to the dcgm exporter
   podAnnotations: {}  
 


### PR DESCRIPTION
Issue #243

**Description of changes**:

Adds an opt-in `dcgmAgent.hostNetwork` value (default `false`) to the dcgm-server DaemonSet template, values, and addon schema. When set, the dcgm-server pod runs with `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet`, letting the host engine bind port 5555 on the node directly.

The agent connects to the host engine at `localhost:5555`, relying on the dcgm-server DaemonSet's `hostPort: 5555` to NAT that to the pod. On clusters whose CNI has no portmap plugin, that NAT never exists, so every reconcile fails (`Host engine connection invalid/disconnected`) and the node latches `AcceleratedHardwareReady=False` (reason `DCGMError`) even when the hardware is healthy. `hostNetwork` removes the hostPort dependency entirely — the same approach NVIDIA's own dcgm-exporter (GPU Operator) uses.

**Testing Done**:

- Live validatio from the agent pod (hostNetwork), `localhost:5555`, `127.0.0.1:5555`, and `<node-ip>:5555` all failed to connect; only the dcgm-server pod IP succeeded.
- Patched the dcgm-server DaemonSet with `hostNetwork: true` / `dnsPolicy: ClusterFirstWithHostNet`; agent connected on the next reconcile and the node condition recovered.
- Re-validated with the chart change (`dcgmAgent.hostNetwork: true`) end to end — same recovery, no manual patch required.
- `helm lint` and `helm template` pass with the value present and absent (default off, no behavior change for existing installs).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license