### PR TITLE
fix(diagnostic): rate-limit console writes to avoid serial-console stalls

### DIFF
--- a/pkg/diagnostic/logger.go
+++ b/pkg/diagnostic/logger.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -73,12 +74,82 @@ const (
 	// unit journal is buffered into memory each cycle and grows unbounded
 	// over the node's lifetime. Chosen to comfortably exceed the section budget.
 	journalMaxLines = "2000"
+
+	// consoleBytesPerSecond caps the rate at which diagnostic output is handed
+	// to /dev/console, a serial device with a finite drain rate (~40 KB/s
+	// observed on a 2-vCPU node). RunOnce already writes one section at a time
+	// (up to ~9.4KB each, sectionBytes), but each of those writes is large
+	// enough to occupy the line long enough (~230ms) to stall co-located
+	// workloads' network path (DNS/TCP latency spikes). Pacing below the drain
+	// rate, in small chunks, keeps any single contiguous span short. 32 KB/s is
+	// set below the ~40 KB/s drain rate; the tradeoff is a slightly longer total
+	// cycle (~68KB at 32 KB/s => ~2.1s vs ~1.7s unpaced) for a much shorter
+	// per-write busy span.
+	consoleBytesPerSecond = 32 * 1024
+	// consoleWriteChunk bounds each contiguous write to the console so that no
+	// single write occupies the serial line long enough to trip the stall,
+	// regardless of section size. Small relative to consoleBytesPerSecond so
+	// writes stay smooth.
+	consoleWriteChunk = 2 * 1024
 )
+
+// pacedWriter wraps an io.Writer (the /dev/console handle) and feeds bytes
+// through at a fixed rate in small chunks, so a large diagnostic cycle is
+// spread over time rather than written as one blocking burst.
+type pacedWriter struct {
+	w       io.Writer
+	limiter *rate.Limiter
+	chunk   int
+}
+
+// newPacedWriter returns a writer that hands bytes to w at bytesPerSecond in
+// chunks of at most chunkBytes. The limiter's burst equals chunkBytes so the
+// allowance never accumulates enough to permit a large instantaneous write.
+func newPacedWriter(w io.Writer, bytesPerSecond, chunkBytes int) *pacedWriter {
+	return &pacedWriter{
+		w:       w,
+		limiter: rate.NewLimiter(rate.Limit(bytesPerSecond), chunkBytes),
+		chunk:   chunkBytes,
+	}
+}
+
+// Write splits p into chunks and blocks before each one until the rate limiter
+// permits it, so the aggregate throughput to the underlying writer stays at or
+// below the configured bytes-per-second.
+func (pw *pacedWriter) Write(p []byte) (int, error) {
+	written := 0
+	for written < len(p) {
+		end := written + pw.chunk
+		if end > len(p) {
+			end = len(p)
+		}
+		// WaitN blocks until len(chunk) tokens are available. context.Background
+		// is used because this write path has no cancellation signal; a full
+		// cycle is bounded (~68KB at 32 KB/s => ~2.1s) and well under the
+		// LogInterval. Note a paced write cannot be aborted by shutdown; worst
+		// case is one cycle (~2.1s, up to ~2.9s for a full ~95KB) against the
+		// 30s console flush grace, so teardown is not meaningfully delayed.
+		if err := pw.limiter.WaitN(context.Background(), end-written); err != nil {
+			return written, err
+		}
+		n, err := pw.w.Write(p[written:end])
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	return written, nil
+}
 
 func NewDiagnosticLogger(writer io.Writer, settings Settings) diagnosticLogger {
 	if writer == nil {
 		writer = os.Stdout
 	}
+	// Pace writes to the (serial) console so each section is fed to the device
+	// at a rate below its drain rate in small chunks, rather than in writes
+	// large enough to occupy the line long enough to stall co-located
+	// workloads' network path.
+	writer = newPacedWriter(writer, consoleBytesPerSecond, consoleWriteChunk)
 	if settings.LogInterval <= 0 {
 		settings.LogInterval = 5 * time.Minute
 	}

--- a/pkg/diagnostic/logger.go
+++ b/pkg/diagnostic/logger.go
@@ -75,21 +75,12 @@ const (
 	// over the node's lifetime. Chosen to comfortably exceed the section budget.
 	journalMaxLines = "2000"
 
-	// consoleBytesPerSecond caps the rate at which diagnostic output is handed
-	// to /dev/console, a serial device with a finite drain rate (~40 KB/s
-	// observed on a 2-vCPU node). RunOnce already writes one section at a time
-	// (up to ~9.4KB each, sectionBytes), but each of those writes is large
-	// enough to occupy the line long enough (~230ms) to stall co-located
-	// workloads' network path (DNS/TCP latency spikes). Pacing below the drain
-	// rate, in small chunks, keeps any single contiguous span short. 32 KB/s is
-	// set below the ~40 KB/s drain rate; the tradeoff is a slightly longer total
-	// cycle (~68KB at 32 KB/s => ~2.1s vs ~1.7s unpaced) for a much shorter
-	// per-write busy span.
+	// Pace console writes below the serial device's drain rate so a diagnostic
+	// cycle cannot monopolize the line and stall co-located workloads' network
+	// path. Set under the ~40 KB/s observed on a 2-vCPU node.
 	consoleBytesPerSecond = 32 * 1024
-	// consoleWriteChunk bounds each contiguous write to the console so that no
-	// single write occupies the serial line long enough to trip the stall,
-	// regardless of section size. Small relative to consoleBytesPerSecond so
-	// writes stay smooth.
+	// Bound each contiguous write so no single write is large enough to stall
+	// the line, independent of section size.
 	consoleWriteChunk = 2 * 1024
 )
 
@@ -123,12 +114,9 @@ func (pw *pacedWriter) Write(p []byte) (int, error) {
 		if end > len(p) {
 			end = len(p)
 		}
-		// WaitN blocks until len(chunk) tokens are available. context.Background
-		// is used because this write path has no cancellation signal; a full
-		// cycle is bounded (~68KB at 32 KB/s => ~2.1s) and well under the
-		// LogInterval. Note a paced write cannot be aborted by shutdown; worst
-		// case is one cycle (~2.1s, up to ~2.9s for a full ~95KB) against the
-		// 30s console flush grace, so teardown is not meaningfully delayed.
+		// context.Background: this path has no cancellation signal, and a bounded
+		// cycle stays well under the flush grace, so a paced write is not worth
+		// making abortable.
 		if err := pw.limiter.WaitN(context.Background(), end-written); err != nil {
 			return written, err
 		}
@@ -145,10 +133,7 @@ func NewDiagnosticLogger(writer io.Writer, settings Settings) diagnosticLogger {
 	if writer == nil {
 		writer = os.Stdout
 	}
-	// Pace writes to the (serial) console so each section is fed to the device
-	// at a rate below its drain rate in small chunks, rather than in writes
-	// large enough to occupy the line long enough to stall co-located
-	// workloads' network path.
+	// Rate-limit console writes; see consoleBytesPerSecond.
 	writer = newPacedWriter(writer, consoleBytesPerSecond, consoleWriteChunk)
 	if settings.LogInterval <= 0 {
 		settings.LogInterval = 5 * time.Minute

--- a/pkg/diagnostic/logger_test.go
+++ b/pkg/diagnostic/logger_test.go
@@ -334,7 +334,7 @@ func (w *errAfterWriter) Write(p []byte) (int, error) {
 }
 
 // chunkRecorder remembers the size of every Write it receives, so a test can
-// assert on how the bytes were SPLIT and not only on the total that arrived.
+// assert on how the bytes were split.
 type chunkRecorder struct {
 	buf   bytes.Buffer
 	sizes []int
@@ -356,62 +356,60 @@ func (c *chunkRecorder) maxSize() int {
 }
 
 // The load-bearing claim of the fix is that no single write occupies the serial
-// line for long. 9517 bytes is a realistic section at the sectionBytes cap, so
-// this exercises the production case: every write must still be chunked to at
-// most consoleWriteChunk, and all bytes must arrive intact. Run this against an
-// unwrapped writer and it fails with maxSize == 9517 — that is the proof the
-// harness measures the right thing.
-func TestPacedWriterBoundsEveryChunkAtSectionSize(t *testing.T) {
-	const sectionSize = 9517
+// line for long: every write to the underlying console is bounded by
+// consoleWriteChunk and all bytes arrive intact and in order.
+func TestPacedWriterBoundsEveryChunk(t *testing.T) {
+	// A realistic large section must be split into ceil(size/chunk) bounded
+	// writes. Against an unwrapped writer this fails with maxSize == sectionSize,
+	// which proves the harness measures the right thing.
+	t.Run("LargeSection", func(t *testing.T) {
+		const sectionSize = 9517
 
-	rec := &chunkRecorder{}
-	pw := newPacedWriter(rec, consoleBytesPerSecond, consoleWriteChunk)
+		rec := &chunkRecorder{}
+		pw := newPacedWriter(rec, consoleBytesPerSecond, consoleWriteChunk)
 
-	// Distinguishable bytes so a chunk written twice, skipped, or reordered is
-	// visible. An all-identical payload would compare equal despite such a bug.
-	payload := make([]byte, sectionSize)
-	for i := range payload {
-		payload[i] = byte('A' + i%26)
-	}
+		// Distinguishable bytes so a chunk written twice, skipped, or reordered
+		// is visible.
+		payload := make([]byte, sectionSize)
+		for i := range payload {
+			payload[i] = byte('A' + i%26)
+		}
 
-	n, err := pw.Write(payload)
+		n, err := pw.Write(payload)
 
-	require.NoError(t, err)
-	assert.Equal(t, sectionSize, n)
-	assert.Equal(t, payload, rec.buf.Bytes(), "bytes must arrive intact and in order")
-	assert.LessOrEqual(t, rec.maxSize(), consoleWriteChunk,
-		"one oversized write is one long contiguous span on the serial line")
-	assert.Len(t, rec.sizes, (sectionSize+consoleWriteChunk-1)/consoleWriteChunk,
-		"must split into ceil(size/chunk) writes")
+		require.NoError(t, err)
+		assert.Equal(t, sectionSize, n)
+		assert.Equal(t, payload, rec.buf.Bytes(), "bytes must arrive intact and in order")
+		assert.LessOrEqual(t, rec.maxSize(), consoleWriteChunk,
+			"one oversized write is one long contiguous span on the serial line")
+		assert.Len(t, rec.sizes, (sectionSize+consoleWriteChunk-1)/consoleWriteChunk,
+			"must split into ceil(size/chunk) writes")
+	})
+
+	// Most real sections are under the chunk size; those pass through as one
+	// write and are not delayed (the initial bucket is full).
+	t.Run("SubChunkWrite", func(t *testing.T) {
+		rec := &chunkRecorder{}
+		pw := newPacedWriter(rec, consoleBytesPerSecond, consoleWriteChunk)
+
+		payload := []byte("short section")
+		start := time.Now()
+		n, err := pw.Write(payload)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		assert.Equal(t, len(payload), n)
+		assert.Equal(t, payload, rec.buf.Bytes())
+		assert.Len(t, rec.sizes, 1, "a write below the chunk size must not be split")
+		assert.Less(t, elapsed, 100*time.Millisecond, "the initial bucket is full, so this must not block")
+	})
 }
 
-// burst MUST equal the chunk size. Smaller and WaitN can never be satisfied and
-// every write fails; larger and the bucket starts with enough allowance to
-// release several chunks back-to-back with no gap between them, recreating the
-// long contiguous span the fix removes. This invariant is the one thing the
-// throughput/total-bytes tests cannot see.
+// burst MUST equal the chunk size: a larger burst lets several chunks fire
+// back-to-back with no gap, recreating the long contiguous write the fix removes.
 func TestPacedWriterBurstEqualsChunk(t *testing.T) {
 	pw := newPacedWriter(&bytes.Buffer{}, consoleBytesPerSecond, consoleWriteChunk)
 	assert.Equal(t, consoleWriteChunk, pw.limiter.Burst())
-}
-
-// Most sections on a real node are well under the chunk size (43-2017 bytes
-// measured). Those must pass through as ONE write, and the full initial bucket
-// means they are not delayed.
-func TestPacedWriterPassesSubChunkWriteThrough(t *testing.T) {
-	rec := &chunkRecorder{}
-	pw := newPacedWriter(rec, consoleBytesPerSecond, consoleWriteChunk)
-
-	payload := []byte("short section")
-	start := time.Now()
-	n, err := pw.Write(payload)
-	elapsed := time.Since(start)
-
-	require.NoError(t, err)
-	assert.Equal(t, len(payload), n)
-	assert.Equal(t, payload, rec.buf.Bytes())
-	assert.Len(t, rec.sizes, 1, "a write below the chunk size must not be split")
-	assert.Less(t, elapsed, 100*time.Millisecond, "the initial bucket is full, so this must not block")
 }
 
 // pacedWriter must throttle throughput: pushing bytesPerSecond worth of data
@@ -450,9 +448,8 @@ func TestPacedWriterPropagatesWriteError(t *testing.T) {
 	assert.Equal(t, 2*1024, n, "must report exactly the bytes the first chunk wrote")
 }
 
-// Both console call sites construct through NewDiagnosticLogger, so the wrap has
-// to live there. Without this, removing that one wrap line breaks the fix
-// silently while every pacedWriter test above stays green.
+// Guards the wiring: if the wrap in NewDiagnosticLogger is removed the fix is
+// silently disabled while every pacedWriter test above still passes.
 func TestNewDiagnosticLoggerWrapsWriterInPacedWriter(t *testing.T) {
 	l := NewDiagnosticLogger(&bytes.Buffer{}, Settings{})
 	_, ok := l.writer.(*pacedWriter)

--- a/pkg/diagnostic/logger_test.go
+++ b/pkg/diagnostic/logger_test.go
@@ -315,3 +315,146 @@ func TestReadFileTail(t *testing.T) {
 		assert.Contains(t, string(got), "failed to read")
 	})
 }
+
+// errAfterWriter writes normally until it has accepted limit bytes, then fails.
+// Used to check that pacedWriter surfaces an underlying write error and reports
+// how much it managed to write.
+type errAfterWriter struct {
+	buf     bytes.Buffer
+	limit   int
+	written int
+}
+
+func (w *errAfterWriter) Write(p []byte) (int, error) {
+	if w.written >= w.limit {
+		return 0, errors.New("write failed")
+	}
+	w.written += len(p)
+	return w.buf.Write(p)
+}
+
+// chunkRecorder remembers the size of every Write it receives, so a test can
+// assert on how the bytes were SPLIT and not only on the total that arrived.
+type chunkRecorder struct {
+	buf   bytes.Buffer
+	sizes []int
+}
+
+func (c *chunkRecorder) Write(p []byte) (int, error) {
+	c.sizes = append(c.sizes, len(p))
+	return c.buf.Write(p)
+}
+
+func (c *chunkRecorder) maxSize() int {
+	m := 0
+	for _, s := range c.sizes {
+		if s > m {
+			m = s
+		}
+	}
+	return m
+}
+
+// The load-bearing claim of the fix is that no single write occupies the serial
+// line for long. 9517 bytes is a realistic section at the sectionBytes cap, so
+// this exercises the production case: every write must still be chunked to at
+// most consoleWriteChunk, and all bytes must arrive intact. Run this against an
+// unwrapped writer and it fails with maxSize == 9517 — that is the proof the
+// harness measures the right thing.
+func TestPacedWriterBoundsEveryChunkAtSectionSize(t *testing.T) {
+	const sectionSize = 9517
+
+	rec := &chunkRecorder{}
+	pw := newPacedWriter(rec, consoleBytesPerSecond, consoleWriteChunk)
+
+	// Distinguishable bytes so a chunk written twice, skipped, or reordered is
+	// visible. An all-identical payload would compare equal despite such a bug.
+	payload := make([]byte, sectionSize)
+	for i := range payload {
+		payload[i] = byte('A' + i%26)
+	}
+
+	n, err := pw.Write(payload)
+
+	require.NoError(t, err)
+	assert.Equal(t, sectionSize, n)
+	assert.Equal(t, payload, rec.buf.Bytes(), "bytes must arrive intact and in order")
+	assert.LessOrEqual(t, rec.maxSize(), consoleWriteChunk,
+		"one oversized write is one long contiguous span on the serial line")
+	assert.Len(t, rec.sizes, (sectionSize+consoleWriteChunk-1)/consoleWriteChunk,
+		"must split into ceil(size/chunk) writes")
+}
+
+// burst MUST equal the chunk size. Smaller and WaitN can never be satisfied and
+// every write fails; larger and the bucket starts with enough allowance to
+// release several chunks back-to-back with no gap between them, recreating the
+// long contiguous span the fix removes. This invariant is the one thing the
+// throughput/total-bytes tests cannot see.
+func TestPacedWriterBurstEqualsChunk(t *testing.T) {
+	pw := newPacedWriter(&bytes.Buffer{}, consoleBytesPerSecond, consoleWriteChunk)
+	assert.Equal(t, consoleWriteChunk, pw.limiter.Burst())
+}
+
+// Most sections on a real node are well under the chunk size (43-2017 bytes
+// measured). Those must pass through as ONE write, and the full initial bucket
+// means they are not delayed.
+func TestPacedWriterPassesSubChunkWriteThrough(t *testing.T) {
+	rec := &chunkRecorder{}
+	pw := newPacedWriter(rec, consoleBytesPerSecond, consoleWriteChunk)
+
+	payload := []byte("short section")
+	start := time.Now()
+	n, err := pw.Write(payload)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, len(payload), n)
+	assert.Equal(t, payload, rec.buf.Bytes())
+	assert.Len(t, rec.sizes, 1, "a write below the chunk size must not be split")
+	assert.Less(t, elapsed, 100*time.Millisecond, "the initial bucket is full, so this must not block")
+}
+
+// pacedWriter must throttle throughput: pushing bytesPerSecond worth of data
+// should take on the order of a second, not complete instantly.
+func TestPacedWriterThrottlesThroughput(t *testing.T) {
+	var dst bytes.Buffer
+	const rate = 8 * 1024 // 8 KB/s
+	pw := newPacedWriter(&dst, rate, 1*1024)
+
+	// Write ~2x the per-second rate; at 8 KB/s that must take ~1s (with the
+	// initial burst allowance, a little less). Assert a conservative floor so
+	// the test is not flaky.
+	payload := bytes.Repeat([]byte("y"), 2*rate)
+	start := time.Now()
+	n, err := pw.Write(payload)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, len(payload), n)
+	assert.GreaterOrEqual(t, elapsed, 800*time.Millisecond,
+		"writing ~2s of data at the configured rate must be throttled, not instant")
+}
+
+// When the underlying writer fails mid-stream, pacedWriter must return the
+// error and the count of bytes written before the failure.
+func TestPacedWriterPropagatesWriteError(t *testing.T) {
+	// Accept the first chunk, fail on the next.
+	dst := &errAfterWriter{limit: 2 * 1024}
+	pw := newPacedWriter(dst, 10*1024*1024, 2*1024)
+
+	payload := bytes.Repeat([]byte("z"), 5*1024)
+	n, err := pw.Write(payload)
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "write failed", "the underlying error must surface unwrapped")
+	assert.Equal(t, 2*1024, n, "must report exactly the bytes the first chunk wrote")
+}
+
+// Both console call sites construct through NewDiagnosticLogger, so the wrap has
+// to live there. Without this, removing that one wrap line breaks the fix
+// silently while every pacedWriter test above stays green.
+func TestNewDiagnosticLoggerWrapsWriterInPacedWriter(t *testing.T) {
+	l := NewDiagnosticLogger(&bytes.Buffer{}, Settings{})
+	_, ok := l.writer.(*pacedWriter)
+	assert.True(t, ok, "NewDiagnosticLogger must wrap its writer for pacing")
+}


### PR DESCRIPTION
**Issue #, if available**: Relates to #224

**Description of changes**:
This change wraps the console writer in a rate limiter (golang.org/x/time/rate, already a dependency) that feeds bytes to the device at 32 KB/s in ~2KB chunks — below the drain rate. This bounds every contiguous write regardless of section size, so no single write occupies the serial line long enough to stall the network path. RunOnce and the emitted content are unchanged; only the write rate is paced. Pacing is always on; the tradeoff is a slightly longer total cycle (~2.1s vs ~1.7s), which stays well under the 5-minute log interval.

**Testing Done**:
- Unit tests (pkg/diagnostic/logger_test.go): writes above the chunk size are split into correctly sized chunks with bytes arriving intact and in order, sub-chunk writes pass through as a single unsplit write, the burst-equals-chunk invariant that makes the spacing work holds, throughput is throttled, the underlying write error surfaces unwrapped, and NewDiagnosticLogger actually wraps its writer. 
- Root-cause isolation (non-Auto 2-vCPU, arm64, under load): a controlled back-to-back write of a full cycle's bytes to /dev/console reproduced DNS/TCP latency spikes (up to ~600–900ms) coinciding with the write; running the collectors without the write produced none; splitting the same bytes into rate-limited chunks eliminated the spikes.
- Symptom reproduction (Auto Mode 2-vCPU, arm64, #224 setup): latency spikes reproduce on the 5-minute NMA cycle (up to ~1.1s total), confirming the issue on the reported configuration.
- On-node smoke test: built and ran the patched agent on a 2-vCPU node; all 10 sections are still emitted, now fed to the console at the paced rate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.