### PR TITLE
fix(dcgm): downgrade NVLink lifetime counter code 71 to Warning on pr…

### DIFF
--- a/e2e/k8s/utils.go
+++ b/e2e/k8s/utils.go
@@ -17,7 +17,7 @@ func ExtractClusterName(kubeContext string) (*string, error) {
 	}
 	clusterField := config.Contexts[config.CurrentContext].Cluster
 	// Support to handle:
-	// kubeconfigs produced by `aws eks update-kubeconfig` which uses the 
+	// kubeconfigs produced by `aws eks update-kubeconfig` which uses the
 	// cluster's full ARN as the context's cluster field AND,
 	// kubeconfigs which use the plain cluster name directly.
 	if arn.IsARN(clusterField) {

--- a/monitors/nvidia/dcgm/dcgm_healthcheck.go
+++ b/monitors/nvidia/dcgm/dcgm_healthcheck.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	dcgmapi "github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -13,6 +14,43 @@ import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
 	"github.com/aws/eks-node-monitoring-agent/pkg/reasons"
 )
+
+// nvlinkLifetimeCounterPrefixes lists the DCGM message prefixes emitted by
+// MonitorNVLinkErrorFields when it fails on a non-zero lifetime-absolute NVLink
+// counter (DCGM_FI_DEV_NVLINK_{CRC,RECOVERY,REPLAY}_ERROR_TOTAL, fields
+// 497/498/499). These messages are distinct from the rate-delta (legacy) and
+// Blackwell recovery-event paths that also emit DCGM_FR_NVLINK_ERROR_CRITICAL
+// (code 71) — those paths do indicate active faults and must remain Fatal.
+//
+// The strings are stable because DCGM_VERSION is pinned in our Dockerfile; a
+// unit test re-checks them on each engine bump.
+//
+// ref: NVIDIA/DCGM modules/health/DcgmHealthWatch.cpp MonitorNVLinkErrorFields
+var nvlinkLifetimeCounterPrefixes = []string{
+	"datalink layer CRC error counter",
+	"datalink layer recovery error counter",
+	"datalink layer replay error counter",
+}
+
+// isNVLinkLifetimeCounterIncident reports whether a code-71 NVLink FAIL
+// incident was produced by the lifetime-absolute counter check rather than an
+// active-fault path. Lifetime-counter incidents are not evidence of a currently
+// degraded link on pre-Blackwell GPUs (Hopper/H100): the counter never resets
+// without a GPU reset, so any historical CRC event triggers the check.
+func isNVLinkLifetimeCounterIncident(inc dcgmapi.Incident) bool {
+	if inc.Error.Code != dcgmapi.DCGM_FR_NVLINK_ERROR_CRITICAL {
+		return false
+	}
+	if inc.System != dcgmapi.DCGM_HEALTH_WATCH_NVLINK {
+		return false
+	}
+	for _, prefix := range nvlinkLifetimeCounterPrefixes {
+		if strings.Contains(inc.Error.Message, prefix) {
+			return true
+		}
+	}
+	return false
+}
 
 func (s *DCGMSystem) HealthCheck(ctx context.Context) ([]monitor.Condition, error) {
 	logger := log.FromContext(ctx)
@@ -42,6 +80,18 @@ func (s *DCGMSystem) HealthCheck(ctx context.Context) ([]monitor.Condition, erro
 		if incidents.Health == dcgmapi.DCGM_HEALTH_RESULT_FAIL {
 			severity = monitor.SeverityFatal
 		}
+
+		// DCGM_FR_NVLINK_ERROR_CRITICAL (71) from the lifetime-absolute counter
+		// path is not an active-fault signal on pre-Blackwell GPUs: the counter
+		// never resets without a GPU reset, so it fires on any historical CRC
+		// event. Downgrade to Warning so the node stays schedulable. The
+		// rate-delta and Blackwell recovery-event paths (also code 71) emit
+		// different messages and remain Fatal.
+		if incidents.Health == dcgmapi.DCGM_HEALTH_RESULT_FAIL && isNVLinkLifetimeCounterIncident(incidents) {
+			logger.V(2).Info("downgrading NVLink lifetime counter incident to Warning", "message", incidents.Error.Message)
+			severity = monitor.SeverityWarning
+		}
+
 		// health check codes comes from the following:
 		// https://github.com/NVIDIA/DCGM/blob/d47c0b77920f8dbfef588eaac2cbbea3401ef463/dcgmlib/dcgm_errors.h#L31
 		conditions = append(conditions,

--- a/monitors/nvidia/dcgm/dcgm_healthcheck_test.go
+++ b/monitors/nvidia/dcgm/dcgm_healthcheck_test.go
@@ -56,4 +56,61 @@ func TestHealthCheck(t *testing.T) {
 			Severity: monitor.SeverityFatal,
 		})
 	})
+
+	// DCGM_FR_NVLINK_ERROR_CRITICAL (71) from the lifetime-absolute counter path
+	// must be downgraded to Warning on pre-Blackwell GPUs. The counter never
+	// resets without a GPU reset, so a non-zero value is not an active-fault
+	// signal. The message prefix is stable because DCGM_VERSION is pinned.
+	t.Run("NVLinkLifetimeCounterDowngradedToWarning", func(t *testing.T) {
+		for _, msg := range []string{
+			"Detected 1 datalink layer CRC error counter NvLink errors on GPU 7's NVLink (should be 0)",
+			"Detected 1 datalink layer recovery error counter NvLink errors on GPU 0's NVLink (should be 0)",
+			"Detected 1 datalink layer replay error counter NvLink errors on GPU 3's NVLink (should be 0)",
+		} {
+			mockDcgm := &fake.FakeDcgm{
+				HealthResponse: dcgmapi.HealthResponse{
+					Incidents: []dcgmapi.Incident{
+						{
+							System: dcgmapi.DCGM_HEALTH_WATCH_NVLINK,
+							Health: dcgmapi.DCGM_HEALTH_RESULT_FAIL,
+							Error: dcgmapi.DiagErrorDetail{
+								Code:    dcgmapi.DCGM_FR_NVLINK_ERROR_CRITICAL,
+								Message: msg,
+							},
+						},
+					},
+				},
+			}
+			dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+			conditions, err := dcgmSystem.HealthCheck(context.TODO())
+			assert.NoError(t, err)
+			assert.Len(t, conditions, 1, "expected one condition for message: %s", msg)
+			assert.Equal(t, monitor.SeverityWarning, conditions[0].Severity,
+				"lifetime counter code 71 must be Warning, not Fatal (message: %s)", msg)
+		}
+	})
+
+	// Code 71 from a different message (active-fault path) must stay Fatal.
+	t.Run("NVLinkActiveFaultRemainsFatal", func(t *testing.T) {
+		mockDcgm := &fake.FakeDcgm{
+			HealthResponse: dcgmapi.HealthResponse{
+				Incidents: []dcgmapi.Incident{
+					{
+						System: dcgmapi.DCGM_HEALTH_WATCH_NVLINK,
+						Health: dcgmapi.DCGM_HEALTH_RESULT_FAIL,
+						Error: dcgmapi.DiagErrorDetail{
+							Code:    dcgmapi.DCGM_FR_NVLINK_ERROR_CRITICAL,
+							Message: "NVLink failure detected on link 3",
+						},
+					},
+				},
+			},
+		}
+		dcgmSystem := dcgm.NewDCGMSystem(mockDcgm, dcgm.GetDiagType())
+		conditions, err := dcgmSystem.HealthCheck(context.TODO())
+		assert.NoError(t, err)
+		assert.Len(t, conditions, 1)
+		assert.Equal(t, monitor.SeverityFatal, conditions[0].Severity,
+			"code 71 without a lifetime-counter message must remain Fatal")
+	})
 }


### PR DESCRIPTION
**Issue #, if available**:
* NMA v1.7.0 bundled DCGM 4.6.1 (up from 4.5.2), which added a lifetime-absolute NVLink counter check that fires on
  any historical CRC event, causing healthy pre-Blackwell (H100) nodes to flip AcceleratedHardwareReady=False with DCGMHealthCode71.

**Description of changes**:
* Adds a targeted carve-out in monitors/nvidia/dcgm/dcgm_healthcheck.go for the DCGM lifetime NVLink counter path of code 71. Incidents matching System == DCGM_HEALTH_WATCH_NVLINK + FAIL + the lifetime-counter message prefixes ("datalink layer CRC/recovery/replay error counter") are downgraded to Warning instead of Fatal. All other code-71 paths (rate-delta, Blackwell recovery-event) remain Fatal. 
* Unit tests cover both the downgrade and the pass-through cases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
