### PR TITLE
feat(nvidia): detect GPU row remapping failures (DCGM fields 393/395)

### DIFF
--- a/docs/node-health-issues.adoc
+++ b/docs/node-health-issues.adoc
@@ -93,6 +93,14 @@ If auto repair is enabled, the repair actions that are listed start 10 minutes a
 |Event
 |Power utilization of GPUs breached the allowed thresholds.
 
+|NvidiaRowRemap
+|Event
+|The GPU remapped memory rows due to uncorrectable memory errors. An early signal of degrading GPU memory.
+
+|NvidiaRowRemapFailure
+|Condition
+|The GPU failed to remap a memory row and can no longer mask bad memory cells. The GPU requires replacement.
+
 |NvidiaThermalError
 |Event
 |Thermal status of GPUs breached the allowed thresholds.

--- a/monitors/nvidia/dcgm/dcgm_client.go
+++ b/monitors/nvidia/dcgm/dcgm_client.go
@@ -195,6 +195,9 @@ func (d *dcgmHelper) Reconcile(ctx context.Context) (bool, error) {
 			// Fabric Manager status and GPU fabric health for NVSwitch instances.
 			dcgmapi.DCGM_FI_DEV_FABRIC_MANAGER_STATUS,
 			dcgmapi.DCGM_FI_DEV_FABRIC_HEALTH_MASK,
+			// Row remapping (Ampere+): 393 counts uncorrectable remaps, 395 flags remap failure.
+			dcgmapi.DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS,
+			dcgmapi.DCGM_FI_DEV_ROW_REMAP_FAILURE,
 		})
 		if err != nil {
 			return false, err

--- a/monitors/nvidia/dcgm/dcgm_watchfield.go
+++ b/monitors/nvidia/dcgm/dcgm_watchfield.go
@@ -45,6 +45,14 @@ func (s *DCGMSystem) WatchFields(ctx context.Context) ([]monitor.Condition, erro
 			continue
 		}
 
+		// Row remap fields also encode health in the value with an OK status.
+		if c, handled := handleRowRemapField(fieldValue); handled {
+			if c != nil {
+				conditions = append(conditions, *c)
+			}
+			continue
+		}
+
 		// skip if there's no issue with the field or no new data was provided.
 		if fieldValue.Status == dcgmapi.DCGM_ST_OK || fieldValue.Status == dcgmapi.DCGM_ST_NO_DATA {
 			continue
@@ -118,6 +126,37 @@ func handleFabricField(fv dcgmapi.FieldValue_v2) (*monitor.Condition, bool) {
 		c := reasons.NvidiaFabricError.
 			Builder().
 			Message(fmt.Sprintf("GPU fabric health mask 0x%x: %s", mask, strings.Join(faults, ", "))).
+			Build()
+		return &c, true
+	default:
+		return nil, false
+	}
+}
+
+// handleRowRemapField handles the row remapping fields. Returns (nil, true)
+// when the field is recognized but healthy (zero count, or blank/sentinel on
+// GPUs without row remapping), (*condition, true) when unhealthy, and
+// (nil, false) for other fields.
+func handleRowRemapField(fv dcgmapi.FieldValue_v2) (*monitor.Condition, bool) {
+	switch fv.FieldID {
+	case dcgmapi.DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS:
+		v := fv.Int64()
+		if dcgmapi.IsInt64Blank(v) || v <= 0 {
+			return nil, true
+		}
+		c := reasons.NvidiaRowRemap.
+			Builder().
+			Message(fmt.Sprintf("GPU remapped %d memory row(s) due to uncorrectable memory errors", v)).
+			Build()
+		return &c, true
+	case dcgmapi.DCGM_FI_DEV_ROW_REMAP_FAILURE:
+		v := fv.Int64()
+		if dcgmapi.IsInt64Blank(v) || v == 0 {
+			return nil, true
+		}
+		c := reasons.NvidiaRowRemapFailure.
+			Builder().
+			Message("GPU row remapping failure: a memory row could not be remapped and the GPU requires replacement").
 			Build()
 		return &c, true
 	default:

--- a/monitors/nvidia/dcgm/dcgm_watchfield_test.go
+++ b/monitors/nvidia/dcgm/dcgm_watchfield_test.go
@@ -184,6 +184,70 @@ func TestFields(t *testing.T) {
 		}}, conditions)
 	})
 
+	t.Run("RowRemapFailureFault", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_ROW_REMAP_FAILURE}
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 1)
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []monitor.Condition{{
+			Reason:   "NvidiaRowRemapFailure",
+			Message:  "GPU row remapping failure: a memory row could not be remapped and the GPU requires replacement",
+			Severity: monitor.SeverityFatal,
+		}}, conditions)
+	})
+
+	t.Run("RowRemapFailureHealthy", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_ROW_REMAP_FAILURE}
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0)
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
+	// Blank/sentinel value = row remapping unsupported (pre-Ampere); not flagged.
+	t.Run("RowRemapFailureBlankValueHealthy", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_ROW_REMAP_FAILURE}
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], uint64(dcgmapi.DCGM_FT_INT64_BLANK))
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
+	t.Run("UncorrectableRemappedRowsWarning", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS}
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 3)
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []monitor.Condition{{
+			Reason:   "NvidiaRowRemap",
+			Message:  "GPU remapped 3 memory row(s) due to uncorrectable memory errors",
+			Severity: monitor.SeverityWarning,
+		}}, conditions)
+	})
+
+	t.Run("UncorrectableRemappedRowsZeroHealthy", func(t *testing.T) {
+		fieldValue := dcgmapi.FieldValue_v2{FieldID: dcgmapi.DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS}
+		fieldValue.Status = dcgmapi.DCGM_ST_OK
+		binary.LittleEndian.PutUint64(fieldValue.Value[:], 0)
+		mockDcgm := &fake.FakeDcgm{FieldValues: []dcgmapi.FieldValue_v2{fieldValue}}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.WatchFields(context.TODO())
+		assert.NoError(t, err)
+		assert.Empty(t, conditions)
+	})
+
 	t.Run("GetResultForBadStatus", func(t *testing.T) {
 		for _, test := range []struct {
 			fieldValue      dcgmapi.FieldValue_v2

--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -76,6 +76,14 @@ var (
         template:        "NvidiaPowerError",
         defaultSeverity: "Warning",
     }
+    NvidiaRowRemap = ReasonMeta{
+        template:        "NvidiaRowRemap",
+        defaultSeverity: "Warning",
+    }
+    NvidiaRowRemapFailure = ReasonMeta{
+        template:        "NvidiaRowRemapFailure",
+        defaultSeverity: "Fatal",
+    }
     NvidiaThermalError = ReasonMeta{
         template:        "NvidiaThermalError",
         defaultSeverity: "Warning",

--- a/pkg/reasons/reasons.yaml
+++ b/pkg/reasons/reasons.yaml
@@ -346,6 +346,18 @@ AcceleratedHardwareReady:
     DefaultSeverity: 'Warning'
     Description: >-
       Power utilization of GPUs breached the allowed thresholds.
+  NvidiaRowRemap:
+    Template: 'NvidiaRowRemap'
+    DefaultSeverity: 'Warning'
+    Description: >-
+      The GPU remapped memory rows due to uncorrectable memory errors. An
+      early signal of degrading GPU memory.
+  NvidiaRowRemapFailure:
+    Template: 'NvidiaRowRemapFailure'
+    DefaultSeverity: 'Fatal'
+    Description: >-
+      The GPU failed to remap a memory row and can no longer mask bad memory
+      cells. The GPU requires replacement.
   NvidiaThermalError:
     Template: 'NvidiaThermalError'
     DefaultSeverity: 'Warning'


### PR DESCRIPTION
Issue #245 

**Description of changes**:

Adds row-remap detection to the nvidia monitor, following the existing field-handling pattern (reasons codegen, field registration, handler):

- `DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS` (field 393) → new `NvidiaRowRemap` reason, Warning severity, event only — an early degradation signal.
- `DCGM_FI_DEV_ROW_REMAP_FAILURE` (field 395) → new `NvidiaRowRemapFailure` reason, Fatal severity — sets `AcceleratedHardwareReady=False` so node auto-repair replaces the node.

Both fields are registered in the DCGM watch group ahead of the OK/NO_DATA gate, since row remap fields encode health directly in the value (like the existing fabric fields). Blank/sentinel values are treated as healthy for pre-Ampere GPUs that don't report these fields.

Neither field was previously watched, so a GPU in row-remap-failure state kept `AcceleratedHardwareReady=True` indefinitely — auto-repair stayed idle and the scheduler kept placing workloads on failing hardware.

**Testing Done**:

- 5 new unit tests covering both fields: warning event emission, fatal condition transition, and pre-Ampere blank-value handling.
- Live validation with injected field 395 via `dcgmi test --inject --gpuid 0 --field 395 --value 1` — node condition flipped to `AcceleratedHardwareReady=False` with reason `NvidiaRowRemapFailure`. Injected field 393 — `NvidiaRowRemap` warning event emitted, condition unchanged.
- `go test ./...` passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.