### PR TITLE
feat(charts)!: remove extraObjects

### DIFF
--- a/charts/configuration.schema.json
+++ b/charts/configuration.schema.json
@@ -16,9 +16,6 @@
                 },
                 "dcgmAgent": {
                     "$ref": "#/definitions/DCGMAgent"
-                },
-                "extraObjects": {
-                    "$ref": "#/definitions/ExtraObjects"
                 }
             }
         },
@@ -223,15 +220,6 @@
         "Tolerations": {
             "title": "Tolerations",
             "type": "array",
-            "items": {
-                "type": "object"
-            }
-        },
-        "ExtraObjects": {
-            "title": "ExtraObjects",
-            "type": "array",
-            "description": "Additional Kubernetes manifests to deploy alongside this chart. Each entry is rendered through `tpl`, so template expressions inside the manifests are evaluated against the release context.",
-            "default": [],
             "items": {
                 "type": "object"
             }

--- a/charts/eks-node-monitoring-agent/README.md
+++ b/charts/eks-node-monitoring-agent/README.md
@@ -110,7 +110,6 @@ The following table lists the configurable parameters for this chart and their d
 | dcgmAgent.resizePolicy | list | `[]` | Container resize policy for in-place pod vertical scaling (requires Kubernetes 1.33+) |
 | dcgmAgent.resources | object | `{}` | Container resources for the dcgm deployment |
 | dcgmAgent.tolerations | list | `[]` | Deployment tolerations for the dcgm |
-| extraObjects | list | see [`values.yaml`](./values.yaml), so template expressions (e.g. {{ .Release.Namespace }}) inside the manifests are evaluated. Example:   extraObjects:     - apiVersion: monitoring.coreos.com/v1       kind: PodMonitor       metadata:         name: eks-node-monitoring-agent         namespace: {{ .Release.Namespace }}       spec:         selector:           matchLabels:             app.kubernetes.io/name: eks-node-monitoring-agent         podMetricsEndpoints:           - port: metrics |
 | fullnameOverride | string | `"eks-node-monitoring-agent"` | A fullname override for the chart |
 | global | object | `{"podAnnotations":{},"podLabels":{}}` | Global values shared across components |
 | global.podAnnotations | object | `{}` | Annotations applied to eks-node-monitoring-agent and dcgm-exporter (can be overridden by component-specific annotations) |

--- a/charts/eks-node-monitoring-agent/templates/extra-objects.yaml
+++ b/charts/eks-node-monitoring-agent/templates/extra-objects.yaml
@@ -1,4 +1,0 @@
-{{- range .Values.extraObjects }}
----
-{{ tpl (toYaml .) $ }}
-{{- end }}

--- a/charts/eks-node-monitoring-agent/values.yaml
+++ b/charts/eks-node-monitoring-agent/values.yaml
@@ -177,20 +177,3 @@ updateStrategy:
   rollingUpdate:
     maxUnavailable: "10%"
 
-# -- Additional Kubernetes manifests to deploy alongside this chart.
-# Each entry is rendered through `tpl`, so template expressions
-# (e.g. {{ .Release.Namespace }}) inside the manifests are evaluated.
-# Example:
-#   extraObjects:
-#     - apiVersion: monitoring.coreos.com/v1
-#       kind: PodMonitor
-#       metadata:
-#         name: eks-node-monitoring-agent
-#         namespace: {{ .Release.Namespace }}
-#       spec:
-#         selector:
-#           matchLabels:
-#             app.kubernetes.io/name: eks-node-monitoring-agent
-#         podMetricsEndpoints:
-#           - port: metrics
-extraObjects: []


### PR DESCRIPTION
**Issue #, if available**: N/A

**Description of changes**:

Removes the `extraObjects` chart value, which let a values file inject arbitrary Kubernetes
manifests that the chart then rendered as its own top-level documents through `tpl`.

That made the set of objects this chart creates unbounded and caller-defined, which isn't
something the chart should own -- its templates should only produce the agent's own resources.
It matters most when the chart is installed on a user's behalf by an operator or add-on
manager rather than by the user's own `helm install`, since the objects are then created under
that installer's identity, not the requester's.

- deleted `charts/eks-node-monitoring-agent/templates/extra-objects.yaml`
- dropped `extraObjects: []` and its example block from `values.yaml`
- dropped the `extraObjects` property and `ExtraObjects` definition from
  `charts/configuration.schema.json`
- dropped the `extraObjects` row from the chart README

No chart template references `.Values.extraObjects` after this, so the change is self-contained
and no default behaviour or rendered resource changes for anyone who didn't set it.

Breaking for direct Helm users who did set `extraObjects`: those manifests should be applied
alongside the release instead -- a separate `kubectl apply`, `helm install`, or a wrapper chart
-- which is also where template expressions in them belong.

**Testing Done**:

- `make generate` clean (helm-docs README + `e2e/setup/manifests/agent.tpl.yaml` unchanged,
  since `extraObjects` defaulted to `[]` and rendered no document).
- `make test` (unit + `helm lint`) passes.
- `helm template` output byte-identical to `main` for default values and for a values file
  exercising every remaining key.
- `helm template` with an `extraObjects:` entry no longer emits the extra document; the value
  is now rejected by `configuration.schema.json`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.