### PR TITLE
refactor(monitors): let plugins declare their node condition

### DIFF
--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -219,7 +219,8 @@ func run() error {
 		}
 
 		// Load monitor configuration from ConfigMap mount
-		monitorConfig, configFound, err := config.LoadMonitorConfig(config.DefaultConfigPath)
+		allPlugins := registry.GlobalRegistry().List()
+		monitorConfig, configFound, err := config.LoadMonitorConfig(config.DefaultConfigPath, pluginNames(allPlugins))
 		if err != nil {
 			logger.Error(err, "failed to load monitor configuration")
 			return err
@@ -229,7 +230,6 @@ func run() error {
 		}
 
 		// Filter plugins by configuration and log effective state
-		allPlugins := registry.GlobalRegistry().List()
 		var enabledMonitors []monitor.Monitor
 		var disabledNames []string
 
@@ -407,6 +407,14 @@ func run() error {
 
 	logger.Info("starting controller manager")
 	return mgr.Start(ctx)
+}
+
+func pluginNames(plugins []registry.MonitorPlugin) []string {
+	names := make([]string, 0, len(plugins))
+	for _, plugin := range plugins {
+		names = append(names, plugin.Name())
+	}
+	return names
 }
 
 // registeredCheck reports ready only once registered is closed, so a node still

--- a/cmd/eks-node-monitoring-agent/main.go
+++ b/cmd/eks-node-monitoring-agent/main.go
@@ -229,7 +229,14 @@ func run() error {
 			logger.Info("monitor config file not found, all monitors will be enabled by default", "path", config.DefaultConfigPath)
 		}
 
+		// hardwareMatches reports whether a plugin can run on this node's hardware
+		hardwareMatches := func(plugin registry.MonitorPlugin) bool {
+			req, ok := plugin.(registry.HardwareRequirer)
+			return !ok || req.RequiredHardware() == "" || runtimeContext.AcceleratedHardware() == req.RequiredHardware()
+		}
+
 		// Filter plugins by configuration and log effective state
+		var enabledPlugins []registry.MonitorPlugin
 		var enabledMonitors []monitor.Monitor
 		var disabledNames []string
 
@@ -240,6 +247,7 @@ func run() error {
 				disabledNames = append(disabledNames, plugin.Name())
 				continue
 			}
+			enabledPlugins = append(enabledPlugins, plugin)
 			enabledMonitors = append(enabledMonitors, plugin.Monitors()...)
 		}
 
@@ -284,50 +292,23 @@ func run() error {
 			}
 		}
 
-		// Build condition configs for node exporter, only for enabled monitors.
+		// Build condition configs for node exporter from enabled plugins.
 		// NodeExporter unconditionally sets all provided conditions to ConditionTrue,
-		// so we must exclude conditions for disabled monitors to avoid falsely
-		// reporting health for subsystems that are not being monitored.
+		// so we must exclude conditions for disabled or hardware-incompatible
+		// plugins to avoid falsely reporting health for subsystems that are not
+		// being monitored.
 		conditionConfigs := make(map[corev1.NodeConditionType]manager.NodeConditionConfig)
-		if monitorConfig.IsMonitorEnabled("kernel-monitor") {
-			conditionConfigs[conditions.KernelReady] = manager.NodeConditionConfig{
-				ReadyReason:  "KernelIsReady",
-				ReadyMessage: "Monitoring for the Kernel system is active",
+		for _, plugin := range enabledPlugins {
+			if !hardwareMatches(plugin) {
+				continue
 			}
-		}
-		if monitorConfig.IsMonitorEnabled("storage-monitor") {
-			conditionConfigs[conditions.StorageReady] = manager.NodeConditionConfig{
-				ReadyReason:  "DiskIsReady",
-				ReadyMessage: "Monitoring for the Disk system is active",
+			provider, ok := plugin.(registry.NodeConditionProvider)
+			if !ok {
+				continue
 			}
-		}
-		if monitorConfig.IsMonitorEnabled("runtime") {
-			conditionConfigs[conditions.ContainerRuntimeReady] = manager.NodeConditionConfig{
-				ReadyReason:  "ContainerRuntimeIsReady",
-				ReadyMessage: "Monitoring for the ContainerRuntime system is active",
-			}
-		}
-		if monitorConfig.IsMonitorEnabled("networking") {
-			conditionConfigs[conditions.NetworkingReady] = manager.NodeConditionConfig{
-				ReadyReason:  "NetworkingIsReady",
-				ReadyMessage: "Monitoring for the Networking system is active",
-			}
-		}
-
-		switch runtimeContext.AcceleratedHardware() {
-		case config.AcceleratedHardwareNvidia:
-			if monitorConfig.IsMonitorEnabled("nvidia") {
-				conditionConfigs[conditions.AcceleratedHardwareReady] = manager.NodeConditionConfig{
-					ReadyReason:  "NvidiaGPUIsReady",
-					ReadyMessage: "Monitoring for the Nvidia GPU system is active",
-				}
-			}
-		case config.AcceleratedHardwareNeuron:
-			if monitorConfig.IsMonitorEnabled("neuron") {
-				conditionConfigs[conditions.AcceleratedHardwareReady] = manager.NodeConditionConfig{
-					ReadyReason:  "NeuronAcceleratedHardwareIsReady",
-					ReadyMessage: "Monitoring for the Neuron AcceleratedHardware system is active",
-				}
+			condType, cfg, ok := provider.NodeCondition()
+			if ok {
+				conditionConfigs[condType] = cfg
 			}
 		}
 
@@ -345,39 +326,27 @@ func run() error {
 		logger.Info("initializing monitoring manager")
 		monitorMgr := manager.NewMonitorManager(hostname, nodeExporter)
 
-		// Register all monitors with the manager
-		for _, mon := range enabledMonitors {
-			monCtx := log.IntoContext(ctx, logger.WithValues("monitor", mon.Name()))
-			var conditionType corev1.NodeConditionType
-			switch mon.Name() {
-			case "kernel":
-				conditionType = conditions.KernelReady
-			case "storage":
-				conditionType = conditions.StorageReady
-			case "container-runtime":
-				conditionType = conditions.ContainerRuntimeReady
-			case "networking":
-				conditionType = conditions.NetworkingReady
-			case "nvidia":
-				if runtimeContext.AcceleratedHardware() != config.AcceleratedHardwareNvidia {
-					logger.Info("skipping monitor registration: no nvidia hardware detected", "monitor", mon.Name())
-					continue
-				}
-				conditionType = conditions.AcceleratedHardwareReady
-			case "neuron":
-				if runtimeContext.AcceleratedHardware() != config.AcceleratedHardwareNeuron {
-					logger.Info("skipping monitor registration: no neuron hardware detected", "monitor", mon.Name())
-					continue
-				}
-				conditionType = conditions.AcceleratedHardwareReady
-			default:
-				conditionType = conditions.KernelReady // Default fallback
+		// Register all monitors with the manager, using the node condition
+		// declared by their plugin
+		for _, plugin := range enabledPlugins {
+			if !hardwareMatches(plugin) {
+				logger.Info("skipping monitor registration: required hardware not detected", "plugin", plugin.Name())
+				continue
 			}
-			if err := monitorMgr.Register(monCtx, mon, conditionType); err != nil {
-				logger.Error(err, "failed to register monitor", "name", mon.Name())
-				return err
+			conditionType := conditions.KernelReady // Default fallback
+			if provider, ok := plugin.(registry.NodeConditionProvider); ok {
+				if ct, _, ok := provider.NodeCondition(); ok {
+					conditionType = ct
+				}
 			}
-			logger.Info("registered monitor with manager", "name", mon.Name(), "conditionType", conditionType)
+			for _, mon := range plugin.Monitors() {
+				monCtx := log.IntoContext(ctx, logger.WithValues("monitor", mon.Name()))
+				if err := monitorMgr.Register(monCtx, mon, conditionType); err != nil {
+					logger.Error(err, "failed to register monitor", "name", mon.Name())
+					return err
+				}
+				logger.Info("registered monitor with manager", "name", mon.Name(), "conditionType", conditionType)
+			}
 		}
 
 		close(registered)

--- a/monitors/kernel/plugin.go
+++ b/monitors/kernel/plugin.go
@@ -2,6 +2,7 @@ package kernel
 
 import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/framework"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/registry"
 )
@@ -10,6 +11,9 @@ func init() {
 	// Auto-register kernel monitor plugin on package import
 	plugin := framework.NewPlugin("kernel-monitor", []monitor.Monitor{
 		&KernelMonitor{},
+	}).WithNodeCondition(conditions.KernelReady, conditions.NodeConditionConfig{
+		ReadyReason:  "KernelIsReady",
+		ReadyMessage: "Monitoring for the Kernel system is active",
 	})
 	registry.MustRegister(plugin)
 }

--- a/monitors/networking/plugin.go
+++ b/monitors/networking/plugin.go
@@ -2,6 +2,7 @@ package networking
 
 import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/framework"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/registry"
 )
@@ -9,6 +10,9 @@ import (
 func init() {
 	plugin := framework.NewPlugin("networking", []monitor.Monitor{
 		NewNetworkingMonitor(),
+	}).WithNodeCondition(conditions.NetworkingReady, conditions.NodeConditionConfig{
+		ReadyReason:  "NetworkingIsReady",
+		ReadyMessage: "Monitoring for the Networking system is active",
 	})
 	if err := registry.ValidateAndRegister(plugin); err != nil {
 		panic(err)

--- a/monitors/neuron/plugin.go
+++ b/monitors/neuron/plugin.go
@@ -2,6 +2,8 @@ package neuron
 
 import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
+	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/framework"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/registry"
 )
@@ -10,6 +12,9 @@ func init() {
 	// Auto-register neuron monitor plugin on package import
 	plugin := framework.NewPlugin("neuron", []monitor.Monitor{
 		&neuronMonitor{},
-	})
+	}).WithNodeCondition(conditions.AcceleratedHardwareReady, conditions.NodeConditionConfig{
+		ReadyReason:  "NeuronAcceleratedHardwareIsReady",
+		ReadyMessage: "Monitoring for the Neuron AcceleratedHardware system is active",
+	}).WithRequiredHardware(config.AcceleratedHardwareNeuron)
 	registry.MustRegister(plugin)
 }

--- a/monitors/nvidia/plugin.go
+++ b/monitors/nvidia/plugin.go
@@ -2,6 +2,8 @@ package nvidia
 
 import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
+	"github.com/aws/eks-node-monitoring-agent/pkg/config"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/framework"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/registry"
 )
@@ -9,7 +11,10 @@ import (
 func init() {
 	plugin := framework.NewPlugin("nvidia", []monitor.Monitor{
 		NewNvidiaMonitor(),
-	})
+	}).WithNodeCondition(conditions.AcceleratedHardwareReady, conditions.NodeConditionConfig{
+		ReadyReason:  "NvidiaGPUIsReady",
+		ReadyMessage: "Monitoring for the Nvidia GPU system is active",
+	}).WithRequiredHardware(config.AcceleratedHardwareNvidia)
 	if err := registry.ValidateAndRegister(plugin); err != nil {
 		panic(err)
 	}

--- a/monitors/runtime/plugin.go
+++ b/monitors/runtime/plugin.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/framework"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/registry"
 	corev1 "k8s.io/api/core/v1"
@@ -14,5 +15,8 @@ import (
 func NewPlugin(node *corev1.Node, kubeClient client.Client) registry.MonitorPlugin {
 	return framework.NewPlugin("runtime", []monitor.Monitor{
 		NewRuntimeMonitor(node, kubeClient),
+	}).WithNodeCondition(conditions.ContainerRuntimeReady, conditions.NodeConditionConfig{
+		ReadyReason:  "ContainerRuntimeIsReady",
+		ReadyMessage: "Monitoring for the ContainerRuntime system is active",
 	})
 }

--- a/monitors/storage/plugin.go
+++ b/monitors/storage/plugin.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/framework"
 	"github.com/aws/eks-node-monitoring-agent/pkg/monitor/registry"
 )
@@ -10,6 +11,9 @@ func init() {
 	// Auto-register storage monitor plugin on package import
 	plugin := framework.NewPlugin("storage-monitor", []monitor.Monitor{
 		NewStorageMonitor(),
+	}).WithNodeCondition(conditions.StorageReady, conditions.NodeConditionConfig{
+		ReadyReason:  "DiskIsReady",
+		ReadyMessage: "Monitoring for the Disk system is active",
 	})
 	registry.MustRegister(plugin)
 }

--- a/pkg/conditions/conditions.go
+++ b/pkg/conditions/conditions.go
@@ -42,3 +42,9 @@ const (
 	// functioning correctly (disks, filesystems, I/O).
 	StorageReady corev1.NodeConditionType = "StorageReady"
 )
+
+// NodeConditionConfig holds the ready state configuration for a node condition
+type NodeConditionConfig struct {
+	ReadyReason  string
+	ReadyMessage string
+}

--- a/pkg/config/monitor.go
+++ b/pkg/config/monitor.go
@@ -100,24 +100,14 @@ func (mc *MonitorConfig) GetExcludedInterfaceNameRegexps() []string {
 	return settings.ExcludedInterfaceNameRegexps
 }
 
-// KnownPluginNames is the set of valid plugin names for validation.
-var KnownPluginNames = []string{
-	"kernel-monitor",
-	"networking",
-	"storage-monitor",
-	"nvidia",
-	"neuron",
-	"runtime",
-}
-
 // Validate checks that all keys in Monitors are known plugin names.
-func (mc *MonitorConfig) Validate() error {
+func (mc *MonitorConfig) Validate(knownPluginNames []string) error {
 	if mc == nil || mc.Monitors == nil {
 		return nil
 	}
 	var unknown []string
 	for name := range mc.Monitors {
-		if !slices.Contains(KnownPluginNames, name) {
+		if !slices.Contains(knownPluginNames, name) {
 			unknown = append(unknown, name)
 		}
 	}
@@ -161,7 +151,7 @@ func (mc *MonitorConfig) Validate() error {
 // Returns a default (all-enabled) config if the file does not exist.
 // Returns an error if the file exists but contains invalid YAML or unknown plugin names.
 // The second return value indicates whether the config file was found on disk.
-func LoadMonitorConfig(path string) (*MonitorConfig, bool, error) {
+func LoadMonitorConfig(path string, knownPluginNames []string) (*MonitorConfig, bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -180,7 +170,7 @@ func LoadMonitorConfig(path string) (*MonitorConfig, bool, error) {
 		return nil, false, fmt.Errorf("parsing monitor config: %w", err)
 	}
 
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.Validate(knownPluginNames); err != nil {
 		return nil, false, fmt.Errorf("validating monitor config: %w", err)
 	}
 

--- a/pkg/config/monitor_test.go
+++ b/pkg/config/monitor_test.go
@@ -15,15 +15,18 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
+// testKnownPlugins stands in for the registered plugin names main passes in.
+var testKnownPlugins = []string{"kernel-monitor", "networking", "storage-monitor", "nvidia", "neuron", "runtime"}
+
 func TestLoadMonitorConfig_NonExistentFile(t *testing.T) {
-	cfg, found, err := config.LoadMonitorConfig("/tmp/does-not-exist-nma-test.yaml")
+	cfg, found, err := config.LoadMonitorConfig("/tmp/does-not-exist-nma-test.yaml", testKnownPlugins)
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.False(t, found, "expected found to be false for non-existent file")
 	// Default config: all monitors enabled (empty map).
 	assert.Empty(t, cfg.Monitors)
 	// Every known plugin should be enabled by default.
-	for _, name := range config.KnownPluginNames {
+	for _, name := range testKnownPlugins {
 		assert.True(t, cfg.IsMonitorEnabled(name), "expected %s to be enabled by default", name)
 	}
 }
@@ -38,7 +41,7 @@ func TestLoadMonitorConfig_ValidFileOneDisabled(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	cfg, found, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.True(t, found)
@@ -60,7 +63,7 @@ func TestLoadMonitorConfig_InvalidYAML(t *testing.T) {
 	content := []byte(`monitors: [this is not valid: yaml: {{{`)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "parsing monitor config")
@@ -76,7 +79,7 @@ func TestLoadMonitorConfig_UnknownPluginName(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "unknown-plugin")
@@ -89,13 +92,13 @@ func TestLoadMonitorConfig_EmptyFile(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(cfgPath, []byte(""), 0644))
 
-	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	cfg, found, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.True(t, found)
 	assert.Empty(t, cfg.Monitors)
 	// All monitors should be enabled by default.
-	for _, name := range config.KnownPluginNames {
+	for _, name := range testKnownPlugins {
 		assert.True(t, cfg.IsMonitorEnabled(name), "expected %s to be enabled for empty file", name)
 	}
 }
@@ -191,7 +194,7 @@ func TestLoadMonitorConfig_AllowedIPTablesChains(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	cfg, found, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.True(t, found)
@@ -210,7 +213,7 @@ func TestLoadMonitorConfig_EmptyChainRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must use \"table/chain\" format")
@@ -227,7 +230,7 @@ func TestLoadMonitorConfig_WhitespaceOnlyChainRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must not have leading or trailing whitespace")
@@ -244,7 +247,7 @@ func TestLoadMonitorConfig_UnqualifiedChainRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must use \"table/chain\" format")
@@ -261,7 +264,7 @@ func TestLoadMonitorConfig_ChainWithExtraSlashRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must use \"table/chain\" format")
@@ -278,7 +281,7 @@ func TestLoadMonitorConfig_ChainWithSurroundingWhitespaceRejected(t *testing.T) 
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must not have leading or trailing whitespace")
@@ -295,7 +298,7 @@ func TestLoadMonitorConfig_AllowedIPTablesChainsOnNonNetworkingMonitorRejected(t
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "allowedIPTablesChains is only supported by the networking monitor")
@@ -360,7 +363,7 @@ func TestLoadMonitorConfig_ExcludedInterfaceNameRegexps(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, found, err := config.LoadMonitorConfig(cfgPath)
+	cfg, found, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.True(t, found)
@@ -378,7 +381,7 @@ func TestLoadMonitorConfig_InvalidRegexpRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "is not a valid regular expression")
@@ -395,7 +398,7 @@ func TestLoadMonitorConfig_EmptyRegexpRejected(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "must not be empty")
@@ -412,7 +415,7 @@ func TestLoadMonitorConfig_ExcludedInterfaceNameRegexpsOnNonNetworkingMonitorRej
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "excludedInterfaceNameRegexps is only supported by the networking monitor")
@@ -430,7 +433,7 @@ func TestLoadMonitorConfig_StrictUnmarshalRejectsUnknownFields(t *testing.T) {
 `)
 	require.NoError(t, os.WriteFile(cfgPath, content, 0644))
 
-	cfg, _, err := config.LoadMonitorConfig(cfgPath)
+	cfg, _, err := config.LoadMonitorConfig(cfgPath, testKnownPlugins)
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "parsing monitor config")

--- a/pkg/manager/node_exporter.go
+++ b/pkg/manager/node_exporter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,10 +30,7 @@ const (
 var _ Exporter = (*nodeExporter)(nil)
 
 // NodeConditionConfig holds the ready state configuration for a node condition
-type NodeConditionConfig struct {
-	ReadyReason  string
-	ReadyMessage string
-}
+type NodeConditionConfig = conditions.NodeConditionConfig
 
 // NewNodeExporter creates a new node exporter that updates Kubernetes node conditions
 func NewNodeExporter(

--- a/pkg/monitor/framework/plugin.go
+++ b/pkg/monitor/framework/plugin.go
@@ -2,14 +2,20 @@ package framework
 
 import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 // Plugin provides a basic plugin implementation
 type Plugin struct {
-	name     string
-	monitors []monitor.Monitor
-	crds     []*apiextensionsv1.CustomResourceDefinition
+	name             string
+	monitors         []monitor.Monitor
+	crds             []*apiextensionsv1.CustomResourceDefinition
+	conditionType    corev1.NodeConditionType
+	conditionConfig  conditions.NodeConditionConfig
+	hasCondition     bool
+	requiredHardware string
 }
 
 // NewPlugin creates a new plugin
@@ -30,6 +36,21 @@ func NewPluginWithCRDs(name string, monitors []monitor.Monitor, crds []*apiexten
 	}
 }
 
+// WithNodeCondition declares the node condition the plugin owns
+func (p *Plugin) WithNodeCondition(condType corev1.NodeConditionType, config conditions.NodeConditionConfig) *Plugin {
+	p.conditionType = condType
+	p.conditionConfig = config
+	p.hasCondition = true
+	return p
+}
+
+// WithRequiredHardware declares that the plugin only runs on the given
+// accelerated hardware
+func (p *Plugin) WithRequiredHardware(hardware string) *Plugin {
+	p.requiredHardware = hardware
+	return p
+}
+
 // Name returns the plugin name
 func (p *Plugin) Name() string {
 	return p.name
@@ -43,4 +64,14 @@ func (p *Plugin) Monitors() []monitor.Monitor {
 // CRDs returns all CRDs provided by this plugin
 func (p *Plugin) CRDs() []*apiextensionsv1.CustomResourceDefinition {
 	return p.crds
+}
+
+// NodeCondition implements registry.NodeConditionProvider
+func (p *Plugin) NodeCondition() (corev1.NodeConditionType, conditions.NodeConditionConfig, bool) {
+	return p.conditionType, p.conditionConfig, p.hasCondition
+}
+
+// RequiredHardware implements registry.HardwareRequirer
+func (p *Plugin) RequiredHardware() string {
+	return p.requiredHardware
 }

--- a/pkg/monitor/registry/interface.go
+++ b/pkg/monitor/registry/interface.go
@@ -2,6 +2,8 @@ package registry
 
 import (
 	"github.com/aws/eks-node-monitoring-agent/api/monitor"
+	"github.com/aws/eks-node-monitoring-agent/pkg/conditions"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -17,6 +19,22 @@ type MonitorPlugin interface {
 type CRDProvider interface {
 	// CRDs returns CRDs that this plugin requires
 	CRDs() []*apiextensionsv1.CustomResourceDefinition
+}
+
+// NodeConditionProvider optionally declares the node condition a plugin owns.
+// Implementing it lets the agent wire the condition without hardcoding
+// plugin names in main.
+type NodeConditionProvider interface {
+	// NodeCondition returns the condition type and its ready-state config.
+	// ok is false when the plugin owns no node condition.
+	NodeCondition() (condType corev1.NodeConditionType, config conditions.NodeConditionConfig, ok bool)
+}
+
+// HardwareRequirer optionally declares that a plugin only runs on specific
+// accelerated hardware (see config.RuntimeContext.AcceleratedHardware).
+type HardwareRequirer interface {
+	// RequiredHardware returns the required hardware, "" means no requirement.
+	RequiredHardware() string
 }
 
 // Registry manages monitor plugin registration


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:

Stacked on #264 (only the last commit is new).

`main.go` hardcoded the monitor-name to node-condition mapping plus every ready reason/message, so adding a monitor required editing `main.go` in two places (and the nvidia/neuron hardware gating was name-based too).

Plugins now optionally declare what they own, mirroring the existing `CRDProvider` pattern:

- `registry.NodeConditionProvider`: the node condition type and its ready-state config
- `registry.HardwareRequirer`: required accelerated hardware, used by nvidia/neuron
- fluent builders on `framework.Plugin`: `WithNodeCondition` / `WithRequiredHardware`

Main builds the node-exporter condition configs and registers monitors generically from these declarations. Behavior is unchanged, including the `KernelReady` default fallback for plugins that declare no condition.

`NodeConditionConfig` moves from `pkg/manager` to `pkg/conditions` so `registry`/`framework` stay leaf packages (`pkg/manager` pulls in cgo deps via the journald observer); `pkg/manager` keeps a type alias.

**Testing Done**:

- `go build ./...` and `go test ./monitors/... ./pkg/...` on linux (docker, golang:1.26 + libsystemd-dev, same as CI)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.