### PR TITLE
fix: generate EKS auth tokens in-process instead of running the aws CLI

### DIFF
--- a/cmd/eks-node-monitoring-agent/restconfig.go
+++ b/cmd/eks-node-monitoring-agent/restconfig.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
+	"net/http"
+	"strings"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/aws/eks-node-monitoring-agent/pkg/auth"
 	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 	"github.com/aws/eks-node-monitoring-agent/pkg/pathlib"
 )
@@ -33,14 +34,10 @@ func (rcp *autoRestConfigProvider) Provide() (*rest.Config, error) {
 }
 
 func NewPodRestConfigProvider() *podRestConfigProvider {
-	return &podRestConfigProvider{
-		execMapper: chrootMapper{},
-	}
+	return &podRestConfigProvider{}
 }
 
-type podRestConfigProvider struct {
-	execMapper chrootMapper
-}
+type podRestConfigProvider struct{}
 
 func (rcp *podRestConfigProvider) Provide() (*rest.Config, error) {
 	kubeconfigPath := pathlib.ResolveKubeconfig(config.HostRoot())
@@ -65,29 +62,80 @@ func (rcp *podRestConfigProvider) Provide() (*rest.Config, error) {
 		return nil, err
 	}
 
-	if err := rewriteExecProvider(restConfig, rcp.execMapper); err != nil {
+	if err := useInProcessTokenAuth(restConfig); err != nil {
 		return nil, err
 	}
 
 	return restConfig, nil
 }
 
-// rewriteExecProvider transforms the exec provider arguments, because they need
-// to call host binaries in order to get a token from the iam authenticator.
-// NOTE: reminder that these calls also utilize hostNetworking in order to
-// reach IMDS to get host credentials.
-// kubeconfigs that authenticate without an exec credential plugin (e.g. a
-// client certificate) have no ExecProvider, so only rewrite it when present.
-func rewriteExecProvider(restConfig *rest.Config, m chrootMapper) error {
+// useInProcessTokenAuth replaces the kubeconfig's exec credential plugin with
+// in-process token generation.
+//
+// The plugin (`aws eks get-token` or `aws-iam-authenticator token`) only exists
+// on the host, so the agent used to invoke it by chrooting onto the host root.
+// That cost a process launch — and the aws CLI's ~50MB resident set — every time
+// client-go refreshed the credential, roughly every 15 minutes, which was enough
+// to push the container past its cgroup memory limit and get it OOM killed.
+// Generating the token in-process with the same library removes the launch
+// entirely; see pkg/auth for how the token is minted and cached.
+//
+// NOTE: the token is a presigned STS request, so this still depends on the pod
+// reaching IMDS to pick up the node's instance profile — which is why the agent
+// runs with hostNetwork, as it did for the chrooted plugin.
+func useInProcessTokenAuth(restConfig *rest.Config) error {
+	// kubeconfigs that authenticate with a client certificate or a token file
+	// (e.g. on kops-provisioned nodes) carry no credential plugin, and client-go
+	// reads that material directly. Nothing to replace.
 	if restConfig.ExecProvider == nil {
 		return nil
 	}
-	var err error
-	restConfig.ExecProvider.Command, restConfig.ExecProvider.Args, err = m.Map(
-		restConfig.ExecProvider.Command,
-		restConfig.ExecProvider.Args...,
-	)
-	return err
+
+	clusterName, err := clusterNameFromExecProvider(restConfig.ExecProvider)
+	if err != nil {
+		return err
+	}
+
+	generator, err := auth.NewEKSTokenGenerator(clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to create EKS token generator: %w", err)
+	}
+
+	// clearing the ExecProvider is what stops client-go from launching the
+	// plugin; the transport supplies the Authorization header in its place.
+	restConfig.ExecProvider = nil
+	restConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &auth.EKSTokenTransport{Base: rt, Generator: generator}
+	})
+
+	return nil
+}
+
+// clusterNameFromExecProvider reads the cluster name out of the credential
+// plugin's arguments. The kubeconfig is the authoritative source here — it is
+// where the plugin itself read the name from — but the flag it uses depends on
+// which plugin the kubeconfig was written for: `aws eks get-token` takes
+// --cluster-name, while `aws-iam-authenticator token` takes --cluster-id (-i).
+// Either may spell its value as a separate argument or joined with '='.
+func clusterNameFromExecProvider(execConfig *clientcmdapi.ExecConfig) (string, error) {
+	for i, arg := range execConfig.Args {
+		flag, value, joined := strings.Cut(arg, "=")
+		switch flag {
+		case "--cluster-name", "--cluster-id", "-i":
+		default:
+			continue
+		}
+		if !joined {
+			if i+1 >= len(execConfig.Args) {
+				continue
+			}
+			value = execConfig.Args[i+1]
+		}
+		if value = strings.TrimSpace(value); value != "" {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("could not determine the cluster name from exec credential plugin args %q", execConfig.Args)
 }
 
 // hostPathOverrides builds clientcmd overrides that resolve the file paths the
@@ -134,19 +182,4 @@ func (rcp *podRestConfigProvider) hostPathOverrides(kubeconfigPath string) (*cli
 	}
 
 	return overrides, nil
-}
-
-type chrootMapper struct{}
-
-func (c *chrootMapper) Map(command string, args ...string) (string, []string, error) {
-	// shift the original command and arguments and call a go wrapper for chroot
-	// because its not available on the system.
-	newArgs := append([]string{config.HostRoot(), command}, args...)
-	executable, err := os.Executable()
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to get executable: %w", err)
-	}
-	// use the chroot wrapper we've built.
-	chroot := filepath.Join(filepath.Dir(executable), "chroot")
-	return chroot, newArgs, nil
 }

--- a/cmd/eks-node-monitoring-agent/restconfig_test.go
+++ b/cmd/eks-node-monitoring-agent/restconfig_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"path/filepath"
 	"testing"
 
@@ -8,37 +9,127 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/aws/eks-node-monitoring-agent/pkg/auth"
 	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 )
 
-func TestRewriteExecProvider(t *testing.T) {
+func TestUseInProcessTokenAuth(t *testing.T) {
 	t.Run("nil exec provider is left untouched", func(t *testing.T) {
 		cfg := &rest.Config{} // client-cert auth, no ExecProvider
-		if err := rewriteExecProvider(cfg, chrootMapper{}); err != nil {
+		if err := useInProcessTokenAuth(cfg); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cfg.ExecProvider != nil {
 			t.Fatal("ExecProvider should stay nil")
 		}
+		if cfg.WrapTransport != nil {
+			t.Fatal("no token transport should be installed without an ExecProvider")
+		}
 	})
 
-	t.Run("exec provider is rewritten through the chroot wrapper", func(t *testing.T) {
+	t.Run("exec provider is replaced by the token transport", func(t *testing.T) {
 		cfg := &rest.Config{
 			ExecProvider: &clientcmdapi.ExecConfig{
 				Command: "aws-iam-authenticator",
 				Args:    []string{"token", "-i", "cluster"},
 			},
 		}
-		if err := rewriteExecProvider(cfg, chrootMapper{}); err != nil {
+		if err := useInProcessTokenAuth(cfg); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if filepath.Base(cfg.ExecProvider.Command) != "chroot" {
-			t.Fatalf("command not rewritten to chroot wrapper: %q", cfg.ExecProvider.Command)
+		// the ExecProvider must be cleared, otherwise client-go still launches
+		// the plugin and the memory spike this change avoids comes back.
+		if cfg.ExecProvider != nil {
+			t.Fatal("ExecProvider should be cleared")
 		}
-		if cfg.ExecProvider.Args[1] != "aws-iam-authenticator" {
-			t.Fatalf("original command not preserved in args: %v", cfg.ExecProvider.Args)
+		if cfg.WrapTransport == nil {
+			t.Fatal("expected a token transport to be installed")
+		}
+		wrapped := cfg.WrapTransport(http.DefaultTransport)
+		tokenTransport, ok := wrapped.(*auth.EKSTokenTransport)
+		if !ok {
+			t.Fatalf("expected an *auth.EKSTokenTransport, got %T", wrapped)
+		}
+		if tokenTransport.Base != http.DefaultTransport {
+			t.Fatal("expected the wrapped transport to be used as the base")
 		}
 	})
+
+	t.Run("an existing transport wrapper is preserved", func(t *testing.T) {
+		wrapped := false
+		cfg := &rest.Config{
+			ExecProvider: &clientcmdapi.ExecConfig{
+				Command: "aws",
+				Args:    []string{"eks", "get-token", "--cluster-name", "cluster"},
+			},
+		}
+		cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+			wrapped = true
+			return rt
+		})
+		if err := useInProcessTokenAuth(cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg.WrapTransport(http.DefaultTransport)
+		if !wrapped {
+			t.Fatal("the pre-existing transport wrapper was dropped")
+		}
+	})
+
+	t.Run("errors when the cluster name is missing", func(t *testing.T) {
+		cfg := &rest.Config{
+			ExecProvider: &clientcmdapi.ExecConfig{
+				Command: "aws",
+				Args:    []string{"eks", "get-token"},
+			},
+		}
+		if err := useInProcessTokenAuth(cfg); err == nil {
+			t.Fatal("expected an error when the cluster name cannot be determined")
+		}
+	})
+}
+
+func TestClusterNameFromExecProvider(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"aws eks get-token", []string{"eks", "get-token", "--cluster-name", "my-cluster"}, "my-cluster"},
+		{"aws eks get-token with region", []string{"--region", "us-west-2", "eks", "get-token", "--cluster-name", "my-cluster", "--output", "json"}, "my-cluster"},
+		{"joined with equals", []string{"eks", "get-token", "--cluster-name=my-cluster"}, "my-cluster"},
+		{"aws-iam-authenticator short flag", []string{"token", "-i", "my-cluster"}, "my-cluster"},
+		{"aws-iam-authenticator long flag", []string{"token", "--cluster-id", "my-cluster"}, "my-cluster"},
+		{"short flag joined with equals", []string{"token", "-i=my-cluster"}, "my-cluster"},
+		{"surrounding whitespace is trimmed", []string{"token", "-i", "  my-cluster  "}, "my-cluster"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := clusterNameFromExecProvider(&clientcmdapi.ExecConfig{Args: tc.args})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"no arguments", nil},
+		{"no cluster flag", []string{"eks", "get-token", "--region", "us-west-2"}},
+		{"flag with no value", []string{"eks", "get-token", "--cluster-name"}},
+		{"blank value", []string{"token", "-i", "   "}},
+		{"blank joined value", []string{"token", "--cluster-id="}},
+	} {
+		t.Run("errors on "+tc.name, func(t *testing.T) {
+			if _, err := clusterNameFromExecProvider(&clientcmdapi.ExecConfig{Args: tc.args}); err == nil {
+				t.Fatalf("expected an error for args %q", tc.args)
+			}
+		})
+	}
 }
 
 func TestHostPathOverrides(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	k8s.io/cri-client v0.36.3
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
 	pgregory.net/rapid v1.3.0
+	sigs.k8s.io/aws-iam-authenticator v0.7.10
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/e2e-framework v0.7.0
 	sigs.k8s.io/yaml v1.6.0
@@ -87,6 +88,7 @@ require (
 	github.com/go-openapi/swag/typeutils v0.25.5 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
+	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/nftables v0.3.1-0.20251119083706-1db35da82052 // indirect
@@ -108,6 +110,7 @@ require (
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/vishvananda/netlink v1.3.1 // indirect
@@ -134,6 +137,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -218,6 +220,8 @@ github.com/shirou/gopsutil/v4 v4.26.7 h1:IXzpHz/dkMRYAhKkOXr1HB6SuzWU3eoyyeWe7g3
 github.com/shirou/gopsutil/v4 v4.26.7/go.mod h1:5O9FjBiXoTDFatIWjZZosqj4pV0DRtLx598xGbBehzM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
+github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -309,6 +313,8 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -338,6 +344,8 @@ k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 h1:jVkFFVfXdXP74B/zbO3hM3hpSFD0x
 k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3/go.mod h1:M2s5JB1lIYP3jzZdorPLHXIPJzt9vv2muW5a6L9DtNM=
 pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
 pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=
+sigs.k8s.io/aws-iam-authenticator v0.7.10 h1:Ue+FTB0uGh6jC8TJx3FCmQd5+nm9SNl67ft73KVRBOU=
+sigs.k8s.io/aws-iam-authenticator v0.7.10/go.mod h1:46w5B+GVUk9fJs4YzMapfZnyiFclWjoRCAPYrzBEenE=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/e2e-framework v0.7.0 h1:AHkySTC6MvnnMbVSxaO4z1m2MhQKNFP+2Ihs5pRNLlM=

--- a/pkg/auth/eks_token.go
+++ b/pkg/auth/eks_token.go
@@ -1,0 +1,137 @@
+// Package auth generates the bearer tokens the agent uses to authenticate to
+// the EKS API server.
+//
+// EKS kubeconfigs authenticate through a client-go exec credential plugin that
+// shells out to `aws eks get-token` (or `aws-iam-authenticator token`). Running
+// that plugin costs a process launch every time client-go refreshes the
+// credential: the aws CLI alone resident-sets roughly 50MB, which on top of the
+// agent's own footprint is enough to cross the container's cgroup memory limit
+// and get the pod OOM killed. Because client-go caches the credential until it
+// expires, the spike recurs on the token's ~15 minute refresh cycle.
+//
+// This package produces the same token in-process using the same library the
+// plugin does, so refreshing costs no extra process and no extra memory.
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/aws-iam-authenticator/pkg/token"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// tokenRefreshBuffer is how long before expiry a cached token is considered
+// stale. EKS tokens live for ~15 minutes, so refreshing a minute early keeps a
+// request from being signed with a token that expires in flight.
+const tokenRefreshBuffer = 1 * time.Minute
+
+// EKSTokenGenerator mints EKS authentication tokens for a single cluster and
+// caches the result until it is close to expiring.
+//
+// Tokens are presigned STS GetCallerIdentity URLs, so generating one requires
+// AWS credentials. Those are resolved by the default AWS credential chain,
+// which reaches IMDS over the pod's network namespace. The agent runs with
+// hostNetwork, so IMDS returns the node's instance profile: the same identity
+// the exec credential plugin obtained by chrooting onto the host.
+type EKSTokenGenerator struct {
+	clusterName string
+	generator   token.Generator
+
+	// mu guards the cached token. A plain Mutex is enough — tokens are reused
+	// for ~14 minutes, so this is contended about once per refresh.
+	mu          sync.Mutex
+	cachedToken string
+	tokenExpiry time.Time
+}
+
+// NewEKSTokenGenerator creates a token generator for the named cluster.
+func NewEKSTokenGenerator(clusterName string) (*EKSTokenGenerator, error) {
+	// the cluster name ends up in the signed request as the x-k8s-aws-id header,
+	// so a blank name would yield a token the API server rejects with a
+	// confusing error. Fail here instead.
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" {
+		return nil, fmt.Errorf("cluster name must not be empty")
+	}
+
+	// forwardSessionName=true preserves the caller's STS session name in the
+	// generated token, which keeps the node's identity legible in CloudTrail.
+	// cache=false disables the library's on-disk credential cache; this process
+	// holds the token in memory (see GetToken) and writing to the container
+	// filesystem buys nothing.
+	gen, err := token.NewGenerator(true, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token generator: %w", err)
+	}
+
+	return &EKSTokenGenerator{
+		clusterName: clusterName,
+		generator:   gen,
+	}, nil
+}
+
+// GetToken returns a valid EKS authentication token, reusing the cached one
+// until it is within tokenRefreshBuffer of expiring.
+func (g *EKSTokenGenerator) GetToken(ctx context.Context) (string, error) {
+	logger := log.FromContext(ctx).WithName("eks-token-generator")
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.valid() {
+		logger.V(4).Info("using cached EKS token", "expiry", g.tokenExpiry)
+		return g.cachedToken, nil
+	}
+
+	tok, err := g.generator.GetWithOptions(ctx, &token.GetTokenOptions{
+		ClusterID: g.clusterName,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate EKS token: %w", err)
+	}
+
+	g.cachedToken = tok.Token
+	g.tokenExpiry = tok.Expiration
+
+	logger.Info("generated new EKS token", "cluster", g.clusterName, "expiry", tok.Expiration)
+	return tok.Token, nil
+}
+
+// valid reports whether the cached token can still be used. Callers must hold mu.
+func (g *EKSTokenGenerator) valid() bool {
+	return g.cachedToken != "" && time.Now().Add(tokenRefreshBuffer).Before(g.tokenExpiry)
+}
+
+// EKSTokenTransport authenticates outbound API server requests with a token
+// from Generator. It replaces the exec credential plugin that client-go would
+// otherwise run, so it must be installed on the rest.Config that has had its
+// ExecProvider cleared.
+type EKSTokenTransport struct {
+	Base      http.RoundTripper
+	Generator *EKSTokenGenerator
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *EKSTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	tok, err := t.Generator.GetToken(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get EKS token: %w", err)
+	}
+
+	// RoundTrippers must not mutate the request they are given: the caller may
+	// still read it, and client-go retries by re-sending the same request. Clone
+	// it and set the header on the copy.
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}

--- a/pkg/auth/eks_token_test.go
+++ b/pkg/auth/eks_token_test.go
@@ -1,0 +1,147 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewEKSTokenGenerator(t *testing.T) {
+	t.Run("builds a generator for the cluster", func(t *testing.T) {
+		generator, err := NewEKSTokenGenerator("test-cluster")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if generator.clusterName != "test-cluster" {
+			t.Fatalf("expected cluster name %q, got %q", "test-cluster", generator.clusterName)
+		}
+		if generator.generator == nil {
+			t.Fatal("expected an underlying token generator")
+		}
+	})
+
+	t.Run("trims surrounding whitespace from the cluster name", func(t *testing.T) {
+		generator, err := NewEKSTokenGenerator("  test-cluster\n")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if generator.clusterName != "test-cluster" {
+			t.Fatalf("expected cluster name %q, got %q", "test-cluster", generator.clusterName)
+		}
+	})
+
+	// a blank cluster name would produce a token the API server rejects, so it
+	// has to fail at construction rather than on the first request.
+	for _, clusterName := range []string{"", " ", "\t\n"} {
+		t.Run(fmt.Sprintf("rejects the blank cluster name %q", clusterName), func(t *testing.T) {
+			if _, err := NewEKSTokenGenerator(clusterName); err == nil {
+				t.Fatalf("expected an error for cluster name %q", clusterName)
+			}
+		})
+	}
+}
+
+func TestGeneratorValid(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		token  string
+		expiry time.Time
+		want   bool
+	}{
+		{"no cached token", "", time.Now().Add(time.Hour), false},
+		{"fresh token", "tok", time.Now().Add(time.Hour), true},
+		{"expired token", "tok", time.Now().Add(-time.Minute), false},
+		// within the refresh buffer the token is still technically valid, but a
+		// request signed with it could expire in flight.
+		{"token inside the refresh buffer", "tok", time.Now().Add(tokenRefreshBuffer / 2), false},
+		{"token just outside the refresh buffer", "tok", time.Now().Add(tokenRefreshBuffer + time.Minute), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &EKSTokenGenerator{cachedToken: tc.token, tokenExpiry: tc.expiry}
+			if got := g.valid(); got != tc.want {
+				t.Fatalf("expected valid()==%v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestGetTokenReturnsCachedToken(t *testing.T) {
+	// generator is deliberately nil: if GetToken tried to mint a new token
+	// instead of serving the cache, this would panic.
+	g := &EKSTokenGenerator{
+		clusterName: "test-cluster",
+		cachedToken: "cached-token",
+		tokenExpiry: time.Now().Add(time.Hour),
+	}
+
+	got, err := g.GetToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "cached-token" {
+		t.Fatalf("expected the cached token, got %q", got)
+	}
+}
+
+func TestEKSTokenTransport(t *testing.T) {
+	newGenerator := func(tok string) *EKSTokenGenerator {
+		return &EKSTokenGenerator{
+			clusterName: "test-cluster",
+			cachedToken: tok,
+			tokenExpiry: time.Now().Add(time.Hour),
+		}
+	}
+
+	t.Run("authorizes the request with a bearer token", func(t *testing.T) {
+		var seen string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			seen = r.Header.Get("Authorization")
+		}))
+		defer server.Close()
+
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		transport := &EKSTokenTransport{Base: server.Client().Transport, Generator: newGenerator("tok")}
+		resp, err := transport.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if want := "Bearer tok"; seen != want {
+			t.Fatalf("expected header %q, got %q", want, seen)
+		}
+		// RoundTrippers must leave the request they are handed alone, because
+		// client-go may re-send it on retry.
+		if got := req.Header.Get("Authorization"); got != "" {
+			t.Fatalf("the original request was mutated: %q", got)
+		}
+	})
+
+	t.Run("propagates errors from the base transport", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://example.invalid", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantErr := errors.New("boom")
+		transport := &EKSTokenTransport{
+			Base:      roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, wantErr }),
+			Generator: newGenerator("tok"),
+		}
+		if _, err := transport.RoundTrip(req); !errors.Is(err, wantErr) {
+			t.Fatalf("expected the base transport error, got %v", err)
+		}
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }


### PR DESCRIPTION
The host kubeconfig authenticates through a client-go exec credential plugin, so the agent invoked `aws eks get-token` by chrooting onto the host root. client-go caches that credential until it expires, so the plugin ran again roughly every 15 minutes, and the aws CLI's ~50MB resident set on top of the agent's own footprint was enough to cross the container's cgroup memory limit and get the pod OOM killed. This is one cause of the agent restarts when launched with ~100Mi memory limits:

    aws invoked oom-killer: gfp_mask=0xcc0(GFP_KERNEL), order=0, oom_score_adj=-997

Generate the same token in-process with the library the plugin itself uses (sigs.k8s.io/aws-iam-authenticator), cache it in memory, and attach it via a rest.Config transport wrapper. Clearing the ExecProvider is what stops client-go from launching the plugin at all, so the periodic spike goes away entirely.

The token is a presigned STS request, so this still relies on reaching IMDS for the node's instance profile — unchanged, since the agent already runs with hostNetwork for the chrooted plugin.

Kubeconfigs that authenticate with a client certificate or token file carry no credential plugin and are left alone.

Cluster-name parsing handles both `aws eks get-token --cluster-name` and `aws-iam-authenticator token -i`, since either plugin may back the kubeconfig. A blank cluster name is rejected up front rather than yielding a token the API server would reject with a confusing error.

**Issue #, if available**:

**Description of changes**:

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
