### PR TITLE
refactor(config): validate monitor config against registered plugins

### DIFF
--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -219,7 +219,8 @@ func run() error {
 		}
 
 		// Load monitor configuration from ConfigMap mount
-		monitorConfig, configFound, err := config.LoadMonitorConfig(config.DefaultConfigPath)
+		allPlugins := registry.GlobalRegistry().List()
+		monitorConfig, configFound, err := config.LoadMonitorConfig(config.DefaultConfigPath, pluginNames(allPlugins))
 		if err != nil {
 			logger.Error(err, "failed to load monitor configuration")
 			return err
@@ -229,7 +230,6 @@ func run() error {
 		}
 
 		// Filter plugins by configuration and log effective state
-		allPlugins := registry.GlobalRegistry().List()
 		var enabledMonitors []monitor.Monitor
 		var disabledNames []string
 
@@ -407,6 +407,14 @@ func run() error {
 
 	logger.Info("starting controller manager")
 	return mgr.Start(ctx)
+}
+
+func pluginNames(plugins []registry.MonitorPlugin) []string {
+	names := make([]string, 0, len(plugins))
+	for _, plugin := range plugins {
+		names = append(names, plugin.Name())
+	}
+	return names
 }
 
 // registeredCheck reports ready only once registered is closed, so a node still

--- a/pkg/config/monitor.go
+++ b/pkg/config/monitor.go
@@ -100,24 +100,14 @@ func (mc *MonitorConfig) GetExcludedInterfaceNameRegexps() []string {
 	return settings.ExcludedInterfaceNameRegexps
 }
 
-// KnownPluginNames is the set of valid plugin names for validation.
-var KnownPluginNames = []string{
-	"kernel-monitor",
-	"networking",
-	"storage-monitor",
-	"nvidia",
-	"neuron",
-	"runtime",
-}
-
 // Validate checks that all keys in Monitors are known plugin names.
-func (mc *MonitorConfig) Validate() error {
+func (mc *MonitorConfig) Validate(knownPluginNames []string) error {
 	if mc == nil || mc.Monitors == nil {
 		return nil
 	}
 	var unknown []string
 	for name := range mc.Monitors {
-		if !slices.Contains(KnownPluginNames, name) {
+		if !slices.Contains(knownPluginNames, name) {
 			unknown = append(unknown, name)
 		}
 	}
@@ -161,7 +151,7 @@ func (mc *MonitorConfig) Validate() error {
 // Returns a default (all-enabled) config if the file does not exist.
 // Returns an error if the file exists but contains invalid YAML or unknown plugin names.
 // The second return value indicates whether the config file was found on disk.
-func LoadMonitorConfig(path string) (*MonitorConfig, bool, error) {
+func LoadMonitorConfig(path string, knownPluginNames []string) (*MonitorConfig, bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -180,7 +170,7 @@ func LoadMonitorConfig(path string) (*MonitorConfig, bool, error) {
 		return nil, false, fmt.Errorf("parsing monitor config: %w", err)
 	}
 
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.Validate(knownPluginNames); err != nil {
 		return nil, false, fmt.Errorf("validating monitor config: %w", err)
 	}
 

--- a/pkg/config/monitor_test.go
+++ b/pkg/config/monitor_test.go
@@ -15,15 +15,18 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
+// testKnownPlugins stands in for the registered plugin names main passes in.
+var testKnownPlugins = []string{"kernel-monitor", "networking", "storage-monitor", "nvidia", "neuron", "runtime"}
+
 func TestLoadMonitorConfig_NonExistentFile(t *testing.T) {
-	cfg, found, err := config.LoadMonitorConfig("/tmp/does-not-exist-nma-test.yaml")
+	cfg, found, err := config.LoadMonitorConfig("/tmp/does-not-exist-nma-test.yaml", testKnownPlugins)
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.False(t, found, "expected found to be false for non-existent file")
 	// Default config: all monitors enabled (empty map).
 	assert.Empty(t, cfg.Monitors)
 	// Every known plugin should be enabled by default.
-	for _, name := range config.KnownPluginNames {
+	for _, name := range testKnownPlugins {
 		assert.True(t, cfg.IsMonitorEnabled(name), "expected %s to be enabled by default", name)
 	}
 }
@@ -38,7 +41,7 @@ func TestLoadMonitorConfig_ValidFileOneDisabled(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	cfg, found, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.True(t, found)
@@ -60,7 +63,7 @@ func TestLoadMonitorConfig_InvalidYAML(t *testing.T) {
 	content := []byte(`monitors: [this is not valid: yaml: {{{`)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "parsing monitor config")
@@ -76,7 +79,7 @@ func TestLoadMonitorConfig_UnknownPluginName(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "unknown-plugin")
@@ -89,13 +92,13 @@ func TestLoadMonitorConfig_EmptyFile(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(cfgPath, []byte(""), 0644))
 
-	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	cfg, found, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.True(t, found)
 	assert.Empty(t, cfg.Monitors)
 	// All monitors should be enabled by default.
-	for _, name := range config.KnownPluginNames {
+	for _, name := range testKnownPlugins {
 		assert.True(t, cfg.IsMonitorEnabled(name), "expected %s to be enabled for empty file", name)
 	}
 }
@@ -191,7 +194,7 @@ func TestLoadMonitorConfig_AllowedIPTablesChains(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	cfg, found, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.True(t, found)
@@ -210,7 +213,7 @@ func TestLoadMonitorConfig_EmptyChainRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must use \"table/chain\" format")
@@ -227,7 +230,7 @@ func TestLoadMonitorConfig_WhitespaceOnlyChainRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must not have leading or trailing whitespace")
@@ -244,7 +247,7 @@ func TestLoadMonitorConfig_UnqualifiedChainRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must use \"table/chain\" format")
@@ -261,7 +264,7 @@ func TestLoadMonitorConfig_ChainWithExtraSlashRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must use \"table/chain\" format")
@@ -278,7 +281,7 @@ func TestLoadMonitorConfig_ChainWithSurroundingWhitespaceRejected(t *testing.T) 
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must not have leading or trailing whitespace")
@@ -295,7 +298,7 @@ func TestLoadMonitorConfig_AllowedIPTablesChainsOnNonNetworkingMonitorRejected(t
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "allowedIPTablesChains is only supported by the networking monitor")
@@ -360,7 +363,7 @@ func TestLoadMonitorConfig_ExcludedInterfaceNameRegexps(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	cfg, found, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.True(t, found)
@@ -378,7 +381,7 @@ func TestLoadMonitorConfig_InvalidRegexpRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "is not a valid regular expression")
@@ -395,7 +398,7 @@ func TestLoadMonitorConfig_EmptyRegexpRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must not be empty")
@@ -412,7 +415,7 @@ func TestLoadMonitorConfig_ExcludedInterfaceNameRegexpsOnNonNetworkingMonitorRej
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "excludedInterfaceNameRegexps is only supported by the networking monitor")
@@ -430,7 +433,7 @@ func TestLoadMonitorConfig_StrictUnmarshalRejectsUnknownFields(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "parsing monitor config")


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

`MonitorConfig.Validate` checked monitor names against a hardcoded `KnownPluginNames` list, so every new monitor plugin also needed an edit to `pkg/config/monitor.go` or its config was rejected as unknown.

The plugin registry is already the source of truth for valid plugin names, so `Validate`/`LoadMonitorConfig` now take the known names as a parameter and main passes the registered plugin names. Adding a plugin no longer touches `pkg/config`.

**Testing Done**:

- `go test ./pkg/config/` passes
- `go build ./cmd/...` on linux (docker, golang:1.26 + libsystemd-dev, same as CI)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.