### PR TITLE
chore: Bump go from 1.26.4 to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /staging/usr/lib64 /staging/usr/bin /staging/usr/libexec && \
 # =============================================================================
 # Stage 3: Go builder to compile the application
 # =============================================================================
-FROM public.ecr.aws/docker/library/golang:1.26.4 AS go-builder
+FROM public.ecr.aws/docker/library/golang:1.26.6 AS go-builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/eks-node-monitoring-agent
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/NVIDIA/go-dcgm v1.4601.1


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Update go version from 1.26.4 to 1.26.6

**Testing Done**:
make build and test's pass.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
