### PR TITLE
fix(kernel): register ZramHighUsage in reasons.yaml

### DIFF
--- a/docs/node-health-issues.adoc
+++ b/docs/node-health-issues.adoc
@@ -213,6 +213,10 @@ The monitoring condition is `KernelReady` for issues in the following table that
 |Event
 |The CPU stalled for a given amount of time.
 
+|ZramHighUsage
+|Event
+|A ZRAM swap device is using more than 10% of its configured disk size, indicating memory pressure on the node.
+
 |===
 
 [#node-health-Networking]

--- a/monitors/kernel/monitor.go
+++ b/monitors/kernel/monitor.go
@@ -418,11 +418,12 @@ func (k *KernelMonitor) checkZram(origSize, compSize, disksize int64, deviceName
 	}
 	usagePercent := float64(origSize) / float64(disksize)
 	if usagePercent > 0.10 {
-		return k.manager.Notify(context.Background(), monitor.Condition{
-			Reason:   "ZramHighUsage",
-			Message:  fmt.Sprintf("ZRAM device %s at %.1f%% capacity", deviceName, usagePercent*100),
-			Severity: monitor.SeverityWarning,
-		})
+		return k.manager.Notify(context.Background(),
+			reasons.ZramHighUsage.
+				Builder().
+				Message(fmt.Sprintf("ZRAM device %s at %.1f%% capacity", deviceName, usagePercent*100)).
+				Build(),
+		)
 	}
 	return nil
 

--- a/pkg/reasons/reasons.go
+++ b/pkg/reasons/reasons.go
@@ -176,6 +176,10 @@ var (
 		template:        "SoftLockup",
 		defaultSeverity: "Warning",
 	}
+	ZramHighUsage = ReasonMeta{
+		template:        "ZramHighUsage",
+		defaultSeverity: "Warning",
+	}
 
 	// reasons for the NetworkingReady condition.
 
@@ -365,6 +369,7 @@ var byName = map[string]ReasonMeta{
 	"LargeEnvironment":                  LargeEnvironment,
 	"RapidCron":                         RapidCron,
 	"SoftLockup":                        SoftLockup,
+	"ZramHighUsage":                     ZramHighUsage,
 	"BandwidthInExceeded":               BandwidthInExceeded,
 	"BandwidthOutExceeded":              BandwidthOutExceeded,
 	"ConntrackExceeded":                 ConntrackExceeded,

--- a/pkg/reasons/reasons.yaml
+++ b/pkg/reasons/reasons.yaml
@@ -79,6 +79,12 @@ KernelReady:
       A kernel bug was detected and reported by the Linux kernel itself, though
       this may sometimes be caused by nodes with high CPU or memory usage
       leading to delayed event processing.
+  ZramHighUsage:
+    Template: 'ZramHighUsage'
+    DefaultSeverity: 'Warning'
+    Description: >-
+      A ZRAM swap device is using more than 10% of its configured disk size,
+      indicating memory pressure on the node.
 ContainerRuntimeReady:
   KubeletFailed:
     Template: 'KubeletFailed'


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

The zram capacity check in the kernel monitor was the only monitor condition using a hardcoded reason string instead of the generated `pkg/reasons` package. This moves `ZramHighUsage` into `reasons.yaml` (Warning severity, same as before) and regenerates `reasons.go` and `docs/node-health-issues.adoc`, so the reason is now part of the registry and the `ByName` lookup.

**Testing Done**:

- `go generate ./pkg/reasons/...` and docs codegen produce the new entry
- `GOOS=linux go build` / `go vet` pass for `monitors/kernel` and `pkg/reasons`
- `go test ./pkg/reasons/...` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.