### PR TITLE
allow disabeling reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ nodeAgent:
         - "^ib[0-9]+$"
 ```
 
+### Disabling individual reasons
+
+Every monitor supports `disabledReasons` to suppress specific findings without turning off the monitor as a whole. Any condition with a matching reason is dropped before it is exported to the node status, events or metrics. Reason names can be found in `docs/node-health-issues.adoc`; parameterized reasons are specified in their rendered form (e.g. `NvidiaXID79Error`). Entries are not validated against a fixed catalog, so a name that does not match an emitted reason has no effect.
+
+For example, to suppress `IPAMDNotReady` findings:
+
+```yaml
+nodeAgent:
+  monitors:
+    networking:
+      disabledReasons:
+        - "IPAMDNotReady"
+```
+
 ### Config File Format
 
 The agent reads a YAML config file mounted at `/etc/nma/config.yaml`. Omitted monitors default to enabled.
@@ -102,6 +116,11 @@ When a monitor is disabled:
 
 - Its health checks are not executed.
 - The corresponding `NodeCondition` (e.g., `NetworkingReady`) is not set on the node, avoiding false-positive healthy status for unmonitored subsystems.
+
+When a reason is disabled via `disabledReasons`:
+
+- The monitor keeps running and its other checks remain active.
+- Conditions with the disabled reason are never exported, so they do not affect the node status or trigger auto-repair actions.
 
 ## Building
 

--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -247,6 +247,14 @@
                     "items": {
                       "type": "string"
                     }
+                },
+                "disabledReasons": {
+                    "type": "array",
+                    "description": "List of reason names (e.g. \"IPAMDNotReady\") whose detected conditions should be suppressed. Any condition with a matching reason is dropped before it is exported to the node status, events or metrics. See the node health issues documentation for the complete list of reason names.",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -260,6 +268,14 @@
                     "type": "boolean",
                     "description": "Whether this monitor is enabled",
                     "default": true
+                },
+                "disabledReasons": {
+                    "type": "array",
+                    "description": "List of reason names (e.g. \"ZramHighUsage\") whose detected conditions should be suppressed. Any condition with a matching reason is dropped before it is exported to the node status, events or metrics. See the node health issues documentation for the complete list of reason names.",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -345,6 +345,12 @@ func run() error {
 		logger.Info("initializing monitoring manager")
 		monitorMgr := manager.NewMonitorManager(hostname, nodeExporter)
 
+		// Drop conditions for individual reasons disabled by configuration.
+		if disabledReasons := monitorConfig.GetDisabledReasons(); len(disabledReasons) > 0 {
+			monitorMgr.SetDisabledReasons(disabledReasons)
+			logger.Info("reasons disabled by configuration", "reasons", disabledReasons)
+		}
+
 		// Register all monitors with the manager
 		for _, mon := range enabledMonitors {
 			monCtx := log.IntoContext(ctx, logger.WithValues("monitor", mon.Name()))

--- a/pkg/config/monitor.go
+++ b/pkg/config/monitor.go
@@ -19,6 +19,10 @@ type MonitorSettings struct {
 	Enabled                      *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	AllowedIPTablesChains        []string `yaml:"allowedIPTablesChains,omitempty" json:"allowedIPTablesChains,omitempty"`
 	ExcludedInterfaceNameRegexps []string `yaml:"excludedInterfaceNameRegexps,omitempty" json:"excludedInterfaceNameRegexps,omitempty"`
+	// DisabledReasons lists reason names (e.g. "IPAMDNotReady") whose
+	// conditions should be suppressed. Parameterized reasons are specified in
+	// their rendered form (e.g. "NvidiaXID79Error").
+	DisabledReasons []string `yaml:"disabledReasons,omitempty" json:"disabledReasons,omitempty"`
 }
 
 // IsEnabled returns true if the monitor is enabled.
@@ -100,6 +104,20 @@ func (mc *MonitorConfig) GetExcludedInterfaceNameRegexps() []string {
 	return settings.ExcludedInterfaceNameRegexps
 }
 
+// GetDisabledReasons returns the aggregated list of reasons disabled across
+// all monitors. Reason names are globally unique across monitors, so an entry
+// applies wherever that reason is emitted.
+func (mc *MonitorConfig) GetDisabledReasons() []string {
+	if mc == nil || mc.Monitors == nil {
+		return nil
+	}
+	var disabled []string
+	for _, settings := range mc.Monitors {
+		disabled = append(disabled, settings.DisabledReasons...)
+	}
+	return disabled
+}
+
 // KnownPluginNames is the set of valid plugin names for validation.
 var KnownPluginNames = []string{
 	"kernel-monitor",
@@ -151,6 +169,11 @@ func (mc *MonitorConfig) Validate() error {
 				if _, err := regexp.Compile(expr); err != nil {
 					return fmt.Errorf("excludedInterfaceNameRegexps entry %q is not a valid regular expression: %w", expr, err)
 				}
+			}
+		}
+		for _, reason := range settings.DisabledReasons {
+			if reason == "" || strings.TrimSpace(reason) != reason {
+				return fmt.Errorf("disabledReasons entry must not be empty or have leading/trailing whitespace")
 			}
 		}
 	}

--- a/pkg/config/monitor_test.go
+++ b/pkg/config/monitor_test.go
@@ -435,3 +435,83 @@ func TestLoadMonitorConfig_StrictUnmarshalRejectsUnknownFields(t *testing.T) {
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "parsing monitor config")
 }
+
+func TestLoadMonitorConfig_DisabledReasons(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`monitors:
+  networking:
+    disabledReasons:
+      - IPAMDNotReady
+  kernel-monitor:
+    disabledReasons:
+      - ZramHighUsage
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.True(t, found)
+
+	// Reasons disabled across monitors are aggregated.
+	elements := cfg.GetDisabledReasons()
+	assert.ElementsMatch(t, []string{"IPAMDNotReady", "ZramHighUsage"}, elements)
+}
+
+func TestGetDisabledReasons(t *testing.T) {
+	t.Run("NilConfig", func(t *testing.T) {
+		var cfg *config.MonitorConfig
+		assert.Nil(t, cfg.GetDisabledReasons())
+	})
+	t.Run("EmptyMap", func(t *testing.T) {
+		cfg := &config.MonitorConfig{}
+		assert.Nil(t, cfg.GetDisabledReasons())
+	})
+	t.Run("NoDisabledReasons", func(t *testing.T) {
+		cfg := &config.MonitorConfig{
+			Monitors: map[string]config.MonitorSettings{
+				"networking": {Enabled: boolPtr(false)},
+			},
+		}
+		assert.Nil(t, cfg.GetDisabledReasons())
+	})
+}
+
+func TestLoadMonitorConfig_DisabledReasonsRenderedTemplateAccepted(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	// Parameterized reasons are referenced in their rendered form. Reason
+	// names are not validated against a catalog, so any non-empty entry is
+	// accepted.
+	content := []byte(`monitors:
+  nvidia:
+    disabledReasons:
+      - NvidiaXID79Error
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, []string{"NvidiaXID79Error"}, cfg.GetDisabledReasons())
+}
+
+func TestLoadMonitorConfig_DisabledReasonsWithWhitespaceRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`monitors:
+  networking:
+    disabledReasons:
+      - " IPAMDNotReady"
+`)
+	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
+
+	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "leading/trailing whitespace")
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -43,6 +43,9 @@ type MonitorManager struct {
 	observers         map[string]observer.Observer
 	notifyChan        chan notification
 	exporter          Exporter
+	// disabledReasons is the set of reason names (e.g. "IPAMDNotReady") whose
+	// conditions should be dropped before being exported.
+	disabledReasons map[string]struct{}
 }
 
 type notification struct {
@@ -61,6 +64,16 @@ func NewMonitorManager(nodeName string, exporter Exporter) *MonitorManager {
 		notifyChan:        make(chan notification, 100),
 		exporter:          exporter,
 	}
+}
+
+// SetDisabledReasons configures the set of reason names whose conditions are
+// dropped before being exported. Must be called before Start.
+func (m *MonitorManager) SetDisabledReasons(reasons []string) {
+	set := make(map[string]struct{}, len(reasons))
+	for _, r := range reasons {
+		set[r] = struct{}{}
+	}
+	m.disabledReasons = set
 }
 
 // Register registers a monitor with the manager
@@ -123,6 +136,12 @@ func (m *MonitorManager) runLoop(ctx context.Context) error {
 
 func (m *MonitorManager) exportCondition(ctx context.Context, monitorName string, condition monitor.Condition) error {
 	logger := log.FromContext(ctx).WithValues("source", monitorName, "condition", condition)
+
+	// Drop conditions whose reason has been disabled by configuration.
+	if _, ok := m.disabledReasons[condition.Reason]; ok {
+		logger.Info("skipping condition with reason disabled by configuration")
+		return nil
+	}
 
 	// track condition metrics
 	conditionCount.WithLabelValues(string(condition.Severity), condition.Reason).Add(1)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -144,3 +144,61 @@ func TestManager_CreateObserver(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, mMgr.Start(ctx))
 }
+
+func TestManager_DisabledReason(t *testing.T) {
+	t.Run("DisabledReasonSkipped", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.TODO(), 50*time.Millisecond)
+		defer cancel()
+
+		mockMon := &mockMonitor{
+			registerFunc: func(ctx context.Context, mgr monitor.Manager) error {
+				go mgr.Notify(ctx, monitor.Condition{
+					Reason:   "ExampleReason",
+					Severity: monitor.SeverityFatal,
+				})
+				return nil
+			},
+		}
+		mMgr, mockExp := NewManagerWithExporterFuncs()
+		mMgr.SetDisabledReasons([]string{"ExampleReason"})
+		if err := mMgr.Register(ctx, mockMon, "MockPassed"); err != nil {
+			t.Fatal(err)
+		}
+		go mMgr.Start(ctx)
+
+		select {
+		case n := <-mockExp.notifyChan:
+			t.Fatalf("expected no events for disabled reason but got %+v", n)
+		case <-ctx.Done():
+			// expected: the condition was dropped because its reason is disabled.
+		}
+	})
+
+	t.Run("OtherReasonStillExported", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond)
+		defer cancel()
+
+		mockMon := &mockMonitor{
+			registerFunc: func(ctx context.Context, mgr monitor.Manager) error {
+				go mgr.Notify(ctx, monitor.Condition{
+					Reason:   "AnotherReason",
+					Severity: monitor.SeverityFatal,
+				})
+				return nil
+			},
+		}
+		mMgr, mockExp := NewManagerWithExporterFuncs()
+		mMgr.SetDisabledReasons([]string{"ExampleReason"})
+		if err := mMgr.Register(ctx, mockMon, "MockPassed"); err != nil {
+			t.Fatal(err)
+		}
+		go mMgr.Start(ctx)
+
+		select {
+		case <-mockExp.notifyChan:
+			// expected: only ExampleReason is disabled.
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
+	})
+}


### PR DESCRIPTION
**Description of changes**:
we want to have an emergency off button if a reason has false-positives,
for example as we saw with IPAMDNotReady [here](https://github.com/aws/eks-node-monitoring-agent/pull/216)

**Testing Done**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
